### PR TITLE
Convert arithmetic ops with a scalar

### DIFF
--- a/tests/lowering/eltwise/binary/test_add.py
+++ b/tests/lowering/eltwise/binary/test_add.py
@@ -41,3 +41,43 @@ def test_add(device, input_shapes):
 
     # Check inference result
     assert torch.allclose(result_before, result_after)
+
+
+@pytest.mark.parametrize("input_shape", [(4, 4)])
+def test_add_scalar(device, input_shape):
+    m = AddModule()
+    inputs = (torch.randint(1, 5, input_shape).type(torch.bfloat16), -2.25)
+    result_before = m.forward(*inputs)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(*inputs)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.add) == 1
+
+    # Check inference result
+    assert torch.allclose(result_before, result_after)
+
+
+@pytest.mark.parametrize("input_shape", [(4, 4)])
+def test_radd_scalar(device, input_shape):
+    m = AddModule()
+    inputs = (-2.25, torch.randint(1, 5, input_shape).type(torch.bfloat16))
+    result_before = m.forward(*inputs)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(*inputs)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.add) == 1
+
+    # Check inference result
+    assert torch.allclose(result_before, result_after)


### PR DESCRIPTION
### Ticket
None

### Problem description
Convert pointwise binary ops that
- Take a tensor and a scalar
- Give a tensor of the same shape and type as the operand.

### What's changed
- [x] Convert `aten.add.Scalar` to `ttnn.add`
- [ ] Convert `aten.sub.Scalar` to `ttnn.sub`
- [ ] Convert `aten.mul.Scalar` to `ttnn.mul`
- [ ] Convert `aten.div.Scalar` to `ttnn.div`

The premise does not require the op to be arithmetic.  Therefore, this method should work on other binary ops as well.
- [ ] Convert `aten.pow.Scalar` to `ttnn.pow`