### PR TITLE
Fix converting `aten.clone`

### DIFF
--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -4,7 +4,7 @@ import torch
 
 @torch.fx.wrap
 def clone(t):
-    return ttnn.clone(t, t.memory_config(), t.dtype)
+    return ttnn.clone(t, memory_config=t.memory_config(), dtype=t.dtype)
 
 
 @torch.fx.wrap


### PR DESCRIPTION
### Ticket
None

### Problem description
`test_clone.py` produced the following error
```
    def __call__(self, *function_args, **function_kwargs):
>       return self.function(*function_args, **function_kwargs)
E       TypeError: __call__(): incompatible function arguments. The following argument types are supported:
E           1. (self: ttnn._ttnn.operations.data_movement.clone_t, input_tensor: ttnn._ttnn.deprecated.tensor.Tensor, *, memory_config: Optional[ttnn._ttnn.deprecated.tensor.MemoryConfig] = None, dtype: Optional[ttnn._ttnn.deprecated.tensor.DataType] = None, queue_id: int = 0) -> ttnn._ttnn.deprecated.tensor.Tensor
E       
E       Invoked with: <ttnn._ttnn.operations.data_movement.clone_t object at 0x7fec66225d70>, ttnn.Tensor([[ 0.07422,  0.47656,  ...,  0.00000,  0.00000],
E                    [ 0.86719,  0.66406,  ...,  0.00000,  0.00000],
E                    ...,
E                    [ 0.00000,  0.00000,  ...,  0.00000,  0.00000],
E                    [ 0.00000,  0.00000,  ...,  0.00000,  0.00000]], shape=Shape([4[32], 4[32]]), dtype=DataType::BFLOAT16, layout=Layout::TILE), MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt), <DataType.BFLOAT16: 0>
E       
E       Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
E       <pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
E       conversions are optional and require extra headers to be included
E       when compiling your pybind11 module.

../tt-metal/ttnn/ttnn/decorators.py:327: TypeError
```

### What's changed
The test should pass now.
