### PR TITLE
Try converting `aten.argmax`

### DIFF
--- a/tests/lowering/reduction/test_argmax.py
+++ b/tests/lowering/reduction/test_argmax.py
@@ -1,0 +1,37 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+from tests.utils import assert_with_pcc
+
+
+class ArgmaxDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim, keepdim=False):
+        return torch.argmax(input, dim, keepdim=keepdim)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [((1, 32, 32), -1)],
+)
+def test_argmax_dim(device, input_shape, dim):
+    m = ArgmaxDimModule()
+    input = torch.zeros(input_shape, dtype=torch.bfloat16).uniform_(-1, 1)
+    keepdim = True
+    result_before = m.forward(input, dim, keepdim)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, dim, keepdim)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has been rewritten and contains ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.argmax) == 1
+    # Check inference result
+    assert_with_pcc(result_before, result_after)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -157,6 +157,7 @@ def is_tt_compute(node) -> bool:
             ttnn.tril,
             ttnn.arange,
             ttnn.zeros_like,
+            ttnn.argmax,
             ttnn.mean,
             ttnn.global_avg_pool2d,
             ttnn.clip,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -623,6 +623,16 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     input = g.call_function(ttnn.to_layout, args=(input, TtnnRowMajorLayout()))
                 return g.call_function(ttnn.pad, args=(input, full_pad, value))
 
+            if node.target == torch.ops.aten.argmax.default:
+                kwargs = {
+                    "dim": args[1],
+                    **kwargs,
+                }
+                input = g.call_function(ttnn.to_layout, (args[0], TtnnRowMajorLayout()))
+                return g.call_function(ttnn.argmax, (input,), kwargs)
+
+            return None
+
         with g.inserting_before(node):
             new_node = rewrite_node(node)
             if new_node is not None:


### PR DESCRIPTION
### Ticket
None

### Problem description
In the beginning, `ttnn.argmax` requests row-major layout.
```
E       RuntimeError: TT_FATAL @ /home/jdh8/tt-metal/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp:19: input_tensor_a.get_layout() == Layout::ROW_MAJOR
E       info:
E       Only ROW_MAJOR layout is supported for inputs!
```

Then I convert the input tensor to row-major layout, but it complains
```
RuntimeError: TT_FATAL @ /home/jdh8/tt-metal/ttnn/cpp/ttnn/operations/reduction/argmax/device/argmax_op.cpp:46: input_shape[1]==1
```

### What's changed
- Convert `aten.argmax` to `ttnn.argmax`
