### PR TITLE
Try converting `aten.cat` to `ttnn.concat`

### DIFF
--- a/tests/lowering/tensor_manipulation/test_concat.py
+++ b/tests/lowering/tensor_manipulation/test_concat.py
@@ -12,7 +12,6 @@ class ConcatModule(torch.nn.Module):
         return torch.cat((x1, x2), dim)
 
 
-@pytest.mark.xfail(reason="lowering issue (#67)")
 @pytest.mark.parametrize(
     "input_shapes, dim",
     [

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -279,6 +279,9 @@ class ReplaceMoreTt(torch.fx.Transformer):
         ############################################################
         # Data movement
         ############################################################
+        if target == torch.ops.aten.cat.default:
+            return self.call_function_prop_meta(ttnn.concat, args, kwargs)
+
         if target == torch.ops.aten.permute.default:
             return self.call_function_prop_meta(ttnn.permute, args, kwargs)
 


### PR DESCRIPTION
### Ticket
Subproblem of tenstorrent/tt-metal#12853

### Problem description
Data movement pass does not take effect.  A difference is that `aten.cat` takes a list of tensors instead of a fixed number of tensors.

```
E       TypeError: __call__(): incompatible function arguments. The following argument types are supported:
E           1. (self: ttnn._ttnn.operations.data_movement.concat_t, tensors: List[ttnn._ttnn.deprecated.tensor.Tensor], dim: int = 0, *, output_tensor: Optional[ttnn._ttnn.deprecated.tensor.Tensor] = None, memory_config: Optional[ttnn._ttnn.deprecated.tensor.MemoryConfig] = None, queue_id: int = 0) -> ttnn._ttnn.deprecated.tensor.Tensor
E
E       Invoked with: <ttnn._ttnn.operations.data_movement.concat_t object at 0x7fd912468d30>, [tensor([[0.5938, 0.2500],
E               [0.4453, 0.0078],
E               [0.7539, 0.1328],
E               [0.6406, 0.1367]], dtype=torch.bfloat16), tensor([[0.4219, 0.3867],
E               [0.0977, 0.8945],
E               [0.2344, 0.1953],
E               [0.9023, 0.4375]], dtype=torch.bfloat16)], 1

../venv/lib/python3.8/site-packages/ttnn/decorators.py:326: TypeError
```

### What's changed
- Restore conversion `aten.cat` → `ttnn.concat`
- Reenable test for `aten.cat` → `ttnn.concat`
