### PR TITLE
Model segment-anything.

### DIFF
--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -1,0 +1,25 @@
+# Reference: https://huggingface.co/facebook/sam2-hiera-tiny
+
+import torch
+from sam2.sam2_image_predictor import SAM2ImagePredictor
+import requests
+from PIL import Image
+
+
+@pytest.mark.skip(
+    reason="Failed to install sam2. sam2 requires Python >=3.10.0 but the default version on Ubuntu 20.04 is 3.8. We found no other pytorch implementation of segment-anything."
+)
+def test_segment_anything(record_property):
+    record_property("model_name", "segment-anything")
+
+    predictor = SAM2ImagePredictor.from_pretrained("facebook/sam2-hiera-small")
+
+    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+    prompt = "Beautiful thing"
+
+    with torch.no_grad():
+        predictor.set_image(image)
+        outputs = predictor.predict(prompt)
+
+    record_property("torch_ttnn", (predictor, prompt, outputs))

--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -1,4 +1,5 @@
-# Reference: https://huggingface.co/facebook/sam2-hiera-tiny
+# Reference: https://github.com/facebookresearch/segment-anything-2
+# Hugging Face version: https://huggingface.co/facebook/sam2-hiera-tiny
 
 import torch
 from sam2.sam2_image_predictor import SAM2ImagePredictor


### PR DESCRIPTION
### Ticket
None

### Problem description
Add model segment-anything to trace. 

However, unfortunately the goal is not achieved. We decided to push the code just for keeping a record, and we marked the test skipped.

The test fails to run because it requires installation of package sam2, but sam2 requires Python>=3.10.0 while the default version on Ubuntu 20.04 is 3.8. 

We tried to find alternative pytorch implementation of the same model but found nothing.

### What's changed
Add model segment-anything.
