### PR TITLE
Try to convert `aten.prod.dim_int` to ttnn.prod

### DIFF
--- a/tests/lowering/reduction/test_prod.py
+++ b/tests/lowering/reduction/test_prod.py
@@ -20,15 +20,15 @@ class ProdDimModule(torch.nn.Module):
         ((1, 2, 32, 32), 1, True, True),
         ((2, 1, 32, 32), 0, True, True),
         ((2, 1, 32, 32), 0, True, True),
-        # TODO(TODO): Cannot get the device from a tensor with host storage
-        ((1, 1, 1, 32, 32), 3, True, False),
-        # TODO(TODO): Not support keep_dim = False
+        # TODO(#244): Unexpected output shape [1, 1, 2, 1]
+        ((1, 1, 2, 32, 32), -1, True, False),
+        # TODO(#244): Not support keep_dim = False
         ((1, 2, 32, 32), 3, False, False),
-        # TODO(TODO): dim >= -4 && dim <= 3 && "Dimension out of range (expected to be in range of [-4, 3]
+        # TODO(#244): dim >= -4 && dim <= 3 && "Dimension out of range (expected to be in range of [-4, 3]"
         ((1, 1, 1, 32, 32), 4, True, False),
-        # TODO(TODO): Need to pad with 1.0 instead of 0
+        # TODO(#244): Need to pad with 1.0 instead of 0
         ((1, 1, 32, 16), -1, True, False),
-        # TODO(TODO): Need 4d shape
+        # TODO(#244): Input rank can't < 4
         ((32, 32), 1, True, False),
     ],
 )

--- a/tests/lowering/reduction/test_prod.py
+++ b/tests/lowering/reduction/test_prod.py
@@ -1,0 +1,47 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class ProdDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim, keep_dim):
+        return torch.prod(input, dim, keep_dim)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keep_dim",
+    [
+        ((1, 2, 32, 32), -1, True),
+        # ((1, 2, 32, 32), -1, False), # Not support keep_dim = False
+        ((1, 1, 32, 32), 2, True),
+        ((1, 2, 32, 32), 1, True),
+        ((2, 1, 32, 32), 0, True),
+        # ((2, 1, 1, 32, 32), -1, True), # Output size cannot fit input with offset
+        # ((1, 1, 32, 16), -1, True), # Need 1.0 padding
+        # ((1, 1, 16, 32), -1, True), # Need to crop
+        # ((32, 32), -1, True), # Need 4d shape
+    ],
+)
+def test_prod_dim(device, input_shape, dim, keep_dim):
+    m = ProdDimModule()
+    input = torch.rand(input_shape, dtype=torch.bfloat16) + 0.5
+    result_before = m.forward(input, dim, keep_dim)
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, dim, keep_dim)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten
+    nodes = list(option._out_fx_graphs[0].nodes)
+    # There should be no op
+    assert [node.target for node in nodes].count(ttnn.prod) == 1
+    # Check inference result
+    assert result_before.shape == result_after.shape
+    # Give higher tolerance for product as it's not associative with float
+    assert torch.allclose(result_before, result_after, rtol=0.1)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -109,6 +109,11 @@ TTNN_POINTWISE_TRINARY_OPS = [
     ttnn.where,
 ]
 
+TTNN_REDUCTION_OPS = [
+    ttnn.mean,
+    ttnn.prod,
+]
+
 TTNN_MATRIX_MULPIPLICATION_OPS = [
     ttnn.matmul,
     ttnn.linear,
@@ -147,6 +152,7 @@ def is_tt_compute(node) -> bool:
         TTNN_POINTWISE_UNARY_OPS
         + TTNN_POINTWISE_BINARY_OPS
         + TTNN_POINTWISE_TRINARY_OPS
+        + TTNN_REDUCTION_OPS
         + TTNN_MATRIX_MULPIPLICATION_OPS
         + TTNN_TARGET_WRAPPERS
         + TTNN_DATAMOVE_OPS

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -289,6 +289,11 @@ class ReplaceMoreTt(torch.fx.Transformer):
         if target == torch.ops.aten.min.default:
             return self.call_function_prop_meta(ttnn.min, args, kwargs)
 
+        if target == torch.ops.aten.prod.dim_int:
+            # Args: input, all_dimensions=false, dim
+            new_args = (args[0], False, args[1])
+            return self.call_function_prop_meta(ttnn.prod, new_args, kwargs)
+
         ############################################################
         # Data movement
         ############################################################

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -627,10 +627,10 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 input_shape = args[0].meta["val"].size()
                 if len(input_shape) != 4:
                     return None
-                # TODO(TODO): Not support keepdim = False (default value)
+                # TODO(#244): Not support keepdim = False (default value)
                 if len(args) < 3 or args[2] == False:
                     return None
-                # TODO(TODO): Not support non-tile-aligned shape
+                # TODO(#244): Not support non-tile-aligned shape
                 if len(input_shape) < 2 or any(size % ttnn.TILE_SIZE != 0 for size in input_shape[-2:]):
                     return None
                 # Args: input, all_dimensions=false, dim

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -289,11 +289,6 @@ class ReplaceMoreTt(torch.fx.Transformer):
         if target == torch.ops.aten.min.default:
             return self.call_function_prop_meta(ttnn.min, args, kwargs)
 
-        if target == torch.ops.aten.prod.dim_int:
-            # Args: input, all_dimensions=false, dim
-            new_args = (args[0], False, args[1])
-            return self.call_function_prop_meta(ttnn.prod, new_args, kwargs)
-
         ############################################################
         # Data movement
         ############################################################
@@ -627,6 +622,20 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 ):
                     input = g.call_function(ttnn.to_layout, args=(input, TtnnRowMajorLayout()))
                 return g.call_function(ttnn.pad, args=(input, full_pad, value))
+
+            if node.target == torch.ops.aten.prod.dim_int:
+                input_shape = args[0].meta["val"].size()
+                if len(input_shape) != 4:
+                    return None
+                # TODO(TODO): Not support keepdim = False (default value)
+                if len(args) < 3 or args[2] == False:
+                    return None
+                # TODO(TODO): Not support non-tile-aligned shape
+                if len(input_shape) < 2 or any(size % ttnn.TILE_SIZE != 0 for size in input_shape[-2:]):
+                    return None
+                # Args: input, all_dimensions=false, dim
+                new_args = (args[0], False, args[1])
+                return g.call_function(ttnn.prod, new_args, kwargs)
 
         with g.inserting_before(node):
             new_node = rewrite_node(node)


### PR DESCRIPTION
### Ticket
Unsupported cases: #244

### Problem description
Convert `aten.prod.dim_int` to `ttnn.prod`. Unsupported cases are listed in #244 and wil fallback to aten

### What's changed
- Add conversion from `aten.prod.dim_int` to `ttnn.prod`
- Add `ttnn.prod` to data movement pass and refactor a little
- Add test cases
