### PR TITLE
Support squeeze in bert model

### DIFF
--- a/docs/models/BERT/input_variations.md
+++ b/docs/models/BERT/input_variations.md
@@ -17,7 +17,7 @@
 | 13 | aten.rsub.Scalar               |                  1 |           1 |
 | 14 | aten.slice.Tensor              |                  4 |           0 |
 | 15 | aten.split.Tensor              |                  1 |           0 |
-| 16 | aten.squeeze.dim               |                  1 |           0 |
+| 16 | aten.squeeze.dim               |                  1 |           1 |
 | 17 | aten.t.default                 |                  4 |           4 |
 | 18 | aten.transpose.int             |                  1 |           1 |
 | 19 | aten.unsqueeze.default         |                  2 |           2 |
@@ -106,7 +106,7 @@
 ### aten.squeeze.dim
 |    | ATen Input Variations                           | Status   |
 |---:|:------------------------------------------------|:---------|
-|  0 | Tensor<[1, 256, 1]> self = ?,<br>int<> dim = -1 | Unknown  |
+|  0 | Tensor<[1, 256, 1]> self = ?,<br>int<> dim = -1 | Done     |
 ### aten.t.default
 |    | ATen Input Variations         | Status   |
 |---:|:------------------------------|:---------|

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,8 @@ def compile_and_run(device, reset_torch_dynamo, request):
             outputs_after = run_model(m, inputs)
             end = time.perf_counter() * 1000
             comp_runtime_metrics = {"success": True, "run_time": round(end - start, 2)}
-            option._out_fx_graphs[0].print_tabular()
+            if option.verbose:
+                option._out_fx_graphs[0].print_tabular()
             accuracy = calculate_accuracy(outputs, outputs_after)
             if accuracy:
                 comp_runtime_metrics["accuracy"] = accuracy

--- a/tests/lowering/tensor_manipulation/test_squeeze.py
+++ b/tests/lowering/tensor_manipulation/test_squeeze.py
@@ -17,6 +17,8 @@ class SqueezeDimModule(torch.nn.Module):
     (
         ((1, 32, 16), 0),
         ((1, 256, 1), 2),
+        ((1, 1, 256), 2),
+        ((1, 256), 1),
     ),
 )
 def test_squeeze_dim(device, input_shapes, dim):

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -189,12 +189,13 @@ def aten_backend(
 
     option._out_fx_graphs.append(gm.graph)
 
-    for node in gm.graph.nodes:
-        if node.op == "placeholder":
-            print(f"{node.name}: {node.meta}")
+    if option.verbose:
+        for node in gm.graph.nodes:
+            if node.op == "placeholder":
+                print(f"{node.name}: {node.meta}")
 
-    for number, line in enumerate(gm.code.splitlines()):
-        print(f"{number + 1}: {line}")
+        for number, line in enumerate(gm.code.splitlines()):
+            print(f"{number + 1}: {line}")
 
     return make_boxed_func(gm)
 

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -265,7 +265,6 @@ def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.N
         kwargs = {}
         if (
             dst_node.target == ttnn.reshape
-            or dst_node.target == ttnn.squeeze
             or dst_node.target == ttnn.embedding
             or dst_node.target == ttnn.zeros_like
             or dst_node.target == target_wrappers.repeat
@@ -325,8 +324,10 @@ def try_add_layout_change_after_node(src_node, dst_idx, dst_node) -> torch.fx.no
     g = dst_node.graph
     with g.inserting_before(dst_node):
         to_layout = g.call_function(ttnn.to_layout, (dst_node, TtnnTileLayout()))
+    with g.inserting_before(dst_node):
+        to_device = g.call_function(ttnn.to_device, (to_layout, TtnnDevice())) 
 
-    insert_node_between(src_node, dst_idx, dst_node, [to_layout])
+    insert_node_between(src_node, dst_idx, dst_node, [to_layout, to_device])
 
     return to_layout
 

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -264,6 +264,7 @@ def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.N
         kwargs = {}
         if (
             dst_node.target == ttnn.reshape
+            or dst_node.target == ttnn.squeeze
             or dst_node.target == ttnn.embedding
             or dst_node.target == ttnn.zeros_like
             or dst_node.target == target_wrappers.repeat

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -325,7 +325,7 @@ def try_add_layout_change_after_node(src_node, dst_idx, dst_node) -> torch.fx.no
     with g.inserting_before(dst_node):
         to_layout = g.call_function(ttnn.to_layout, (dst_node, TtnnTileLayout()))
     with g.inserting_before(dst_node):
-        to_device = g.call_function(ttnn.to_device, (to_layout, TtnnDevice())) 
+        to_device = g.call_function(ttnn.to_device, (to_layout, TtnnDevice()))
 
     insert_node_between(src_node, dst_idx, dst_node, [to_layout, to_device])
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/12851

### Problem description
ttnn squeeze is only supported for dim = 0. So for such inputs convert aten squeeze to ttnn squeeze.
While for dim != 0 inputs, converted aten squeeze to ttnn reshape keeping input in row major layout.