### PR TITLE
Convert `aten.view` to `ttnn.reshape`

### DIFF
--- a/tests/lowering/tensor_manipulation/test_view.py
+++ b/tests/lowering/tensor_manipulation/test_view.py
@@ -1,0 +1,84 @@
+import pytest
+import torch
+import ttnn
+import torch_ttnn
+
+
+class ViewModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        return torch.reshape(x, new_shape)
+
+
+class ViewAfterOpModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        abs = torch.abs(x)
+        return torch.reshape(abs, new_shape)
+
+
+class ViewBeforeOpModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        reshape = torch.reshape(x, new_shape)
+        return torch.abs(reshape)
+
+
+class ViewBetweenOpModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        abs = torch.abs(x)
+        reshape = torch.reshape(abs, new_shape)
+        return torch.abs(reshape)
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        ViewModule(),
+        ViewAfterOpModule(),
+        ViewBeforeOpModule(),
+        ViewBetweenOpModule(),
+    ],
+)
+@pytest.mark.parametrize(
+    "input_shape, new_shape",
+    [
+        ((1, 16, 256, 256), (16, 256, 256)),
+        ((1, 16, 256, 64), (16, 256, 64)),
+        ((1, 16, 64, 256), (16, 64, 256)),
+        pytest.param((1, 256, 1024), (1, 256, 16, 64), marks=pytest.mark.xfail(reason="Unsupported")),
+        ((1, 256, 1024), (256, 1024)),
+        pytest.param((1, 256, 16, 64), (1, 256, 1024), marks=pytest.mark.xfail(reason="Unsupported")),
+        ((1, 256, 4096), (256, 4096)),
+        ((16, 256, 256), (1, 16, 256, 256)),
+        ((16, 256, 64), (1, 16, 256, 64)),
+        ((256, 1024), (1, 256, 1024)),
+        ((256, 2), (1, 256, 2)),
+        ((256, 4096), (1, 256, 4096)),
+    ],
+)
+def test_reshape(device, input_shape, new_shape, module):
+    m = module
+    input = torch.rand(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(input, new_shape)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, new_shape)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.reshape) == 1
+    # Check inference result
+    assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -132,6 +132,11 @@ TTNN_NORM_OPS = [
 ]
 
 
+def can_be_tilized(node):
+    size = node.meta["val"].size()
+    return len(size) >= 2 and size[-1] % 32 == 0 and size[-2] % 32 == 0
+
+
 # For operations limitations
 # See https://github.com/tenstorrent-metal/tt-metal/blob/main/ttnn/README.md?plain=1#L19
 def is_tt_compute(node) -> bool:
@@ -264,7 +269,7 @@ def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.N
     with g.inserting_before(dst_node):
         kwargs = {}
         if (
-            dst_node.target == ttnn.reshape
+            (dst_node.target == ttnn.reshape and not can_be_tilized(dst_node))
             or dst_node.target == ttnn.embedding
             or dst_node.target == ttnn.zeros_like
             or dst_node.target == target_wrappers.repeat
@@ -277,9 +282,7 @@ def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.N
             kwargs["dtype"] = TtnnBfloat16()
 
         # For reshape only put tensor on device if rank is 4
-        if (is_tt_compute(dst_node) and dst_node.target != ttnn.reshape) or (
-            dst_node.target == ttnn.reshape and len(dst_node.args[1]) == 4
-        ):
+        if is_tt_compute(dst_node):
             kwargs["device"] = device
 
         new_nodes.append(g.call_function(ttnn.from_torch, (src_node,), kwargs))
@@ -302,7 +305,12 @@ def try_add_layout_change_before_node(src_node, dst_idx, dst_node) -> torch.fx.n
         return None
     if not is_function_call(dst_node):
         return None
-    if dst_node.target not in layout_change_ops or dst_idx != 0 or not is_tt(src_node):
+    if (
+        dst_node.target not in layout_change_ops
+        or dst_idx != 0
+        or not is_tt(src_node)
+        or (dst_node.target == ttnn.reshape and can_be_tilized(dst_node))
+    ):
         return None
 
     g = dst_node.graph
@@ -318,7 +326,12 @@ def try_add_layout_change_after_node(src_node, dst_idx, dst_node) -> torch.fx.no
     # Consider src_node is ttnn.repeat, and dst_node should be any tt_compute node that uses ttnn.repeat
     if not is_function_call(src_node):
         return None
-    if src_node.target not in layout_change_ops or not is_tt_compute(dst_node) or dst_node.target == ttnn.embedding:
+    if (
+        src_node.target not in layout_change_ops
+        or not is_tt_compute(dst_node)
+        or dst_node.target == ttnn.embedding
+        or (src_node.target == ttnn.reshape and can_be_tilized(src_node))
+    ):
         return None
 
     g = dst_node.graph

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -295,10 +295,6 @@ class ReplaceMoreTt(torch.fx.Transformer):
         if target == torch.ops.aten.permute.default:
             return self.call_function_prop_meta(ttnn.permute, args, kwargs)
 
-        if target == torch.ops.aten.view.default:
-            # aten.reshape is more stable if the input nodes have changed
-            return self.call_function_prop_meta(torch.ops.aten.reshape.default, args, kwargs)
-
         ############################################################
         # Other ops
         ############################################################
@@ -622,6 +618,56 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 ):
                     input = g.call_function(ttnn.to_layout, args=(input, TtnnRowMajorLayout()))
                 return g.call_function(ttnn.pad, args=(input, full_pad, value))
