### PR TITLE
Add support for model.generate with T5 model

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ You can also substitute the backend with `torch_stat` to run a reference compari
 
 # Add a model test
 If you want to record run time metrics for a model or test, include a Pytest fixture named `record_property` as a parameter and set the "model_name" key.  
-If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. Currently, only `torch.nn.Module` models with a `forward` function are supported.
+If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. `torch.nn.Module` models with `generate` method is supported.
 ```python
 def Model(torch.nn.Module):
     def forward(self, x):
@@ -340,3 +340,4 @@ def test_model_name(record_property):
     record_property("torch_ttnn", (model, test_input(s), outputs))
 ```
 
+If `model.generate(inputs)` is used, pass in `model.generate` instead of `model` to `record_property`.

--- a/docs/README.md.in
+++ b/docs/README.md.in
@@ -109,7 +109,7 @@ You can also substitute the backend with `torch_stat` to run a reference compari
 
 # Add a model test
 If you want to record run time metrics for a model or test, include a Pytest fixture named `record_property` as a parameter and set the "model_name" key.  
-If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. Currently, only `torch.nn.Module` models with a `forward` function are supported.
+If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. `torch.nn.Module` models with `generate` method is supported.
 ```python
 def Model(torch.nn.Module):
     def forward(self, x):
@@ -132,3 +132,5 @@ def test_model_name(record_property):
     # Can be set once all three objects for the tuple are defined
     record_property("torch_ttnn", (model, test_input(s), outputs))
 ```
+
+If `model.generate(inputs)` is used, pass in `model.generate` instead of `model` to `record_property`.

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -19,4 +19,4 @@ def test_t5(record_property, model_name):
 
     print(f"Model: {model_name} | Input: {input_text} | Output: {output_text}")
 
-    record_property("torch_ttnn", (model, input_ids, output_ids))
+    record_property("torch_ttnn", (model.generate, input_ids, output_ids))

--- a/torch_ttnn/metrics.py
+++ b/torch_ttnn/metrics.py
@@ -68,7 +68,11 @@ def collect_schema_from_nodes(nodes: list):
 
                 # Collect the input shapes from the metadata if possible.
                 if hasattr(arg, "meta") and "val" in arg.meta:
-                    arg_shapes.append(str(list(arg.meta["val"].size())))
+                    val = arg.meta["val"]
+                    if isinstance(val, torch._subclasses.fake_tensor.FakeTensor):
+                        arg_shapes.append(str(list(val.size())))
+                    else:
+                        arg_shapes.append(str(val))
                 else:
                     arg_shapes.append("")
 


### PR DESCRIPTION
`model.generate` can be passed into `torch.compile` without any changes to the current backend. This commit will display better error messages if the torch rerun failed due to mismatch between `model.generate`, `model`, and the inputs.