### PR TITLE
Add skip and fallback for ops not supported by Grayskull

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,26 @@ def reset_torch_dynamo():
 
 
 @pytest.fixture(autouse=True)
+def skip_by_platform(request, device):
+    platforms = {
+        "grayskull": ttnn.device.is_grayskull(device),
+        "wormhole_b0": ttnn.device.is_wormhole_b0(device),
+    }
+    if skip_platform := request.node.get_closest_marker("skip_platform"):
+        if skip_platform.args:
+            arch = skip_platform.args[0]
+            if current_platform := platforms.get(arch):
+                pytest.skip(f"Skipped on {arch}")
+            elif current_platform == None:
+                raise ValueError(f'pytest.skip_platform arch: "{arch}" not valid.')
+            # if false, then continue with test
+        else:
+            raise ValueError(
+                f'pytest.skip_platform missing arch argument string, i.e. pytest.skip_platform("grayskull")'
+            )
+
+
+@pytest.fixture(autouse=True)
 def compile_and_run(device, reset_torch_dynamo, request):
     # Initialize early to ensure it's defined
     runtime_metrics = {"success": False}  # Initialize early to ensure it's defined

--- a/tests/lowering/eltwise/unary/test_floor.py
+++ b/tests/lowering/eltwise/unary/test_floor.py
@@ -12,6 +12,7 @@ class FloorModule(torch.nn.Module):
         return torch.floor(x)
 
 
+@pytest.mark.skip_platform("grayskull")
 @pytest.mark.parametrize(
     "input_shape",
     [(4, 4)],

--- a/tests/lowering/misc/test_fallback_incompatible_platform.py
+++ b/tests/lowering/misc/test_fallback_incompatible_platform.py
@@ -1,0 +1,43 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class FloorModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return torch.floor(x)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [(4, 4)],
+)
+def test_floor(device, input_shape):
+    m = FloorModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16) * 20 - 10
+    result_before = m.forward(input)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input)
+    option._out_fx_graphs[0].print_tabular()
+
+    # This test will fallback to torch.ops.aten.floor.default
+    nodes = list(option._out_fx_graphs[0].nodes)
+    target = [node.target for node in nodes]
+    if ttnn.device.is_grayskull:
+        assert target.count(ttnn.floor) == 0
+        assert target.count(torch.ops.aten.floor.default) == 1
+    else:
+        assert target.count(ttnn.floor) == 1
+        assert target.count(torch.ops.aten.floor.default) == 0
+
+    # Check inference result
+    from tests.utils import assert_with_pcc
+
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/misc/test_fallback_incompatible_platform.py
+++ b/tests/lowering/misc/test_fallback_incompatible_platform.py
@@ -30,7 +30,7 @@ def test_floor(device, input_shape):
     # This test will fallback to torch.ops.aten.floor.default
     nodes = list(option._out_fx_graphs[0].nodes)
     target = [node.target for node in nodes]
-    if ttnn.device.is_grayskull:
+    if ttnn.device.is_grayskull(device):
         assert target.count(ttnn.floor) == 0
         assert target.count(torch.ops.aten.floor.default) == 1
     else:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
     compilation_xfail: marks tests with compiled run as xfail but does not change torch run
-
+    skip_platform: marks tests that are not compatible with specified platform

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -116,7 +116,7 @@ def aten_backend(
     from torch_ttnn.passes.memory_pass import MemoryPass
 
     passes = [
-        ToTtPass(),
+        ToTtPass(option.device),
         AddDataMovePass(),
         EliminateCoreopsPass(),
         CSEPass(),


### PR DESCRIPTION
### Ticket
None

### Problem description
Some ttnn ops do not run on Grayskull like `ttnn.floor`

### What's changed

- [x] Add a pytest marker to skip a test if it's not compatible with specified platform. 
- [x] Add fallback for certain ops if Grayskull is detected
  - [x] Add unit test to check for fallback