+
+            if node.target == torch.ops.aten.view.default:
+                source_shape = args[0].meta["val"].size()
+                out_shape = args[1]
+                source_rank = len(source_shape)
+                out_rank = len(out_shape)
+
+                # Allow lowering by default
+                can_reshape = True
+
+                # Unsupported:
+                # (1) -> (1, 1) or (1, 1, 1), etc
+                if (source_rank == 1) and (np.prod(source_shape) == 1):
+                    can_reshape = False
+                elif not has_valid_page_size(source_shape):
+                    can_reshape = False
+                # Same as ttnn.squeeze with dim = 0
+                # Supported:
+                # (1, 16, 256, 256) -> (16, 256, 256)
+                # (1, 256, 256) - > (256, 256)
+                elif (source_rank != 1) and (out_rank == (source_rank - 1)) and (source_shape[0] == 1):
+                    for i in range(0, out_rank):
+                        if source_shape[i + 1] != out_shape[i]:
+                            can_reshape = False
+                            break
+
+                # Same as ttnn.unsqueeze_to_4D
+                # Supported:
+                # (16, 256, 256) -> (1, 16, 256, 256)
+                # (256, 256) -> (1, 1, 256, 256)
+                elif (out_rank > 1) and (out_rank <= 4) and (source_rank > 0) and (source_rank <= 4):
+                    for i in range(0, out_rank):
+                        si = i + (source_rank - out_rank)
+                        if si < 0:
+                            if out_shape[i] != 1:
+                                can_reshape = False
+                                break
+                        else:
+                            if out_shape[i] != source_shape[si]:
+                                can_reshape = False
+                                break
+                else:
+                    can_reshape = False
+
+                # Transform to ttnn.reshape if possible
+                if can_reshape:
+                    return g.call_function(ttnn.reshape, (args[0], args[1]), {})
+                else:
+                    # Fallback: aten.reshape is more stable if the input nodes have changed
+                    return g.call_function(torch.ops.aten.reshape.default, args, kwargs)
 
         with g.inserting_before(node):
             new_node = rewrite_node(node)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/173

### Problem description
Currently, `aten.view` falls back to `aten.reshape`. 

### What's changed
Add conversion to `ttnn.reshape` based on supported shapes. 

BERT has the following input variations. The unchecked boxes indicate fallback to `aten.reshape`.
- [x] (1, 16, 256, 256) -> (16, 256, 256)
- [x] (1, 16, 256, 64) -> (16, 256, 64)
- [x] (1, 16, 64, 256) -> (16, 64, 256)
- [ ] (1, 256, 1024) -> (1, 256, 16, 64)
- [x] (1, 256, 1024) -> (256, 1024)
- [ ] (1, 256, 16, 64) -> (1, 256, 1024)
- [x] (1, 256, 4096) -> (256, 4096)
- [x] (16, 256, 256) -> (1, 16, 256, 256)
- [x] (16, 256, 64) -> (1, 16, 256, 64)
- [x] (256, 1024) -> (1, 256, 1024)
- [x] (256, 2) -> (1, 256, 2)
- [x] (256, 4096) -> (1, 256, 4096)

There are currently 2 unsupported shapes. TTNN team is currently looking to add support: https://github.com/tenstorrent/tt-metal/issues/12715
