### PR TITLE
Try to convert `aten.amin/amax` to `ttnn.min/max`

### DIFF
--- a/tests/lowering/reduction/test_amax.py
+++ b/tests/lowering/reduction/test_amax.py
@@ -1,0 +1,48 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class AmaxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim, keepdim):
+        return torch.amax(input, dim=dim, keepdim=keepdim)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim",
+    [
+        # pytest.param((32, 32), [], False, marks=pytest.mark.xfail(reason="keepdim = false not supported (#TODO)")),
+        # ((32, 32), [], True),
+        # ((16, 32, 32), [0], True),  Output size cannot fit input with offset
+        ((16, 32, 32), [1], True),
+        ((16, 32, 32), [2], True),
+        ((16, 32, 32), [1, 2], True),
+        # ((16, 32, 32), [0, 1, 2], True),  Unsupported dim
+        ((1, 32), [], True),
+        ((32, 1), [], True),
+        # ((16,), [], True), assert torch.Size([1]) == torch.Size([1, 1])
+        # ((4, 16, 32), [2], True), Unable to reshape a tensor in TILE_LAYOUT to non-tile height and width! Please convert the tensor to ROW_MAJOR_LAYOUT first.
+    ],
+)
+def test_amax(device, input_shape, dim, keepdim):
+    m = AmaxModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(input, dim, keepdim)
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, dim, keepdim)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten
+    nodes = list(option._out_fx_graphs[0].nodes)
+    # There should be no op
+    assert [node.target for node in nodes].count(ttnn.max) == 1
+    # Check inference result
+    assert result_before.shape == result_after.shape
+    assert torch.allclose(result_before, result_after)

--- a/tests/lowering/reduction/test_amax.py
+++ b/tests/lowering/reduction/test_amax.py
@@ -22,17 +22,17 @@ class AmaxModule(torch.nn.Module):
         ((16, 32, 32), 1, True, True),
         ((16, 32, 32), [2], True, True),
         ((16, 32, 32), [1, 2], True, True),
-        # TODO(TODO): keepdim = false is not supported
+        # TODO(#240): keepdim = false is not supported
         ((32, 32), [1], False, False),
-        # TODO(TODO): Unsupport reduction on < rank - 2 dims
+        # TODO(#240): Unsupport reduction on < rank - 2 dims
         ((16, 32, 32), [0], True, False),
         ((32, 32, 32), [0, 1, 2], True, False),
-        # TODO(TODO): Unexpected output shape (1, 1) instead of (1)
+        # TODO(#240): Unexpected output shape (1, 1) instead of (1)
         ((32,), [], True, False),
-        # TODO(TODO): Need -inf padding value
+        # TODO(#240): Need -inf padding value
         ((1, 32), [], True, False),
         ((32, 1), [], True, False),
-        # TODO(TODO): Output reshape inside generic reduction can't handle non-tile-aligned size
+        # TODO(#240): Output reshape inside generic reduction can't handle non-tile-aligned size
         ((1, 32), [1], True, False),
     ],
 )

--- a/tests/lowering/reduction/test_amin.py
+++ b/tests/lowering/reduction/test_amin.py
@@ -1,0 +1,48 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class AmaxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim, keepdim):
+        return torch.amin(input, dim=dim, keepdim=keepdim)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim",
+    [
+        pytest.param((32, 32), [], False, marks=pytest.mark.xfail(reason="keepdim = false not supported (#TODO)")),
+        ((32, 32), [], True),
+        # ((16, 32, 32), [0], True),  #Output size cannot fit input with offset
+        ((16, 32, 32), [1], True),
+        ((16, 32, 32), [2], True),
+        ((16, 32, 32), [1, 2], True),
+        # ((16, 32, 32), [0, 1, 2], True),  Unsupported dim
+        # ((1, 32), [], True), 0.0 padding issue
+        # ((32, 1), [], True), 0.0 padding issue
+        # ((16,), [], True), #assert torch.Size([1]) == torch.Size([1, 1])
+        # ((4, 16, 32), [2], True), #Unable to reshape a tensor in TILE_LAYOUT to non-tile height and width! Please convert the tensor to ROW_MAJOR_LAYOUT first.
+    ],
+)
+def test_amax(device, input_shape, dim, keepdim):
+    m = AmaxModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(input, dim, keepdim)
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, dim, keepdim)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten
+    nodes = list(option._out_fx_graphs[0].nodes)
+    # There should be no op
+    assert [node.target for node in nodes].count(ttnn.min) == 1
+    # Check inference result
+    assert result_before.shape == result_after.shape
+    assert torch.allclose(result_before, result_after)

