### PR TITLE
Update TT-NN to 0.52.0-rc28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tabulate==0.9.0
 networkx==3.1
 graphviz
 matplotlib==3.7.1
-https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc27/metal_libs-0.52.0rc27+wormhole.b0-cp38-cp38-linux_x86_64.whl
+https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0-rc28/metal_libs-0.52.0rc28+wormhole.b0-cp38-cp38-linux_x86_64.whl


### PR DESCRIPTION
This PR updates TT-NN wheel to the latest pre-release version.