### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,4 @@ repos:
   hooks:
     - id: black
       language_version: python3
+      args: ["--line-length=120"]


### PR DESCRIPTION
### Ticket
none

### Problem description
Default line width in 88 characters is way too small
![Screenshot 2024-08-22 at 7 34 21 PM](https://github.com/user-attachments/assets/84c920c3-d7fe-4811-81d4-289c42218330)
It makes code worse

### What's changed
Bumping to 120
