### PR TITLE
Convert `aten._log_softmax`

### DIFF
--- a/tests/lowering/normalization/test_log_softmax.py
+++ b/tests/lowering/normalization/test_log_softmax.py
@@ -1,0 +1,38 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class LogSoftmaxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, axis):
+        return torch.log_softmax(x, axis)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [[(1, 1, 64, 32)]],
+)
+def test_log_softmax(device, input_shapes):
+    m = LogSoftmaxModule()
+    inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+    axis = -1
+    result_before = m.forward(*inputs, axis)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(*inputs, axis)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    targets = [node.target for node in nodes]
+    assert targets.count(ttnn.softmax) == 1
+    assert targets.count(ttnn.log) == 1
+    assert targets.index(ttnn.softmax) < targets.index(ttnn.log)
+    # Check inference result
+    assert torch.allclose(result_before, result_after, rtol=0.2)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -425,6 +425,10 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_kwargs = {"layout": TtnnTileLayout()}
                 new_node = g.call_function(ttnn.embedding, args=(args[1], args[0]), kwargs=new_kwargs)
                 new_nodes.append(new_node)
+            if node.target == torch.ops.aten._log_softmax.default:
+                softmax_node = g.call_function(ttnn.softmax, args[:2])
+                new_node = g.call_function(ttnn.log, (softmax_node,))
+                new_nodes.append(new_node)
             if node.target == torch.ops.aten.rsub.Scalar:
                 # NOTE(kevinwuTT): ttnn.sub shows error if passing a literal scalar as the first argument.
                 # Instead, fill a tensor with the same size as args[0] with the scalar value using ttnn.full

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -426,8 +426,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_node = g.call_function(ttnn.embedding, args=(args[1], args[0]), kwargs=new_kwargs)
                 new_nodes.append(new_node)
             if node.target == torch.ops.aten._log_softmax.default:
-                softmax_node = g.call_function(ttnn.softmax, args[:2])
-                new_node = g.call_function(ttnn.log, (softmax_node,))
+                softmax_node = g.call_function(ttnn.softmax, args[:2], node.kwargs)
+                new_node = g.call_function(ttnn.log, (softmax_node,), node.kwargs)
                 new_nodes.append(new_node)
             if node.target == torch.ops.aten.rsub.Scalar:
                 # NOTE(kevinwuTT): ttnn.sub shows error if passing a literal scalar as the first argument.


### PR DESCRIPTION
### Ticket
None

### Problem description
Lower `aten._log_softmax`

### What's changed
- [x] Convert `aten._log_softmax` to `ttnn.softmax` followed by `ttnn.log`
- [x] Test this conversion

We might encounter issues about numerical stability in the future by splitting `log_softmax`, but this is the best we can do for now.
