### PR TITLE
Try to convert `aten.var.correction` to `ttnn.var`

### DIFF
--- a/tests/lowering/reduction/test_var.py
+++ b/tests/lowering/reduction/test_var.py
@@ -1,0 +1,50 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class VarModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim, keepdim, correction):
+        return torch.var(input, dim=dim, keepdim=keepdim, correction=correction)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim, correction",
+    [
+        # pytest.param((32, 32), [], False, marks=pytest.mark.xfail(reason="keepdim = false not supported (#TODO)")),
+        # ((32, 32), [], True, True), # dim = [], Unsupported reduction operation
+        ((32, 32), [1], True, 0),
+        # ((32, 32), [1], True, 1), # Not support correction
+        # ((16, 32, 32), [0], True),  #Output size cannot fit input with offset
+        ((16, 32, 32), [1], True, 0),
+        ((16, 32, 32), [2], True, 0),
+        ((16, 32, 32), [1, 2], True, 0),
+        # ((16, 32, 32), [0, 1, 2], True),  Unsupported dim
+        # ((1, 32), [], True), 0.0 padding issue
+        # ((32, 1), [], True), 0.0 padding issue
+        # ((16,), [], True), #assert torch.Size([1]) == torch.Size([1, 1])
+        # ((4, 16, 32), [2], True), #Unable to reshape a tensor in TILE_LAYOUT to non-tile height and width! Please convert the tensor to ROW_MAJOR_LAYOUT first.
+    ],
+)
+def test_var(device, input_shape, dim, keepdim, correction):
+    m = VarModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(input, dim, keepdim, correction)
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, dim, keepdim, correction)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten
+    nodes = list(option._out_fx_graphs[0].nodes)
+    # There should be no op
+    assert [node.target for node in nodes].count(ttnn.var) == 1
+    # Check inference result
+    assert result_before.shape == result_after.shape
+    assert torch.allclose(result_before, result_after, rtol=0.2)

--- a/tests/lowering/reduction/test_var.py
+++ b/tests/lowering/reduction/test_var.py
@@ -20,9 +20,9 @@ class VarModule(torch.nn.Module):
         ((16, 32, 32), 1, True, 0, True),
         ((16, 32, 32), [2], True, 0, True),
         ((16, 32, 32), [1, 2], True, 0, True),
-        # TODO(TODO): Not support correction != 0
+        # TODO(#242): Not support correction != 0
         ((32, 32), [1], True, 1, False),
-        # TODO(TODO): Unsupported reduction operation
+        # TODO(#242): Unsupported reduction operation
         ((32, 32), [], True, 0, False),
         # TODO(#240): keepdim = false is not supported
         ((32, 32), [1], False, 0, False),

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -109,6 +109,11 @@ TTNN_POINTWISE_TRINARY_OPS = [
     ttnn.where,
 ]
 
+TTNN_REDUCTION_OPS = [
+    ttnn.mean,
+    ttnn.var,
+]
+
 TTNN_MATRIX_MULPIPLICATION_OPS = [
     ttnn.matmul,
     ttnn.linear,
@@ -147,6 +152,7 @@ def is_tt_compute(node) -> bool:
         TTNN_POINTWISE_UNARY_OPS
         + TTNN_POINTWISE_BINARY_OPS
         + TTNN_POINTWISE_TRINARY_OPS
+        + TTNN_REDUCTION_OPS
         + TTNN_MATRIX_MULPIPLICATION_OPS
         + TTNN_TARGET_WRAPPERS
         + TTNN_DATAMOVE_OPS
@@ -157,7 +163,6 @@ def is_tt_compute(node) -> bool:
             ttnn.tril,
             ttnn.arange,
             ttnn.zeros_like,
-            ttnn.mean,
             ttnn.global_avg_pool2d,
             ttnn.clip,
             ttnn.squeeze,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -629,7 +629,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # TODO(#240): Not support keepdim = false (default value)
                 if new_kwargs.get("keepdim", False) == False:
                     return None
-                # TODO(TODO): Not support correction != 0
+                # TODO(#242): Not support correction != 0
                 if new_kwargs.pop("correction", 0) != 0:
                     return None
                 # TODO(#240): Not support rank < 2 or non-tile-size-aligned tensor
@@ -644,7 +644,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     if any(idx < len(input_shape) - 2 for idx in dim):
                         return None
                     new_args[1] = dim if len(dim) > 0 else None
-                # TODO(TODO): Not support all reduction
+                # TODO(#242): Not support all-dimension reduction
                 if len(dim) == 0:
                     return None
                 return g.call_function(ttnn.var, tuple(new_args), new_kwargs)


### PR DESCRIPTION
### Ticket
Unsupported cases: #242

### Problem description
Convert `aten.var.correction` to `ttnn.var`. The current unsupported cases are listed in #240, #242 and will fallback to aten

### What's changed
- Add conversion from  `aten.var.correction` to `ttnn.var`
- Add `ttnn.var` to data movement pass and refactor a little
- Add test cases
