### PR TITLE
Simplify testing of models to minimize extra code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ The table below summarizes the results of running various ML models through our 
 
 | Model                               | Run Success   | Torch Ops Before (Unique Ops)   | Torch Ops Remain (Unique Ops)   | To/From Device Ops   |   Original Run Time (ms) | Compiled Run Time (ms)   | Accuracy (%)   |
 |:------------------------------------|:--------------|:--------------------------------|:--------------------------------|:---------------------|-------------------------:|:-------------------------|:---------------|
-| [Mnist (Eval)](tests/models/mnist)  | ✘             | 14 (8)                          | 5 (4)                           | 12                   |                    11.04 | N/A                      | N/A            |
-| [Mnist (Train)](tests/models/mnist) | ✅            | 14 (8)                          | 7 (5)                           | 14                   |                    18.01 | 2922.51                  | 85.88          |
-| [ResNet18](tests/models/resnet)     | ✅            | 70 (9)                          | 42 (4)                          | 45                   |                  1772.4  | 8398.87                  | 99.99          |
-| [Bloom](tests/models/bloom)         | ✘             | 1407 (29)                       | N/A                             | N/A                  |                  5602.6  | N/A                      | N/A            |
-| [YOLOS](tests/models/yolos)         | ✘             | 964 (28)                        | N/A                             | N/A                  |                   209.04 | N/A                      | N/A            |
-| [Llama](tests/models/llama)         | ✘             | 3 (3)                           | 1 (1)                           | 5                    |                 38255.4  | N/A                      | N/A            |
-| [BERT](tests/models/bert)           | ✅            | 1393 (21)                       | 537 (4)                         | 1388                 |                 61919.4  | 52814.88                 | 98.64          |
-| [Falcon](tests/models/falcon)       | ✘             | 3 (3)                           | 1 (1)                           | 5                    |                 35014.3  | N/A                      | N/A            |
-| [GPT-2](tests/models/gpt2)          | ✘             | 748 (31)                        | N/A                             | N/A                  |                  1033.47 | N/A                      | N/A            |
+| [Mnist (Eval)](tests/models/mnist)  | ✘             | 14 (8)                          | 5 (4)                           | 16                   |                    36.12 | N/A                      | N/A            |
+| [Mnist (Train)](tests/models/mnist) | ✅            | 14 (8)                          | 7 (5)                           | 14                   |                   114.49 | 2742.8                   | 81.75          |
+| [ResNet18](tests/models/resnet)     | ✅            | 70 (9)                          | 42 (4)                          | 47                   |                  2094.6  | 10950.18                 | 99.99          |
+| [Bloom](tests/models/bloom)         | ✘             | 1407 (29)                       | N/A                             | N/A                  |                  9127.68 | N/A                      | N/A            |
+| [YOLOS](tests/models/yolos)         | ✘             | 964 (28)                        | N/A                             | N/A                  |                  1353.22 | N/A                      | N/A            |
+| [Llama](tests/models/llama)         | ✘             | 3 (3)                           | 1 (1)                           | 5                    |                 52926.3  | N/A                      | N/A            |
+| [BERT](tests/models/bert)           | ✅            | 1393 (21)                       | 537 (4)                         | 1607                 |                 65342    | 61028.65                 | 98.64          |
+| [Falcon](tests/models/falcon)       | ✘             | 3 (3)                           | 1 (1)                           | 5                    |                 47738.8  | N/A                      | N/A            |
+| [GPT-2](tests/models/gpt2)          | ✘             | 748 (31)                        | N/A                             | N/A                  |                  2287.61 | N/A                      | N/A            |
 
 ### Explanation of Metrics
 
