### PR TITLE
Convert `constant_pad_nd` into `ttnn.pad`

### DIFF
--- a/tests/lowering/tensor_manipulation/test_constant_pad_nd.py
+++ b/tests/lowering/tensor_manipulation/test_constant_pad_nd.py
@@ -22,6 +22,7 @@ class ConstantPadNdModule(torch.nn.Module):
         ((1, 32), [0, 32, 0, 0], True),
         ((16, 16), [0, 16, 0, 0], True),
         ((4,), [0, 16], True),
+        [(1, 14, 14, 384), [0, 0, 0, 0, 0, 0], True],
         # Not supported: more than 4 dims
         ((1, 1, 1, 32, 32), [0, 32], False),
         # Not supported: front padding

--- a/tests/lowering/tensor_manipulation/test_constant_pad_nd.py
+++ b/tests/lowering/tensor_manipulation/test_constant_pad_nd.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+import torch_ttnn
+import ttnn
+
+
+class ConstantPadNdModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, pad, value):
+        return torch.constant_pad_nd(input, pad, value)
+
+
+@pytest.mark.parametrize(
+    "input_shape, pad",
+    [
+        ((1, 32, 32), [0, 64, 0, 32]),
+        ((64, 32), [0, 32, 0, 64]),
+        pytest.param((1, 32), [0, 32, 0, 0], marks=pytest.mark.xfail(reason="output shape incorrect (#176)")),
+        pytest.param((16, 16), [0, 16, 0, 0], marks=pytest.mark.xfail(reason="not support layout (#176)")),
+        pytest.param((32, 32), [32, 0, 32, 0], marks=pytest.mark.xfail(reason="not support front padding (#176)")),
+    ],
+)
+def test_constant_pad_nd(device, input_shape, pad):
+    m = ConstantPadNdModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16)
+    value = 0.5
+    result_before = m.forward(input, pad, value)
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, pad, value)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contains ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.pad) == 1
+    # Check inference result
+    assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -115,6 +115,7 @@ TTNN_MATRIX_MULPIPLICATION_OPS = [
 
 TTNN_DATAMOVE_OPS = [
     ttnn.reshape,
+    ttnn.pad,
     ttnn.permute,
     ttnn.concat,
     ttnn.split,

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -120,6 +120,7 @@ TTNN_DATAMOVE_OPS = [
     ttnn.concat,
     ttnn.split,
     ttnn.slice,
+    ttnn.to_layout,
 ]
 
 TTNN_TARGET_WRAPPERS = [target_wrappers.clone, target_wrappers.repeat]

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -594,6 +594,12 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     permutation = [1, 0]
                     return g.call_function(ttnn.permute, args=(args[0], permutation))
                 return None
+            if node.target == torch.ops.aten.constant_pad_nd.default:
+                input, pad, value = args
+                # # The order of pad from pytorch is reversed.
+                pad = [(pad[i], pad[i + 1]) for i in range(0, len(pad), 2)][::-1]
+                new_node = g.call_function(ttnn.pad, args=(input, pad, value))
+                new_nodes.append(new_node)
 
         with g.inserting_before(node):
             new_node = rewrite_node(node)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -601,10 +601,10 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 full_pad = [(0, 0)] * (rank - len(pad))
                 # The order of pad from pytorch is reversed
                 full_pad += [(pad[i], pad[i + 1]) for i in range(0, len(pad), 2)][::-1]
-                # Front padding isn't well supported so skip for now
+                # TODO(#192): Front padding isn't well supported so skip for now
                 if rank > 4 or (not all(f == 0 for f, _ in full_pad)):
                     return None
-                # Change layout to row-major for non tile-size-aligned tensor
+                # Change layout to row-major for non-tile-size-aligned tensor
                 if (
                     rank < 2
                     or input_shape[-1] % ttnn.TILE_SIZE != 0

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -602,18 +602,18 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # The order of pad from pytorch is reversed
                 full_pad += [(pad[i], pad[i + 1]) for i in range(0, len(pad), 2)][::-1]
                 # Front padding isn't well supported so skip for now
-                if rank <= 4 and all(f == 0 for f, _ in full_pad):
-                    # Change layout to row-major for non tile-size-aligned tensor
-                    if not (
-                        rank >= 2
-                        and input_shape[-1] % ttnn.TILE_SIZE == 0
-                        and input_shape[-2] % ttnn.TILE_SIZE == 0
-                        and full_pad[-1][1] % ttnn.TILE_SIZE == 0
-                        and full_pad[-2][1] % ttnn.TILE_SIZE == 0
-                    ):
-                        new_nodes.append(g.call_function(ttnn.to_layout, (input,), {"layout": TtnnRowMajorLayout()}))
-                        input = new_nodes[-1]
-                    new_nodes.append(g.call_function(ttnn.pad, args=(input, full_pad, value)))
+                if rank > 4 or (not all(f == 0 for f, _ in full_pad)):
+                    return None
+                # Change layout to row-major for non tile-size-aligned tensor
+                if not (
+                    rank >= 2
+                    and input_shape[-1] % ttnn.TILE_SIZE == 0
+                    and input_shape[-2] % ttnn.TILE_SIZE == 0
+                    and full_pad[-1][1] % ttnn.TILE_SIZE == 0
+                    and full_pad[-2][1] % ttnn.TILE_SIZE == 0
+                ):
+                    input = g.call_function(ttnn.to_layout, (input,), {"layout": TtnnRowMajorLayout()})
+                return g.call_function(ttnn.pad, args=(input, full_pad, value))
 
         with g.inserting_before(node):
             new_node = rewrite_node(node)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -605,14 +605,14 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 if rank > 4 or (not all(f == 0 for f, _ in full_pad)):
                     return None
                 # Change layout to row-major for non tile-size-aligned tensor
-                if not (
-                    rank >= 2
-                    and input_shape[-1] % ttnn.TILE_SIZE == 0
-                    and input_shape[-2] % ttnn.TILE_SIZE == 0
-                    and full_pad[-1][1] % ttnn.TILE_SIZE == 0
-                    and full_pad[-2][1] % ttnn.TILE_SIZE == 0
+                if (
+                    rank < 2
+                    or input_shape[-1] % ttnn.TILE_SIZE != 0
+                    or input_shape[-2] % ttnn.TILE_SIZE != 0
+                    or full_pad[-1][1] % ttnn.TILE_SIZE != 0
+                    or full_pad[-2][1] % ttnn.TILE_SIZE != 0
                 ):
-                    input = g.call_function(ttnn.to_layout, (input,), {"layout": TtnnRowMajorLayout()})
+                    input = g.call_function(ttnn.to_layout, args=(input, TtnnRowMajorLayout()))
                 return g.call_function(ttnn.pad, args=(input, full_pad, value))
 
         with g.inserting_before(node):


### PR DESCRIPTION
### Ticket
For currently unsupported front padding: #192

### Problem description
Convert `constant_pad_nd` into `ttnn.pad`. It supports padding tile-size aligned tensor in `TILE_LAYOUT` directly; otherwise it converts the non-aligned tensor into `ROW_MAJOR_LAYOUT` first then pad

Currently it doesn't support front padding and fallbacks to aten.

### What's changed
- Conversion from `aten.constant_pad_nd` to `ttnn.pad`
- Add `ttnn.pad` and `ttnn.to_layout` to `TTNN_DATAMOVE_OPS` for inserting data movement
- Test cases for the conversion