### PR TITLE
Fix assertion with unit tests

### DIFF
--- a/tests/lowering/creation/test_clone.py
+++ b/tests/lowering/creation/test_clone.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class CloneFromNodeModule(torch.nn.Module):

--- a/tests/lowering/eltwise/binary/test_div.py
+++ b/tests/lowering/eltwise/binary/test_div.py
@@ -2,7 +2,7 @@ import torch
 import torch_ttnn
 import pytest
 import ttnn
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class DivModule(torch.nn.Module):
@@ -40,7 +40,7 @@ def test_div(device, input_shapes):
         if node.target == ttnn.full or node.target == ttnn.reciprocal:
             assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)
 
 
 @pytest.mark.parametrize(
@@ -72,4 +72,4 @@ def test_div_scalar_denom(device, input_shapes):
         if node.target == ttnn.full or node.target == ttnn.reciprocal:
             assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/binary/test_lt.py
+++ b/tests/lowering/eltwise/binary/test_lt.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class LtModule(torch.nn.Module):
@@ -67,4 +67,4 @@ def test_lt_scalar(device, input_shapes):
         if node.target == ttnn.full:
             assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/binary/test_sub.py
+++ b/tests/lowering/eltwise/binary/test_sub.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class SubModule(torch.nn.Module):
@@ -104,4 +104,4 @@ def test_rsub_scalar(device, input_shapes):
         if node.target == ttnn.full:
             assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
-    assert check_with_pcc(result_before, result_after, 0.9998)
+    assert_with_pcc(result_before, result_after, 0.999)

--- a/tests/lowering/eltwise/unary/test_clamp.py
+++ b/tests/lowering/eltwise/unary/test_clamp.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class ClampModule(torch.nn.Module):
@@ -34,4 +34,4 @@ def test_clamp(device, input_shapes):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.clip) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/unary/test_gelu.py
+++ b/tests/lowering/eltwise/unary/test_gelu.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class GeluModule(torch.nn.Module):
@@ -34,4 +34,4 @@ def test_gelu(device, input_shapes):
     assert [node.target for node in nodes].count(ttnn.gelu) == 1
     # Check inference result
     print(result_before, "\n", result_after)
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/unary/test_pow.py
+++ b/tests/lowering/eltwise/unary/test_pow.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class PowTensorScalarModule(torch.nn.Module):
@@ -35,4 +35,4 @@ def test_pow_tensor_scalar(device, input_shapes):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.pow) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/unary/test_rsqrt.py
+++ b/tests/lowering/eltwise/unary/test_rsqrt.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class RsqrtModule(torch.nn.Module):
@@ -33,4 +33,4 @@ def test_rsqrt(device, input_shapes):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.rsqrt) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/eltwise/unary/test_sigmoid.py
+++ b/tests/lowering/eltwise/unary/test_sigmoid.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class SigmoidModule(torch.nn.Module):

--- a/tests/lowering/eltwise/unary/test_silu.py
+++ b/tests/lowering/eltwise/unary/test_silu.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class SiluModule(torch.nn.Module):
@@ -33,4 +33,4 @@ def test_silu(device, input_shapes):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.silu) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/matmul/test_addmm.py
+++ b/tests/lowering/matmul/test_addmm.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class AddMmModule(torch.nn.Module):
@@ -41,4 +41,4 @@ def test_addmm(device, input_shapes):
         if node.target == ttnn.matmul:
             assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/matmul/test_baddbmm.py
+++ b/tests/lowering/matmul/test_baddbmm.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class BaddbmmModule(torch.nn.Module):
@@ -50,7 +50,7 @@ def test_baddbmm(device, input_shapes):
         if node.target == ttnn.matmul or node.target == ttnn.multiply:
             assert node.meta["val"].size() == input_shapes[0]
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after, 0.999)
 
     # (2) Test with alpha and default beta value
     result_before = m.forward(*inputs, alpha=2)
@@ -71,7 +71,7 @@ def test_baddbmm(device, input_shapes):
     for node in nodes:
         if node.target == ttnn.matmul or node.target == ttnn.multiply:
             assert node.meta["val"].size() == input_shapes[0]
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after, 0.999)
 
     # (3) Test with beta and default alpha value
     result_before = m.forward(*inputs, beta=2)
@@ -92,7 +92,7 @@ def test_baddbmm(device, input_shapes):
     for node in nodes:
         if node.target == ttnn.matmul or node.target == ttnn.multiply:
             assert node.meta["val"].size() == input_shapes[0]
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after, 0.999)
 
     # (4) Test with beta and alpha values
     result_before = m.forward(*inputs, beta=2, alpha=2)
@@ -117,7 +117,7 @@ def test_baddbmm(device, input_shapes):
     for node in nodes:
         if node.target == ttnn.matmul or node.target == ttnn.multiply:
             assert node.meta["val"].size() == input_shapes[0]
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after, 0.999)
 
     # (5) Test special case when beta is 0
     result_before = m.forward(*inputs, beta=0, alpha=2)
@@ -135,4 +135,4 @@ def test_baddbmm(device, input_shapes):
     for node in nodes:
         if node.target == ttnn.matmul or node.target == ttnn.multiply:
             assert node.meta["val"].size() == input_shapes[0]
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after, 0.999)

