### PR TITLE
Bump metal to latest available wheel build. Fix ttnn.clone usage

### DIFF
--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -24,8 +24,9 @@ jobs:
         id: update-requirements
         run: |
           latest_version=${{ steps.fetch_release.outputs.release }}
+          latest_version_short=$(echo $latest_version | sed 's/-rc/rc/')
           # Replace the old version with the new pre-release version in requirements.txt
-          sed -i "s|https://github.com/tenstorrent/tt-metal/releases/download/v[0-9\.]*/metal_libs-[^+]*+wormhole\.b0-cp38-cp38-linux_x86_64\.whl|https://github.com/tenstorrent/tt-metal/releases/download/v$latest_version/metal_libs-$latest_version+wormhole.b0-cp38-cp38-linux_x86_64.whl|" requirements.txt
+          sed -i "s|https://github.com/tenstorrent/tt-metal/releases/download/v[0-9\.]*/metal_libs-[0-9\.]*-[^+]*+wormhole\.b0-cp38-cp38-linux_x86_64\.whl|https://github.com/tenstorrent/tt-metal/releases/download/v$latest_version/metal_libs-$(echo $latest_version | sed 's/-rc/rc/')+wormhole.b0-cp38-cp38-linux_x86_64.whl|" requirements.txt
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ tabulate==0.9.0
 networkx==3.1
 graphviz
 matplotlib==3.7.1
-https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc6/metal_libs-0.52.0rc6+wormhole.b0-cp38-cp38-linux_x86_64.whl
+https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc13/metal_libs-0.52.0rc13+wormhole.b0-cp38-cp38-linux_x86_64.whl
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ networkx==3.1
 graphviz
 matplotlib==3.7.1
 https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc15/metal_libs-0.52.0rc15+wormhole.b0-cp38-cp38-linux_x86_64.whl
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ tabulate==0.9.0
 networkx==3.1
 graphviz
 matplotlib==3.7.1
-https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc14/metal_libs-0.52.0rc14+wormhole.b0-cp38-cp38-linux_x86_64.whl
+https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc15/metal_libs-0.52.0rc15+wormhole.b0-cp38-cp38-linux_x86_64.whl
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ tabulate==0.9.0
 networkx==3.1
 graphviz
 matplotlib==3.7.1
-https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc13/metal_libs-0.52.0rc13+wormhole.b0-cp38-cp38-linux_x86_64.whl
+https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc14/metal_libs-0.52.0rc14+wormhole.b0-cp38-cp38-linux_x86_64.whl
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tabulate==0.9.0
 networkx==3.1
 graphviz
 matplotlib==3.7.1
-https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0/metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc6/metal_libs-0.52.0rc6+wormhole.b0-cp38-cp38-linux_x86_64.whl

--- a/tools/huggingface_delete_cache.py
+++ b/tools/huggingface_delete_cache.py
@@ -10,6 +10,6 @@ try:
 
     delete_strategy.execute()
     print("Cache deletion done.")
-    
+
 except Exception as e:
     print(f"Error: {e}. No cache directory found, skipping cache deletion.")

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -189,6 +189,14 @@ def aten_backend(
         option.compiled_schema_list.extend(metrics.collect_schema_from_nodes(gm.graph.nodes))
 
     option._out_fx_graphs.append(gm.graph)
+
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            print(f"{node.name}: {node.meta}")
+
+    for number, line in enumerate(gm.code.splitlines()):
+        print(f"{number + 1}: {line}")
+
     return make_boxed_func(gm)
 
 

--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -4,7 +4,7 @@ import torch
 
 @torch.fx.wrap
 def clone(t):
-    return ttnn.clone(t, t.memory_config(), t.dtype)
+    return ttnn.clone(t, memory_config=t.memory_config(), dtype=t.dtype)
 
 
 @torch.fx.wrap


### PR DESCRIPTION
### Ticket
None

### Problem description
Several PRs require latest version of Metal wheel

### What's changed
Bumping the TT-NN dependency.
Fixing lowering issue.
```
E       TypeError: __call__(): incompatible function arguments. The following argument types are supported:
E           1. (self: ttnn._ttnn.operations.data_movement.clone_t, input_tensor: ttnn._ttnn.deprecated.tensor.Tensor, *, memory_config: Optional[ttnn._ttnn.deprecated.tensor.MemoryConfig] = None, dtype: Optional[ttnn._ttnn.deprecated.tensor.DataType] = None, queue_id: int = 0) -> ttnn._ttnn.deprecated.tensor.Tensor
E       
E       Invoked with: <ttnn._ttnn.operations.data_movement.clone_t object at 0x7f53506ff570>, ttnn.Tensor([[ 0.51562,  1.50781,  ...,  0.00000,  0.00000],
E                    [ 1.39844,  1.61719,  ...,  0.00000,  0.00000],
E                    ...,
E                    [ 0.00000,  0.00000,  ...,  0.00000,  0.00000],
E                    [ 0.00000,  0.00000,  ...,  0.00000,  0.00000]], shape=Shape([4[32], 4[32]]), dtype=DataType::BFLOAT16, layout=Layout::TILE), MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt), <DataType.BFLOAT16: 0>
E       
E       Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
E       <pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
E       conversions are optional and require extra headers to be included
E       when compiling your pybind11 module.
```
