### PR TITLE
Convert `aten.remainder.Scalar` to `ttnn.remainder`

### DIFF
--- a/tests/lowering/eltwise/unary/test_remainder.py
+++ b/tests/lowering/eltwise/unary/test_remainder.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+import torch_ttnn
+import ttnn
+
+
+class RemainderModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, mod):
+        return input % mod
+
+
+@pytest.mark.parametrize(
+    "input_shape, mod, converted",
+    [
+        ((32, 32), 7, True),
+        ((1, 32), 3, True),
+        ((16, 16), 5, True),
+        ((4,), 1, True),
+        ((1, 2, 3, 6, 4), 1, True),
+    ],
+)
+def test_remainder(device, input_shape, mod, converted):
+    m = RemainderModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16) * (mod * 3)
+    result_before = m.forward(input, mod)
+    # print(torch.export.export(m, args=(input, mod)))
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
+    # # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, mod)
+    option._out_fx_graphs[0].print_tabular()
+
+    # # Check the graph has be rewritten and contains ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.remainder) == (1 if converted else 0)
+    # Check inference result
+    assert torch.allclose(result_before, result_after)

--- a/tests/lowering/eltwise/unary/test_remainder.py
+++ b/tests/lowering/eltwise/unary/test_remainder.py
@@ -29,12 +29,12 @@ def test_remainder(device, input_shape, mod, converted):
     # print(torch.export.export(m, args=(input, mod)))
 
     option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
-    # # The compilation is lazy, so we need to run forward once to trigger the compilation
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
     result_after = m.forward(input, mod)
     option._out_fx_graphs[0].print_tabular()
 
-    # # Check the graph has be rewritten and contains ttnn ops
+    # Check the graph has be rewritten and contains ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.remainder) == (1 if converted else 0)
     # Check inference result

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -54,6 +54,7 @@ TTNN_POINTWISE_UNARY_OPS = [
     ttnn.neg,
     ttnn.reciprocal,
     ttnn.relu,
+    ttnn.remainder,
     ttnn.rsqrt,
     ttnn.sigmoid,
     ttnn.softmax,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -191,6 +191,9 @@ class ReplaceMoreTt(torch.fx.Transformer):
         if target == torch.ops.aten.relu.default:
             return self.call_function_prop_meta(ttnn.relu, args, kwargs)
 
+        if target == torch.ops.aten.remainder.Scalar:
+            return self.call_function_prop_meta(ttnn.remainder, args, kwargs)
+
         if target == torch.ops.aten.rsqrt.default:
             return self.call_function_prop_meta(ttnn.rsqrt, args, kwargs)
 


### PR DESCRIPTION
### Ticket
None

### Problem description
Convert `aten.remainder.Scalar` to `ttnn.remainder`

### What's changed
- Add conversion from `aten.remainder.Scalar` to `ttnn.remainder`
- Test cases for the conversion
