### PR TITLE
Try lowering `aten.col2im` to `ttnn.fold`

### DIFF
--- a/tests/lowering/tensor_manipulation/test_fold.py
+++ b/tests/lowering/tensor_manipulation/test_fold.py
@@ -1,0 +1,39 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class FoldModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *args, **kwargs):
+        return torch.nn.functional.fold(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "input_size, output_size, kernel_size, dilation, padding, stride",
+    (
+        ((36, 36), (8, 8), (3, 3), 1, 0, 1),
+    )
+)
+def test_fold(device, input_size, output_size, kernel_size, dilation, padding, stride):
+    m = FoldModule()
+    tensor = torch.randn(input_size, dtype=torch.bfloat16)
+    inputs = tensor, output_size, kernel_size, dilation, padding, stride
+    result_before = m.forward(*inputs)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(*inputs)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.fold) == 1
+
+    # Check inference result
+    assert torch.allclose(result_before, result_after)
+    

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -113,6 +113,7 @@ TTNN_MATRIX_MULPIPLICATION_OPS = [
 ]
 
 TTNN_DATAMOVE_OPS = [
+    ttnn.fold,
     ttnn.reshape,
     ttnn.permute,
     #  ttnn.repeat,  in target_wrapper


### PR DESCRIPTION
### Ticket
None

### Problem description
Currently the test is stuck at the following error.
```
E       RuntimeError: TT_FATAL @ ../tt_metal/impl/buffers/buffer.cpp:31: size != 0 and page_size != 0
E       info:
E       Buffer size and page size should be larger than 0 bytes!
E       backtrace:
E        --- tt::tt_metal::validate_buffer_size_and_page_size(unsigned long, unsigned long, tt::tt_metal::BufferType const&, tt::tt_metal::TensorMemoryLayout const&, std::__1::optional<tt::tt_metal::ShardSpecBuffer> const&)
E        --- tt::tt_metal::Buffer::Buffer(tt::tt_metal::Device*, unsigned long, unsigned long, tt::tt_metal::BufferType, tt::tt_metal::TensorMemoryLayout, std::__1::optional<tt::tt_metal::ShardSpecBuffer> const&, std::__1::optional<bool>, bool)
E        --- /home/ubuntu/tt-metal/ttnn/ttnn/_ttnn.so(+0xe2ebbe) [0x7f365e640bbe]
```

### What's changed
- [x] Conversion from `aten.col2im` to `ttnn.fold`
- [x] Test cases for the conversion
