### PR TITLE
Hook `ttnn.split` (since 0.51.0) and `ttnn.slice` into the data movement pass

### DIFF
--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -116,9 +116,9 @@ TTNN_MATRIX_MULPIPLICATION_OPS = [
 TTNN_DATAMOVE_OPS = [
     ttnn.reshape,
     ttnn.permute,
-    #  ttnn.repeat,  in target_wrapper
     ttnn.concat,
-    # ttnn.split,  # ttnn has no split, remote the comment in the future when it has
+    ttnn.split,
+    ttnn.slice,
 ]
 
 TTNN_TARGET_WRAPPERS = [target_wrappers.clone, target_wrappers.repeat]


### PR DESCRIPTION
### Ticket
This patch originates from #179 but is good on its own
https://github.com/tenstorrent/pytorch2.0_ttnn/pull/179#discussion_r1755237688

### Problem description
TTNN ops need a hook in the data movement pass for correct tensor type/location.

### What's changed
- Added `ttnn.split` to the data movement pass
- Added `ttnn.slice` to the data movement pass