@@ -172,4 +172,28 @@ PYTHONPATH=${TT_METAL_HOME}:$(pwd) python3 tools/run_transformers.py --model "ph
 ```
 
 You can also substitute the backend with `torch_stat` to run a reference comparison.
+
+# Add a model test
+If you want to record run time metrics for a model or test, include a Pytest fixture named `record_property` as a parameter and set the "model_name" key.  
+If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. Currently, only `torch.nn.Module` models with a `forward` function are supported.
+```
+def Model(torch.nn.Module):
+    def forward(self, x):
+        # ...
+        return outputs
+
+# Add "record_property" parameter
+def test_model_name(record_property):
+    # Should be set as early as possible
+    record_property("model_name", "Model Name")
+
+    model = Model()
+    # ...
+    outputs = model(test_input)
+    # outputs = model(**test_inputs) # dictionary inputs are also supported
+    # ...
+
+    # Can be set once all three objects for the tuple are defined
+    record_property("torch_ttnn", (model, test_input(s), outputs))
+```
 

--- a/docs/README.md.in
+++ b/docs/README.md.in
@@ -81,3 +81,27 @@ PYTHONPATH=${{TT_METAL_HOME}}:$(pwd) python3 tools/run_transformers.py --model "
 ```
 
 You can also substitute the backend with `torch_stat` to run a reference comparison.