--- a/tests/lowering/reduction/test_amin.py
+++ b/tests/lowering/reduction/test_amin.py
@@ -4,7 +4,7 @@ import pytest
 import ttnn
 
 
-class AmaxModule(torch.nn.Module):
+class AminModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
@@ -12,25 +12,33 @@ class AmaxModule(torch.nn.Module):
         return torch.amin(input, dim=dim, keepdim=keepdim)
 
 
+@pytest.mark.parametrize("sign", [1, -1])
 @pytest.mark.parametrize(
-    "input_shape, dim, keepdim",
+    "input_shape, dim, keepdim, converted",
     [
-        pytest.param((32, 32), [], False, marks=pytest.mark.xfail(reason="keepdim = false not supported (#TODO)")),
-        ((32, 32), [], True),
-        # ((16, 32, 32), [0], True),  #Output size cannot fit input with offset
-        ((16, 32, 32), [1], True),
-        ((16, 32, 32), [2], True),
-        ((16, 32, 32), [1, 2], True),
-        # ((16, 32, 32), [0, 1, 2], True),  Unsupported dim
-        # ((1, 32), [], True), 0.0 padding issue
-        # ((32, 1), [], True), 0.0 padding issue
-        # ((16,), [], True), #assert torch.Size([1]) == torch.Size([1, 1])
-        # ((4, 16, 32), [2], True), #Unable to reshape a tensor in TILE_LAYOUT to non-tile height and width! Please convert the tensor to ROW_MAJOR_LAYOUT first.
+        ((32, 32), [], True, True),
+        ((16, 32, 32), [], True, True),
+        ((16, 32, 32), 1, True, True),
+        ((16, 32, 32), [1], True, True),
+        ((16, 32, 32), [2], True, True),
+        ((16, 32, 32), [1, 2], True, True),
+        # TODO(TODO): keepdim = false is not supported
+        ((32, 32), [1], False, False),
+        # TODO(TODO): Unsupport reduction on < rank - 2 dims
+        ((16, 32, 32), [0], True, False),
+        ((32, 32, 32), [0, 1, 2], True, False),
+        # TODO(TODO): Unexpected output shape (1, 1) instead of (1)
+        ((32,), [], True, False),
+        # TODO(TODO): Need -inf padding value
+        ((1, 32), [], True, False),
+        ((32, 1), [], True, False),
+        # TODO(TODO): Output reshape inside generic reduction can't handle non-tile-aligned size
+        ((1, 32), [1], True, False),
     ],
 )
-def test_amax(device, input_shape, dim, keepdim):
-    m = AmaxModule()
-    input = torch.rand(input_shape, dtype=torch.bfloat16)
+def test_amin(device, sign, input_shape, dim, keepdim, converted):
+    m = AminModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16) * sign
     result_before = m.forward(input, dim, keepdim)
 
     option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
@@ -42,7 +50,7 @@ def test_amax(device, input_shape, dim, keepdim):
     # Check the graph has be rewritten
     nodes = list(option._out_fx_graphs[0].nodes)
     # There should be no op
-    assert [node.target for node in nodes].count(ttnn.min) == 1
+    assert [node.target for node in nodes].count(ttnn.min) == (1 if converted else 0)
     # Check inference result
     assert result_before.shape == result_after.shape
     assert torch.allclose(result_before, result_after)

--- a/tests/lowering/reduction/test_amin.py
+++ b/tests/lowering/reduction/test_amin.py
@@ -22,17 +22,17 @@ class AminModule(torch.nn.Module):
         ((16, 32, 32), [1], True, True),
         ((16, 32, 32), [2], True, True),
         ((16, 32, 32), [1, 2], True, True),
-        # TODO(TODO): keepdim = false is not supported
+        # TODO(#240): keepdim = false is not supported
         ((32, 32), [1], False, False),
-        # TODO(TODO): Unsupport reduction on < rank - 2 dims
+        # TODO(#240): Unsupport reduction on < rank - 2 dims
         ((16, 32, 32), [0], True, False),
         ((32, 32, 32), [0, 1, 2], True, False),
-        # TODO(TODO): Unexpected output shape (1, 1) instead of (1)
+        # TODO(#240): Unexpected output shape (1, 1) instead of (1)
         ((32,), [], True, False),
-        # TODO(TODO): Need -inf padding value
+        # TODO(#240): Need inf padding value
         ((1, 32), [], True, False),
         ((32, 1), [], True, False),
