### PR TITLE
Model OpenPose.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,8 +9,9 @@ pydantic==2.8.2
 requests>=2.31
 sentencepiece==0.2.0
 protobuf==5.27.3
-timm
+timm<=0.6.7
 mlp-mixer-pytorch==0.1.1
 datasets
 diffusers
 controlnet_aux
+pytorchcv

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -1,0 +1,45 @@
+# Reference: https://github.com/tenstorrent/tt-buda-demos/blob/main/model_demos/cv_demos/openpose/pytorch_lwopenpose_2d_osmr.py
+
+import requests
+import torch
+from PIL import Image
+from pytorchcv.model_provider import get_model as ptcv_get_model
+from torchvision import transforms
+import pytest
+
+
+def get_image_tensor():
+    # Image processing
+    url = "https://raw.githubusercontent.com/axinc-ai/ailia-models/master/pose_estimation_3d/blazepose-fullbody/girl-5204299_640.jpg"
+    input_image = Image.open(requests.get(url, stream=True).raw)
+    preprocess = transforms.Compose(
+        [
+            transforms.Resize(224),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+    input_tensor = preprocess(input_image)
+    input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model
+    return input_batch
+
+
+@pytest.mark.compilation_xfail
+def test_openpose_v2(record_property):
+    record_property("model_name", "OpenPose")
+
+    # Create PyBuda module from PyTorch model
+    model = ptcv_get_model("lwopenpose2d_mobilenet_cmupan_coco", pretrained=True)
+    model.eval()
+
+    input_batch = [get_image_tensor()]
+    batch_input = torch.cat(input_batch, dim=0)
+
+    # Run inference on Tenstorrent device
+    output = model(batch_input)
+
+    # Print output
+    print(f"Output: {output}")
+
+    record_property("torch_ttnn", (model, batch_input, output))


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
The current OpenPose test does not work because the model in use is not supported by the PyTorch Dynamo compiler flow. 

I suspect the issue is due to the model's use of dynamic shapes, which the current PyTorch Dynamo compilation flow does not support well. My assumption is based on the error message during compilation.

```
E       torch._dynamo.exc.BackendCompilerFailed: backend='ttnn_backend' raised:
E       RuntimeError: aten::clone() Expected a value of type 'Tensor' for argument 'self' but instead found type 'SymInt'.
E       Position: 0
E       Value: s1
E       Declaration: aten::clone(Tensor self, *, MemoryFormat? memory_format=None) -> Tensor
E       Cast error details: Unable to cast s1 to Tensor
E
E       While executing %clone_default_1 : [num_users=1] = call_function[target=torch.ops.aten.clone.default](args = (%l_s_1_,\
), kwargs = {})
E       Original traceback:
E       None
E
E
E       You can suppress this exception and fall back to eager by setting:
E           import torch._dynamo
E           torch._dynamo.config.suppress_errors = True
```

The error indicates that an `aten` operator received data of type `SymInt` instead of the expected `Tensor`. PyTorch indeed provides a type called `SymInt` (symbolic integer), introduced as part of its symbolic shapes feature. This feature supports symbolic shape inference in tensor operations, which is especially useful when working with dynamic shapes, enabling more flexible and efficient model design. However, the use of `SymInt` seems to conflict with the expectations of the Dynamo compiler, as the error occurs within Dynamo itself.

`SymInt` Reference: [pytorch source code](https://github.com/pytorch/pytorch/blob/main/c10/core/SymInt.h)

### What's changed
We have retained the current test implementation for future study and added another test using a different model that does not have issues with dynamic shapes.