--- a/tests/lowering/matmul/test_only_add_matmul.py
+++ b/tests/lowering/matmul/test_only_add_matmul.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class AddModule(torch.nn.Module):
@@ -111,7 +111,7 @@ def test_batchmatmul(device, input_shapes):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.matmul) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after, 0.999)
 
 
 @pytest.mark.parametrize(
@@ -141,4 +141,4 @@ def test_add_and_matmul(device, input_shapes):
     assert nodes[target.index(ttnn.matmul)].args[0].target == ttnn.add
     assert nodes[target.index(ttnn.matmul)].args[1].target == ttnn.add
     # Check inference result
-    assert torch.allclose(result_before, result_after)
+    assert torch.allclose(result_before, result_after, 0.999)

--- a/tests/lowering/normalization/test_layer_norm.py
+++ b/tests/lowering/normalization/test_layer_norm.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class LayerNormModule(torch.nn.Module):
@@ -51,7 +51,7 @@ def test_layer_norm(device, batch, sentence_length, embedding_dim):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.layer_norm) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after, 0.9998)
+    assert_with_pcc(result_before, result_after, 0.9998)
 
 
 @pytest.mark.parametrize(
@@ -78,4 +78,4 @@ def test_layer_norm_with_other_op(device, batch, sentence_length, embedding_dim)
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.layer_norm) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after, 0.9998)
+    assert_with_pcc(result_before, result_after, 0.9998)

--- a/tests/lowering/pool/test_avg_pool_2d.py
+++ b/tests/lowering/pool/test_avg_pool_2d.py
@@ -16,21 +16,24 @@ class AdaptiveAvgPool2dModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [[(1, 2048, 7, 7)]],
+    [(1, 2048, 7, 7)],
 )
 def test_adaptive_avg_pool_2d(device, input_shapes):
     m = AdaptiveAvgPool2dModule()
-    inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
-    result_before = m.forward(*inputs)
+    inputs = torch.rand(input_shapes, dtype=torch.bfloat16)
+    result_before = m.forward(inputs)
     option = torch_ttnn.TorchTtnnOption(device=device)
     option.gen_graphviz = True
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    result_after = m.forward(*inputs)
+    # ttnn operates on channels-last tensors
+    input_tensor = torch.permute(inputs, (0, 2, 3, 1))
+    result_after = m.forward(input_tensor)
+    result_after = torch.permute(result_after, (0, 3, 1, 2))
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.global_avg_pool2d) == 1
     # Check inference result
-    assert_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after, pcc=0.99)

--- a/tests/lowering/pool/test_avg_pool_2d.py
+++ b/tests/lowering/pool/test_avg_pool_2d.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class AdaptiveAvgPool2dModule(torch.nn.Module):
@@ -33,4 +33,4 @@ def test_adaptive_avg_pool_2d(device, input_shapes):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.global_avg_pool2d) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/reduction/test_mean.py
+++ b/tests/lowering/reduction/test_mean.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class MeanDimModule(torch.nn.Module):
@@ -34,4 +34,4 @@ def test_mean_dim(device, input_shape, dim):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.mean) == 1
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/tensor_manipulation/test_aten_t.py
+++ b/tests/lowering/tensor_manipulation/test_aten_t.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class AtenTModule(torch.nn.Module):
@@ -26,7 +26,7 @@ def _t(device, input_shapes):
     option._out_fx_graphs[0].print_tabular()
 
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)
 
     # Return nodes
     return list(option._out_fx_graphs[0].nodes)

--- a/tests/lowering/tensor_manipulation/test_transpose.py
+++ b/tests/lowering/tensor_manipulation/test_transpose.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 class TransposeModule(torch.nn.Module):
@@ -38,4 +38,4 @@ def test_transpose(device, input_shape, dim0, dim1):
     nodes = list(option._out_fx_graphs[0].nodes)
     [node.target for node in nodes].count(ttnn.permute) == 1
     # Check inference result
-    check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/test_fall_back.py
+++ b/tests/test_fall_back.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import check_with_pcc
+from tests.utils import assert_with_pcc
 
 
 @pytest.mark.parametrize(
@@ -59,4 +59,4 @@ def test_fall_back(device, input_shapes):
     assert matmul_idx < multiply_idx[2]
 
     # Check inference result
-    assert check_with_pcc(result_before, result_after)
+    assert_with_pcc(result_before, result_after)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -71,6 +71,19 @@ def construct_pcc_assert_message(
     return "\n".join(messages)
 
 
+def assert_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
+    assert list(expected_pytorch_result.shape) == list(
+        actual_pytorch_result.shape
+    ), f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}"
+    pcc_passed, pcc_message = comp_pcc(
+        expected_pytorch_result, actual_pytorch_result, pcc
+    )
+    assert pcc_passed, construct_pcc_assert_message(
+        pcc_message, expected_pytorch_result, actual_pytorch_result
+    )
+    return pcc_passed, pcc_message
+
+
 def check_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
     if expected_pytorch_result.shape != actual_pytorch_result.shape:
         return (


### PR DESCRIPTION
The tests were not using assert correctly. This PR will follow the assertion from tt-metal unit tests.

Also fix avg_pool_2d test from the tt-metal unit test example.