-        # TODO(TODO): Output reshape inside generic reduction can't handle non-tile-aligned size
+        # TODO(#240): Output reshape inside generic reduction can't handle non-tile-aligned size
         ((1, 32), [1], True, False),
     ],
 )

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -50,7 +50,6 @@ TTNN_POINTWISE_UNARY_OPS = [
     ttnn.log1p,
     ttnn.log2,
     ttnn.logical_not,
-    ttnn.min,
     ttnn.neg,
     ttnn.reciprocal,
     ttnn.relu,
@@ -109,6 +108,12 @@ TTNN_POINTWISE_TRINARY_OPS = [
     ttnn.where,
 ]
 
+TTNN_REDUCTION_OPS = [
+    ttnn.max,
+    ttnn.mean,
+    ttnn.min,
+]
+
 TTNN_MATRIX_MULPIPLICATION_OPS = [
     ttnn.matmul,
     ttnn.linear,
@@ -148,6 +153,7 @@ def is_tt_compute(node) -> bool:
         + TTNN_POINTWISE_BINARY_OPS
         + TTNN_POINTWISE_TRINARY_OPS
         + TTNN_MATRIX_MULPIPLICATION_OPS
+        + TTNN_REDUCTION_OPS
         + TTNN_TARGET_WRAPPERS
         + TTNN_DATAMOVE_OPS
         + TTNN_NORM_OPS
@@ -157,7 +163,6 @@ def is_tt_compute(node) -> bool:
             ttnn.tril,
             ttnn.arange,
             ttnn.zeros_like,
-            ttnn.mean,
             ttnn.global_avg_pool2d,
             ttnn.clip,
             ttnn.squeeze,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -280,6 +280,13 @@ class ReplaceMoreTt(torch.fx.Transformer):
         ############################################################
         # Reduction
         ############################################################
+        if target == torch.ops.aten.amax.default:
+            new_args = list(args)
+            if len(new_args) >= 2 and not isinstance(new_args[1], int):
+                dim = new_args[1]
+                new_args[1] = tuple(dim) if len(dim) > 0 else None
+            return self.call_function_prop_meta(ttnn.max, tuple(new_args), kwargs)
+
         if target == torch.ops.aten.mean.dim:
             # change dim parameter to tuple
             new_args = list(args)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -287,6 +287,13 @@ class ReplaceMoreTt(torch.fx.Transformer):
                 new_args[1] = tuple(dim) if len(dim) > 0 else None
             return self.call_function_prop_meta(ttnn.max, tuple(new_args), kwargs)
 
+        if target == torch.ops.aten.amin.default:
+            new_args = list(args)
+            if len(new_args) >= 2 and not isinstance(new_args[1], int):
+                dim = new_args[1]
+                new_args[1] = tuple(dim) if len(dim) > 0 else None
+            return self.call_function_prop_meta(ttnn.min, tuple(new_args), kwargs)
+
         if target == torch.ops.aten.mean.dim:
             # change dim parameter to tuple
             new_args = list(args)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -625,10 +625,10 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
             if node.target in [torch.ops.aten.amin.default, torch.ops.aten.amax.default]:
                 input_shape = args[0].meta["val"].size()
-                # TODO(TODO): Unsupport keepdim = false (default value)
+                # TODO(#240): Unsupport keepdim = false (default value)
                 if len(args) < 3 or args[2] == False:
                     return None
-                # TODO(TODO): Unsupport rank < 2 or non-tile-size-aligned tensor
+                # TODO(#240): Unsupport rank < 2 or non-tile-size-aligned tensor
                 if len(input_shape) < 2 or any(size % ttnn.TILE_SIZE != 0 for size in input_shape[-2:]):
                     return None
                 new_args = list(args)
@@ -636,7 +636,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 if len(args) >= 2:
                     dim = args[1]
                     dim = (dim,) if isinstance(dim, int) else tuple(dim)
-                    # TODO(TODO): Unsupport reduction on < rank - 2 dims
+                    # TODO(#240): Unsupport reduction on < rank - 2 dims
                     if any(idx < len(input_shape) - 2 for idx in dim):
                         return None
                     new_args[1] = dim if len(dim) > 0 else None


### PR DESCRIPTION
### Ticket
#240 

### Problem description
Convert `aten.amin/amax` to `ttnn.min/max`. The current unsupported cases are listed in #240 and will fallback to aten

### What's changed
- Add conversion from  `aten.amin/amax` to `ttnn.min/max`
- Add test cases
