### PR TITLE
Test GLPN-KITTI

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ transformers==4.38.0
 pandas==2.0.3
 Pillow==10.3.0
 pydantic==2.8.2
+requests>=2.31

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -3,8 +3,10 @@ import numpy as np
 from PIL import Image
 import requests
 from transformers import GLPNImageProcessor, GLPNForDepthEstimation
+import pytest
 
 
+@pytest.mark.compilation_xfail
 def test_glpn_kitti(record_property):
     record_property("model_name", "GLPN-KITTI")
 

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -1,0 +1,37 @@
+import torch
+import numpy as np
+from PIL import Image
+import requests
+from transformers import GLPNImageProcessor, GLPNForDepthEstimation
+
+
+def test_glpn_kitti(record_property):
+    record_property("model_name", "GLPN-KITTI")
+
+    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+
+    processor = GLPNImageProcessor.from_pretrained("vinvino02/glpn-kitti")
+    model = GLPNForDepthEstimation.from_pretrained("vinvino02/glpn-kitti")
+
+    # prepare image for the model
+    inputs = processor(images=image, return_tensors="pt")
+
+    with torch.no_grad():
+        outputs = model(**inputs)
+        predicted_depth = outputs.predicted_depth
+
+    # interpolate to original size
+    prediction = torch.nn.functional.interpolate(
+        predicted_depth.unsqueeze(1),
+        size=image.size[::-1],
+        mode="bicubic",
+        align_corners=False,
+    )
+
+    # visualize the prediction
+    output = prediction.squeeze().cpu().numpy()
+    formatted = (output * 255 / np.max(output)).astype("uint8")
+    depth = Image.fromarray(formatted)
+
+    record_property("torch_ttnn", (model, inputs, outputs))


### PR DESCRIPTION
### Ticket
None

### Problem description
The test fails for now:
```
self = <OpOverload(op='aten.convolution', overload='default')>
args = (TorchTensor([[[[-0.3418, -0.1445, -0.3398,  ...,  0.0801, -0.0059,  0.0332],
               [-0.4160, -0.8438, -0.964...2.0743,  0.1114, -0.0142,  0.0484, -0.3084,  0.2446, -0.5519],
       requires_grad=True), [8, 8], [0, 0], [1, 1], ...)
kwargs = {}

    def __call__(self, *args, **kwargs):
>       return self._op(*args, **(kwargs or {}))
E       RuntimeError: expected scalar type BFloat16 but found Float

../tt-metal/python_env/lib/python3.8/site-packages/torch/_ops.py:513: RuntimeError
```

### What's changed
Add test for GLPN-KITTI
https://huggingface.co/vinvino02/glpn-kitti