### PR TITLE
Preserve intermediate node meta for composite ops

### DIFF
--- a/tests/lowering/eltwise/binary/test_div.py
+++ b/tests/lowering/eltwise/binary/test_div.py
@@ -35,6 +35,10 @@ def test_div(device, input_shapes):
     assert target.count(ttnn.mul) == 1
     assert target.index(ttnn.reciprocal) < target.index(ttnn.mul)
     assert nodes[target.index(ttnn.mul)].args[1].target == ttnn.reciprocal
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full or node.target == ttnn.reciprocal:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert check_with_pcc(result_before, result_after)
 
@@ -63,5 +67,9 @@ def test_div_scalar_denom(device, input_shapes):
     assert target.index(ttnn.full) < target.index(ttnn.reciprocal)
     assert target.index(ttnn.reciprocal) < target.index(ttnn.mul)
     assert nodes[target.index(ttnn.mul)].args[1].target == ttnn.reciprocal
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full or node.target == ttnn.reciprocal:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert check_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/binary/test_eq.py
+++ b/tests/lowering/eltwise/binary/test_eq.py
@@ -32,6 +32,10 @@ def test_eq_tensor(device, input_shapes):
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.eq) == 1
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert torch.allclose(result_before, result_after.to(torch.bool))
 
@@ -60,5 +64,9 @@ def test_eq_scalar(device, input_shapes):
     assert target.count(ttnn.full) == 1
     assert target.count(ttnn.eq) == 1
     assert target.index(ttnn.full) < target.index(ttnn.eq)
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert torch.allclose(result_before, result_after.to(torch.bool))

--- a/tests/lowering/eltwise/binary/test_lt.py
+++ b/tests/lowering/eltwise/binary/test_lt.py
@@ -32,6 +32,10 @@ def test_lt_tensor(device, input_shapes):
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.lt) == 1
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert torch.allclose(result_before, result_after.to(torch.bool))
 
@@ -58,5 +62,9 @@ def test_lt_scalar(device, input_shapes):
     assert target.count(ttnn.full) == 1
     assert target.count(ttnn.lt) == 1
     assert target.index(ttnn.full) < target.index(ttnn.lt)
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert check_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/binary/test_sub.py
+++ b/tests/lowering/eltwise/binary/test_sub.py
@@ -70,6 +70,10 @@ def test_rsub(device, input_shapes):
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.sub) == 1
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert torch.allclose(result_before, result_after)
 
@@ -95,5 +99,9 @@ def test_rsub_scalar(device, input_shapes):
     assert target.count(ttnn.full) == 1
     assert target.count(ttnn.sub) == 1
     assert target.index(ttnn.full) < target.index(ttnn.sub)
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.full:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert check_with_pcc(result_before, result_after, 0.9998)

--- a/tests/lowering/matmul/test_addmm.py
+++ b/tests/lowering/matmul/test_addmm.py
@@ -36,5 +36,9 @@ def test_addmm(device, input_shapes):
     assert target.count(ttnn.add) == 1
     assert target.index(ttnn.matmul) < target.index(ttnn.add)
     assert nodes[target.index(ttnn.add)].args[1].target == ttnn.matmul
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.matmul:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert check_with_pcc(result_before, result_after)

--- a/tests/lowering/matmul/test_baddbmm.py
+++ b/tests/lowering/matmul/test_baddbmm.py
@@ -45,6 +45,10 @@ def test_baddbmm(device, input_shapes):
     assert target.count(ttnn.add) == 1
     assert target.index(ttnn.matmul) < target.index(ttnn.add)
     assert nodes[target.index(ttnn.add)].args[1].target == ttnn.matmul
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.matmul or node.target == ttnn.multiply:
+            assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
     assert check_with_pcc(result_before, result_after)
 
@@ -63,6 +67,10 @@ def test_baddbmm(device, input_shapes):
     assert target.count(ttnn.add) == 1
     assert target.index(ttnn.multiply) < target.index(ttnn.add)
     assert nodes[target.index(ttnn.add)].args[1].target == ttnn.multiply
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.matmul or node.target == ttnn.multiply:
+            assert node.meta["val"].size() == input_shapes[0]
     assert check_with_pcc(result_before, result_after)
 
     # (3) Test with beta and default alpha value
@@ -80,6 +88,10 @@ def test_baddbmm(device, input_shapes):
     assert target.index(ttnn.multiply) < target.index(ttnn.add)
     assert nodes[target.index(ttnn.add)].args[0].target == ttnn.multiply
     assert nodes[target.index(ttnn.add)].args[1].target == ttnn.matmul
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.matmul or node.target == ttnn.multiply:
+            assert node.meta["val"].size() == input_shapes[0]
     assert check_with_pcc(result_before, result_after)
 
     # (4) Test with beta and alpha values