+
+# Add a model test
+If you want to record run time metrics for a model or test, include a Pytest fixture named `record_property` as a parameter and set the "model_name" key.  
+If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. Currently, only `torch.nn.Module` models with a `forward` function are supported.
+```
+def Model(torch.nn.Module):
+    def forward(self, x):
+        # ...
+        return outputs
+
+# Add "record_property" parameter
+def test_model_name(record_property):
+    # Should be set as early as possible
+    record_property("model_name", "Model Name")
+
+    model = Model()
+    # ...
+    outputs = model(test_input)
+    # outputs = model(**test_inputs) # dictionary inputs are also supported
+    # ...
+
+    # Can be set once all three objects for the tuple are defined
+    record_property("torch_ttnn", (model, test_input(s), outputs))
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import pytest
 import ttnn
 import torch
+import torch_ttnn
+import collections
+from tests.utils import calculate_accuracy
+import time
+from pathlib import Path
+import os
+import pickle
 
 
 @pytest.fixture(scope="session")
@@ -15,3 +22,61 @@ def reset_torch_dynamo():
     # PyTorch caches models. Start a fresh compile for each parameter of the test case.
     torch._dynamo.reset()
     yield
+
+
+@pytest.fixture(autouse=True)
+def compile_and_run(device, reset_torch_dynamo, request):
+    try:
+        start = time.perf_counter() * 1000
+        yield
+        end = time.perf_counter() * 1000
+        runtime_metrics = {"success": True, "run_time": round(end - start, 2)}
+    except Exception as e:
+        runtime_metrics = {"success": False}
+        print(f"{model_name} original failed to run. Raised exception: {e}")
+        raise
+    finally:
+        record = dict(request.node.user_properties)
+        model_path = Path(request.node.location[0])
+        runtime_metrics["model_path"] = str(model_path.parent)
+        if "model_name" in record:
+            model_name = record["model_name"]
+            p = Path(f"metrics/{model_name}")
+            os.makedirs(p, exist_ok=True)
+
+            original_metrics_path = p / f"original-run_time_metrics.pickle"
+            with open(original_metrics_path, "wb") as f:
+                pickle.dump(runtime_metrics, f)
+
+    if "torch_ttnn" in record:
+        model, inputs, outputs = record["torch_ttnn"]
+        try:
+            # check that model contains a forward function
+            assert "forward" in dir(model), f"forward() not implemented in {model_name}"
+            # Compile model with ttnn backend
+            option = torch_ttnn.TorchTtnnOption(
+                device=device, gen_graphviz=True, metrics_path=model_name
+            )
+            m = torch.compile(model, backend=torch_ttnn.backend, options=option)
+
+            start = time.perf_counter() * 1000
+            if isinstance(inputs, collections.Mapping):
+                outputs_after = m(**inputs)
+            elif isinstance(inputs, collections.Sequence):
+                outputs_after = m(*inputs)
+            else:
+                outputs_after = m(inputs)
+            end = time.perf_counter() * 1000
+            comp_runtime_metrics = {"success": True, "run_time": round(end - start, 2)}
+            option._out_fx_graphs[0].print_tabular()
+            accuracy = calculate_accuracy(outputs, outputs_after)
+            if accuracy:
+                comp_runtime_metrics["accuracy"] = accuracy
+        except Exception as e:
+            comp_runtime_metrics = {"success": False}
+            print(f"{model_name} compiled failed to run. Raised exception: {e}")
+            raise
+        finally:
+            compiled_metrics_path = p / f"compiled-run_time_metrics.pickle"
+            with open(compiled_metrics_path, "wb") as f:
+                pickle.dump(comp_runtime_metrics, f)

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -1,13 +1,12 @@
 import torch
-import torch_ttnn
-import pytest
-from torch_ttnn.metrics import RunTimeMetrics
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForQuestionAnswering
 
 
-def test_bert(device):
+def test_bert(record_property):
+    record_property("model_name", "BERT")
+
     # Download model from cloud
     model_name = "phiyodr/bert-large-finetuned-squad2"
     tokenizer = AutoTokenizer.from_pretrained(
@@ -32,10 +31,9 @@ def test_bert(device):
         truncation=True,
     )
 
-    metrics_path = "BERT"
     # Run inference with the original model
     with torch.no_grad():
-        outputs_before = RunTimeMetrics(metrics_path, "original", lambda: m(**inputs))
+        outputs = m(**inputs)
 
     # Helper function to decode output to human-readable text
     def decode_output(outputs):
@@ -44,21 +42,7 @@ def test_bert(device):
         response_tokens = inputs.input_ids[0, response_start:response_end]
         return tokenizer.decode(response_tokens)
 
-    answer_before = decode_output(outputs_before)
-
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        outputs_after = RunTimeMetrics(metrics_path, "compiled", lambda: m(**inputs))
-
-    option._out_fx_graphs[0].print_tabular()
-
-    answer_after = decode_output(outputs_after)
+    answer = decode_output(outputs)
 
     print(
         f"""
@@ -66,12 +50,8 @@ def test_bert(device):
     input:
         context: {context}
         question: {question}
-    answer before: {answer_before}
-    answer after: {answer_after}
+    answer: {answer}
     """
     )
 
-    # TODO: Add more checks for the compiled graph
-
-    # Check inference result
-    assert answer_before == answer_after
+    record_property("torch_ttnn", (m, inputs, outputs))

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -1,14 +1,14 @@
 import torch
-import torch_ttnn
 import pytest
-from torch_ttnn.metrics import RunTimeMetrics
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
 @pytest.mark.xfail
-def test_bloom(device):
+def test_bloom(record_property):
+    record_property("model_name", "Bloom")
+
     # Download model from cloud
     model_name = "bigscience/bloom-1b1"
     tokenizer = AutoTokenizer.from_pretrained(
@@ -21,10 +21,9 @@ def test_bloom(device):
     test_input = "This is a sample text from "
     inputs = tokenizer(test_input, return_tensors="pt")
 
-    metrics_path = "Bloom"
     # Run inference with the original model
     with torch.no_grad():
-        outputs_before = RunTimeMetrics(metrics_path, "original", lambda: m(**inputs))
+        outputs = m(**inputs)
 
     # Helper function to decode output to human-readable text
     def decode_output(outputs):
@@ -32,31 +31,14 @@ def test_bloom(device):
         next_token = next_token_logits.softmax(dim=-1).argmax()
         return tokenizer.decode([next_token])
 
-    decoded_output_before = decode_output(outputs_before)
-
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        outputs_after = RunTimeMetrics(metrics_path, "compiled", lambda: m(**inputs))
-    option._out_fx_graphs[0].print_tabular()
-
-    decoded_output_after = decode_output(outputs_after)
+    decoded_output = decode_output(outputs)
 
     print(
         f"""
     model_name: {model_name}
     input: {test_input}
-    output before: {decoded_output_before}
-    output after: {decoded_output_after}
+    output: {decoded_output}
     """
     )
 
-    # TODO: Add more checks for the compiled graph
-
-    # Check inference result
-    assert decoded_output_before == decoded_output_after
+    record_property("torch_ttnn", (m, inputs, outputs))

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -1,14 +1,14 @@
 import torch
-import torch_ttnn
 import pytest
-from torch_ttnn.metrics import RunTimeMetrics
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
 @pytest.mark.xfail
-def test_falcon(device):
+def test_falcon(record_property):
+    record_property("model_name", "Falcon")
+
     # Download model from cloud
     model_name = "tiiuae/falcon-7b-instruct"
     tokenizer = AutoTokenizer.from_pretrained(
@@ -21,10 +21,9 @@ def test_falcon(device):
     test_input = "This is a sample text from "
     inputs = tokenizer(test_input, return_tensors="pt")
 
-    metrics_path = "Falcon"
     # Run inference with the original model
     with torch.no_grad():
-        outputs_before = RunTimeMetrics(metrics_path, "original", lambda: m(**inputs))
+        outputs = m(**inputs)
 
     # Helper function to decode output to human-readable text
     def decode_output(outputs):
@@ -32,32 +31,14 @@ def test_falcon(device):
         next_token = next_token_logits.softmax(dim=-1).argmax()
         return tokenizer.decode([next_token])
 
-    decoded_output_before = decode_output(outputs_before)
-
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        outputs_after = RunTimeMetrics(metrics_path, "compiled", lambda: m(**inputs))
-
-    option._out_fx_graphs[0].print_tabular()
-
-    decoded_output_after = decode_output(outputs_after)
+    decoded_output = decode_output(outputs)
 
     print(
         f"""
     model_name: {model_name}
     input: {test_input}
-    output before: {decoded_output_before}
-    output after: {decoded_output_after}
+    output before: {decoded_output}
     """
     )
 
-    # TODO: Add more checks for the compiled graph
-
-    # Check inference result
-    assert decoded_output_before == decoded_output_after
+    record_property("torch_ttnn", (m, inputs, outputs))

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -1,14 +1,14 @@
 import torch
-import torch_ttnn
 import pytest
-from torch_ttnn.metrics import RunTimeMetrics
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
 
 @pytest.mark.xfail
-def test_gpt2(device):
+def test_gpt2(record_property):
+    record_property("model_name", "GPT-2")
+
     # Download model from cloud
     model_name = "mnoukhov/gpt2-imdb-sentiment-classifier"
     tokenizer = AutoTokenizer.from_pretrained(
@@ -23,42 +23,23 @@ def test_gpt2(device):
     test_input = "This is a sample text from "
     inputs = tokenizer(test_input, return_tensors="pt")
 
-    metrics_path = "GPT-2"
     # Run inference with the original model
     with torch.no_grad():
-        outputs_before = RunTimeMetrics(metrics_path, "original", lambda: m(**inputs))
+        outputs = m(**inputs)
 
     # Helper function to decode output to human-readable text
     def decode_output(outputs):
         normalized = outputs.logits.softmax(dim=-1)
         return normalized.argmax().item()
 
-    decoded_output_before = decode_output(outputs_before)
-
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        outputs_after = RunTimeMetrics(metrics_path, "compiled", lambda: m(**inputs))
-
-    option._out_fx_graphs[0].print_tabular()
-
-    decoded_output_after = decode_output(outputs_after)
+    decoded_output = decode_output(outputs)
 
     print(
         f"""
     model_name: {model_name}
     input: {test_input}
-    output before: {decoded_output_before}
-    output after: {decoded_output_after}
+    output before: {decoded_output}
     """
     )
 
-    # TODO: Add more checks for the compiled graph
-
-    # Check inference result
-    assert decoded_output_before == decoded_output_after
+    record_property("torch_ttnn", (m, inputs, outputs))

--- a/tests/models/llama/test_llama.py
+++ b/tests/models/llama/test_llama.py
@@ -1,14 +1,14 @@
 import torch
-import torch_ttnn
 import pytest
-from torch_ttnn.metrics import RunTimeMetrics
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
 @pytest.mark.xfail
-def test_llama(device):
+def test_llama(record_property):
+    record_property("model_name", "Llama")
+
     # Download model from cloud
     model_name = "huggyllama/llama-7b"
     tokenizer = AutoTokenizer.from_pretrained(
@@ -21,10 +21,9 @@ def test_llama(device):
     test_input = "This is a sample text from "
     inputs = tokenizer(test_input, return_tensors="pt")
 
-    metrics_path = "Llama"
     # Run inference with the original model
     with torch.no_grad():
-        outputs_before = RunTimeMetrics(metrics_path, "original", lambda: m(**inputs))
+        outputs = m(**inputs)
 
     # Helper function to decode output to human-readable text
     def decode_output(outputs):
@@ -32,32 +31,14 @@ def test_llama(device):
         next_token = next_token_logits.softmax(dim=-1).argmax()
         return tokenizer.decode([next_token])
 
-    decoded_output_before = decode_output(outputs_before)
-
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        outputs_after = RunTimeMetrics(metrics_path, "compiled", lambda: m(**inputs))
-
-    option._out_fx_graphs[0].print_tabular()
-
-    decoded_output_after = decode_output(outputs_after)
+    decoded_output = decode_output(outputs)
 
     print(
         f"""
     model_name: {model_name}
     input: {test_input}
-    output before: {decoded_output_before}
-    output after: {decoded_output_after}
+    output before: {decoded_output}
     """
     )
 
-    # TODO: Add more checks for the compiled graph
-
-    # Check inference result
-    assert decoded_output_before == decoded_output_after
+    record_property("torch_ttnn", (m, inputs, outputs))

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -1,8 +1,5 @@
 import torch
-import torch_ttnn
 import pytest
-from torch_ttnn.metrics import RunTimeMetrics
-from tests.utils import check_with_pcc
 from torchvision import transforms, datasets
 from torch.utils.data import DataLoader
 
@@ -37,7 +34,9 @@ class MnistModel(torch.nn.Module):
         return output
 
 
-def test_mnist_train(device):
+def test_mnist_train(record_property):
+    record_property("model_name", "Mnist (Train)")
+
     transform = transforms.Compose([transforms.ToTensor()])
 
     train_dataset = datasets.MNIST(
@@ -49,32 +48,20 @@ def test_mnist_train(device):
     m = m.to(torch.bfloat16)
     m.train()
 
-    metrics_path = "Mnist (Train)"
     test_input, target = next(iter(dataloader))
-    # Run train with the original model
-    outputs_before = RunTimeMetrics(
-        metrics_path, "original", lambda: m(test_input.to(torch.bfloat16))
-    )
-
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run train with the compiled model
-    outputs_after = RunTimeMetrics(
-        metrics_path, "compiled", lambda: m(test_input.to(torch.bfloat16))
-    )
-
-    option._out_fx_graphs[0].print_tabular()
+    test_input = test_input.to(torch.bfloat16)
+    outputs = m(test_input)
 
     # TODO: Since only one loop of training is done, the outputs could have greater differences.
     # Consider adding more loops.
 
+    record_property("torch_ttnn", (m, test_input, outputs))
+
 
 @pytest.mark.xfail
-def test_mnist_eval(device):
+def test_mnist_eval(record_property):
+    record_property("model_name", "Mnist (Eval)")
+
     transform = transforms.Compose([transforms.ToTensor()])
 
     test_dataset = datasets.MNIST(
@@ -86,26 +73,9 @@ def test_mnist_eval(device):
     m = m.to(torch.bfloat16)
     m.eval()
 
-    metrics_path = "Mnist (Eval)"
     test_input, _ = next(iter(dataloader))
-    # Run inference with the original model
+    test_input = test_input.to(torch.bfloat16)
     with torch.no_grad():
-        outputs_before = RunTimeMetrics(
-            metrics_path, "original", lambda: m(test_input.to(torch.bfloat16))
-        )
+        outputs = m(test_input)
 
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        outputs_after = RunTimeMetrics(
-            metrics_path, "compiled", lambda: m(test_input.to(torch.bfloat16))
-        )
-
-    option._out_fx_graphs[0].print_tabular()
-
-    assert check_with_pcc(outputs_before, outputs_after)
+    record_property("torch_ttnn", (m, test_input, outputs))

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -1,12 +1,10 @@
 import torch
 import torchvision
-import torch_ttnn
-import pytest
-from torch_ttnn.metrics import RunTimeMetrics
-from tests.utils import check_with_pcc
 
 
-def test_resnet(device):
+def test_resnet(record_property):
+    record_property("model_name", "ResNet18")
+
     # Download model from cloud
     model = torchvision.models.get_model("resnet18", pretrained=True)
     model.eval()
@@ -15,29 +13,9 @@ def test_resnet(device):
     # Create random input tensor
     input_batch = torch.rand((1, 3, 224, 224), dtype=torch.bfloat16)
 
-    metrics_path = "ResNet18"
     # Run inference with the original model
     with torch.no_grad():
-        output_before = RunTimeMetrics(
-            metrics_path, "original", lambda: model(input_batch)
-        )
-
-    # Compile the model
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    option.gen_graphviz = True
-    model = torch.compile(model, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        output_after = RunTimeMetrics(
-            metrics_path, "compiled", lambda: model(input_batch)
-        )
-
-    option._out_fx_graphs[0].print_tabular()
-
-    # TODO: Check the graph has be rewritten and contain ttnn ops
+        output = model(input_batch)
 
     # Check inference result
-    assert check_with_pcc(output_before, output_after)
+    record_property("torch_ttnn", (model, input_batch, output))

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -1,7 +1,5 @@
 import torch
-import torch_ttnn
 import pytest
-from torch_ttnn.metrics import RunTimeMetrics
 from PIL import Image
 import requests
 
@@ -10,7 +8,9 @@ from transformers import AutoImageProcessor, AutoModelForObjectDetection
 
 
 @pytest.mark.xfail
-def test_yolos(device):
+def test_yolos(record_property):
+    record_property("model_name", "YOLOS")
+
     # Download model from cloud
     model_name = "hustvl/yolos-tiny"
     image_processor = AutoImageProcessor.from_pretrained(
@@ -26,10 +26,9 @@ def test_yolos(device):
     image = Image.open(requests.get(test_input, stream=True).raw)
     inputs = image_processor(images=image, return_tensors="pt")
 
-    metrics_path = "YOLOS"
     # Run inference with the original model
     with torch.no_grad():
-        outputs_before = RunTimeMetrics(metrics_path, "original", lambda: m(**inputs))
+        outputs = m(**inputs)
 
     # Helper function to decode output to human-readable text
     def decode_output(outputs):
@@ -39,17 +38,7 @@ def test_yolos(device):
         )[0]
         return results
 
-    decoded_output_before = decode_output(outputs_before)
-
-    # Compile model with ttnn backend
-    option = torch_ttnn.TorchTtnnOption(
-        device=device, gen_graphviz=True, metrics_path=metrics_path
-    )
-    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-
-    # Run inference with the compiled model
-    with torch.no_grad():
-        outputs_after = RunTimeMetrics(metrics_path, "compiled", lambda: m(**inputs))
+    decoded_output = decode_output(outputs)
 
     def interpret_results(decoded_output):
         for score, label, box in zip(
@@ -64,19 +53,12 @@ def test_yolos(device):
             )
             return string
 
-    option._out_fx_graphs[0].print_tabular()
-
-    decoded_output_after = decode_output(outputs_after)
-
     print(
         f"""
     model_name: {model_name}
     input_url: {test_input}
-    answer before: {interpret_results(decoded_output_before)}
-    answer after: {interpret_results(decoded_output_after)}
+    answer before: {interpret_results(decoded_output)}
     """
     )
 
-    # TODO: Add more checks for the compiled graph
-
-    # TODO: Check inference result
+    record_property("torch_ttnn", (m, inputs, outputs))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -83,3 +83,23 @@ def check_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
     return pcc_passed, construct_pcc_assert_message(
         pcc_message, expected_pytorch_result, actual_pytorch_result
     )
+
+
+def calculate_accuracy(original_outputs, compiled_outputs):
+    if isinstance(original_outputs, dict) and isinstance(compiled_outputs, dict):
+        # Handle case where outputs can be converted to dictionaries
+        original_outputs = dict(original_outputs)
+        compiled_outputs = dict(compiled_outputs)
+        output_pccs = []
+        for key in original_outputs.keys() & compiled_outputs.keys():
+            _, pcc = comp_pcc(original_outputs[key], compiled_outputs[key])
+            output_pccs.append(pcc)
+        accuracy = torch.mean(torch.tensor(output_pccs)).item()
+    elif isinstance(original_outputs, torch.Tensor) and isinstance(
+        compiled_outputs, torch.Tensor
+    ):
+        # Handle case where outputs are Pytorch Tensors
+        _, accuracy = comp_pcc(original_outputs, compiled_outputs)
+    else:
+        accuracy = None
+    return accuracy

--- a/torch_ttnn/metrics.py
+++ b/torch_ttnn/metrics.py
@@ -3,7 +3,6 @@ import pickle
 import time
 import os
 from pathlib import Path
-import warnings
 
 
 # Save a pickle file from a Python object to metrics/{base_path}/{filename}.pickle
@@ -104,45 +103,3 @@ def collect_schema_from_nodes(nodes: list):
             collection.append(node_stats)
 
     return collection
-
-
-def RunTimeMetrics(path: str, prefix: str, f):
-    """
-    Measure the runtime of the model in seconds.
-    * Exports a pickle file containing success and runtime data
-    * Exports outputs in Pytorch tensor format
-
-    Parameters:
-        path (str): Typically the name of the model
-        prefix (str): Either "original" or "compiled" is recommended
-        f: lambda function of model run
-
-    Example:
-        output = RunTimeMetrics("BERT", "compiled", lambda: model(**inputs))
-
-    Returns:
-        Output from the model or None if model fails
-    """
-    p = Path(f"metrics/{path}")
-    pt_out_path = p / f"{prefix}-outputs.pt"
-    pickle_out_path = p / f"{prefix}-run_time_metrics.pickle"
-    os.makedirs(p, exist_ok=True)
-    try:
-        # get time in milliseconds
-        start = time.perf_counter() * 1000
-        ret = f()
-        end = time.perf_counter() * 1000
-        runtime_metrics = {"success": True, "run_time": round(end - start, 2)}
-
-        torch.save(ret, pt_out_path)
-    except Exception as e:
-        runtime_metrics = {"success": False}
-        print(
-            f"{path} {prefix} failed to run. No outputs generated. Raised exception: {e}"
-        )
-        raise
-    finally:
-        with open(pickle_out_path, "wb") as f:
-            pickle.dump(runtime_metrics, f)
-
-    return ret


### PR DESCRIPTION
* Add Pytest autouse fixture that compiles a model and records metrics for original and compiled run
  * Models no longer need to import ttnn or torch_ttnn modules
  * Models will need to register a few lines of information for this fixture to work
* Simplify the collect metrics script
  * No longer need to hard-code a map of model paths
  * No longer need to import output artifacts to calculate accuracy
    * Accuracy is calculated in the pytest fixture directly