### PR TITLE
Add torch_only marker to mark compiled run as xfail but leave torch run as normal

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,12 +297,14 @@ You can also substitute the backend with `torch_stat` to run a reference compari
 # Add a model test
 If you want to record run time metrics for a model or test, include a Pytest fixture named `record_property` as a parameter and set the "model_name" key.  
 If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. Currently, only `torch.nn.Module` models with a `forward` function are supported.
-```
+```python
 def Model(torch.nn.Module):
     def forward(self, x):
         # ...
         return outputs
 
+# Add torch_only marker if torch/CPU runs, but compiled version is xfail
+@pytest.mark.torch_only
 # Add "record_property" parameter
 def test_model_name(record_property):
     # Should be set as early as possible

--- a/README.md
+++ b/README.md
@@ -303,8 +303,8 @@ def Model(torch.nn.Module):
         # ...
         return outputs
 
-# Add torch_only marker if torch/CPU runs, but compiled version is xfail
-@pytest.mark.torch_only
+# Add compilation_xfail marker if torch/CPU runs, but compiled version is xfail
+@pytest.mark.compilation_xfail
 # Add "record_property" parameter
 def test_model_name(record_property):
     # Should be set as early as possible

--- a/docs/README.md.in
+++ b/docs/README.md.in
@@ -116,8 +116,8 @@ def Model(torch.nn.Module):
         # ...
         return outputs
 
-# Add torch_only marker if torch/CPU runs, but compiled version is xfail
-@pytest.mark.torch_only
+# Add compilation_xfail marker if torch/CPU runs, but compiled version is xfail
+@pytest.mark.compilation_xfail
 # Add "record_property" parameter
 def test_model_name(record_property):
     # Should be set as early as possible

--- a/docs/README.md.in
+++ b/docs/README.md.in
@@ -110,12 +110,14 @@ You can also substitute the backend with `torch_stat` to run a reference compari
 # Add a model test
 If you want to record run time metrics for a model or test, include a Pytest fixture named `record_property` as a parameter and set the "model_name" key.  
 If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. Currently, only `torch.nn.Module` models with a `forward` function are supported.
-```
+```python
 def Model(torch.nn.Module):
     def forward(self, x):
         # ...
         return outputs
 
+# Add torch_only marker if torch/CPU runs, but compiled version is xfail
+@pytest.mark.torch_only
 # Add "record_property" parameter
 def test_model_name(record_property):
     # Should be set as early as possible

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,10 @@ def compile_and_run(device, reset_torch_dynamo, request):
         except Exception as e:
             comp_runtime_metrics = {"success": False}
             print(f"{model_name} compiled failed to run. Raised exception: {e}")
-            raise
+            if request.node.get_closest_marker("torch_only"):
+                pytest.xfail()
+            else:
+                raise
         finally:
             compiled_metrics_path = p / f"compiled-run_time_metrics.pickle"
             with open(compiled_metrics_path, "wb") as f:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,7 +73,7 @@ def compile_and_run(device, reset_torch_dynamo, request):
         except Exception as e:
             comp_runtime_metrics = {"success": False}
             print(f"{model_name} compiled failed to run. Raised exception: {e}")
-            if request.node.get_closest_marker("torch_only"):
+            if request.node.get_closest_marker("compilation_xfail"):
                 pytest.xfail()
             else:
                 raise

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -5,7 +5,7 @@ import pytest
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
-@pytest.mark.torch_only
+@pytest.mark.compilation_xfail
 def test_falcon(record_property):
     record_property("model_name", "Falcon")
 

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -5,7 +5,7 @@ import pytest
 from transformers import AutoTokenizer, AutoModelForCausalLM
 
 
-@pytest.mark.xfail
+@pytest.mark.torch_only
 def test_falcon(record_property):
     record_property("model_name", "Falcon")
 

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -5,7 +5,7 @@ import pytest
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
 
-@pytest.mark.xfail
+@pytest.mark.torch_only
 def test_gpt2(record_property):
     record_property("model_name", "GPT-2")
 

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -5,7 +5,7 @@ import pytest
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
 
-@pytest.mark.torch_only
+@pytest.mark.compilation_xfail
 def test_gpt2(record_property):
     record_property("model_name", "GPT-2")
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    compilation_xfail: marks tests with compiled run as xfail but does not change torch run
+


### PR DESCRIPTION
When we introduce a model test, we want to ensure that the torch/CPU version runs. The compiled version may be expected to fail at this time. The `torch_only` mark will raise an `pytest.xfail` instead of the normal exception when compiled run fails.