@@ -101,7 +113,10 @@ def test_baddbmm(device, input_shapes):
     assert multiply_idx[1] < add_index
     assert nodes[add_index].args[0].target == ttnn.multiply
     assert nodes[add_index].args[1].target == ttnn.multiply
-
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.matmul or node.target == ttnn.multiply:
+            assert node.meta["val"].size() == input_shapes[0]
     assert check_with_pcc(result_before, result_after)
 
     # (5) Test special case when beta is 0
@@ -116,5 +131,8 @@ def test_baddbmm(device, input_shapes):
     assert target.count(ttnn.multiply) == 1
     assert target.index(ttnn.matmul) < target.index(ttnn.multiply)
     assert nodes[target.index(ttnn.multiply)].args[0].target == ttnn.matmul
-
+    # Intermediate node meta check if preserved
+    for node in nodes:
+        if node.target == ttnn.matmul or node.target == ttnn.multiply:
+            assert node.meta["val"].size() == input_shapes[0]
     assert check_with_pcc(result_before, result_after)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -57,6 +57,10 @@ class ReplaceMoreTt(torch.fx.Transformer):
         elif target == torch.ops.aten.addmm.default:
             # TODO(kevinwuMCW): include beta, alpha, and optional args
             mm = super().call_function(ttnn.matmul, (args[1], args[2]), kwargs)
+            # Intermediate node meta is not preserved, this ensures retention
+            meta = fx_traceback.get_current_meta()
+            if meta is not None and "val" in meta:
+                mm.node.meta["val"] = meta["val"]
             call_func = super().call_function(ttnn.add, (args[0], mm), kwargs)
         elif target == torch.ops.aten.bmm.default:
             call_func = super().call_function(ttnn.matmul, args, kwargs)
@@ -235,6 +239,10 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     full_node = g.call_function(
                         ttnn.full, args=(arg_metadata.size(),), kwargs=new_kwargs
                     )
+                    # Intermediate node meta is not preserved, this ensures retention
+                    # Are output dims same for full node and actual node to be replaced?
+                    full_node.meta["val"] = node.meta["val"]
+
                     new_node = g.call_function(
                         relational_scalar_ops[node.target],
                         args=(args[0], full_node),
@@ -266,15 +274,22 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # out = beta * input + alpha * (batch1 @ batch2)
                 # if beta is 0, input is ignored, and nan and inf in it will not be propogated
                 new_node = g.call_function(ttnn.matmul, args=(args[1], args[2]))
+                # Intermediate node meta is not preserved, this ensures retention
+                new_node.meta["val"] = node.meta["val"]
+
                 if "alpha" in kwargs:
                     new_node = g.call_function(
                         ttnn.multiply, args=(new_node, kwargs["alpha"])
                     )
+                    # Intermediate node meta is not preserved, this ensures retention
+                    new_node.meta["val"] = node.meta["val"]
                 if "beta" in kwargs:
                     if kwargs["beta"] != 0:
                         beta_node = g.call_function(
                             ttnn.multiply, args=(args[0], kwargs["beta"])
                         )
+                        # Intermediate node meta is not preserved, this ensures retention
+                        beta_node.meta["val"] = node.meta["val"]
                         new_node = g.call_function(ttnn.add, args=(beta_node, new_node))
                 else:
                     new_node = g.call_function(ttnn.add, args=(args[0], new_node))
@@ -307,6 +322,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 full = g.call_function(
                     ttnn.full, args=(tuple(node_metadata.size()),), kwargs=new_kwargs
                 )
+                # Intermediate node meta is not preserved, this ensures retention
+                full.meta["val"] = node.meta["val"]
                 to_layout = g.call_function(
                     ttnn.to_layout, (full,), {"layout": TtnnTileLayout()}
                 )
@@ -332,12 +349,16 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                         args=(tuple(node_metadata.size()),),
                         kwargs=new_kwargs,
                     )
+                    # Intermediate node meta is not preserved, this ensures retention
+                    full.meta["val"] = node.meta["val"]
                     to_layout = g.call_function(
                         ttnn.to_layout, (full,), {"layout": TtnnTileLayout()}
                     )
                     recip = g.call_function(ttnn.reciprocal, (to_layout,), {})
                 else:
                     recip = g.call_function(ttnn.reciprocal, (args[1],), {})
+                # Intermediate node meta is not preserved, this ensures retention
+                recip.meta["val"] = node.meta["val"]
                 new_node = g.call_function(ttnn.mul, (args[0], recip), {})
                 new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(


### PR DESCRIPTION
### Brief

- Restore node meta for intermediate nodes created during lowering of composite ops
- Add checks in composite op tests
