### PR TITLE
Generate tests/input_variations

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -147,6 +147,47 @@ jobs:
             git push
           fi
 
+  generate-input-variations-tests:
+    needs: model-tests
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_report != 'None'}}
+    runs-on: ["in-service", "n150"]
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/common_repo_setup
+
+      - name: Download All Metrics Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: model-tests-metrics-group-*
+          merge-multiple: true
+          path: metrics/
+      # - name: Download Metrics Artifacts
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      #     GH_REPO: ${{ github.repository }}
+      #   run: |
+      #     mkdir -p metrics
+      #     for i in $(seq 1 40); do
+      #       echo "Downloading metrics for Group $i"
+      #       gh run download ${{ github.run_id }} --name "model-tests-metrics-group-$i" --dir metrics/
+      #       cd metrics
+      #       ls -l
+      #       cd ..
+      #     done
+
+      - name: Generate input variations tests
+        run: |
+          python3 tools/generate_input_variation_test_from_models.py
+
+      - name: Upload variations tests
+        if: success()  # Only run if tests passed
+        uses: actions/upload-artifact@v4
+        with:
+          name: input-variations-tests
+          path: tests/input_variation/
+
   validate-pr:
     if: ${{ always() }}
     runs-on: ubuntu-latest    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,27 @@ import sys
 mb_in_bytes = 1048576
 
 
+def pytest_addoption(parser):
+    parser.addoption("--input_var_only_native", action="store_true")
+    parser.addoption("--input_var_check_ttnn", action="store_true")
+    parser.addoption("--input_var_check_accu", action="store_true")
+
+
+@pytest.fixture(scope="session")
+def input_var_only_native(request):
+    return request.config.getoption("--input_var_only_native")
+
+
+@pytest.fixture(scope="session")
+def input_var_check_ttnn(request):
+    return request.config.getoption("--input_var_check_ttnn")
+
+
+@pytest.fixture(scope="session")
+def input_var_check_accu(request):
+    return request.config.getoption("--input_var_check_accu")
+
+
 @pytest.fixture(scope="session")
 def device():
     device = ttnn.open_device(device_id=0)

--- a/tools/aten_test.tmpl
+++ b/tools/aten_test.tmpl
@@ -1,0 +1,42 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+from tests.utils import calculate_accuracy, get_input_vals_from_metric_str
+
+class AtenModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *args, **kwargs):
+        return torch.ops.{opname}(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "input_strings",
+    {inputs_strings}
+)
+def test_aten(device, input_strings, input_var_only_native, input_var_check_ttnn, input_var_check_accu):
+    m = AtenModule()
+    input_args, input_kwargs = get_input_vals_from_metric_str('{opname}', input_strings)
+    if input_args is None and input_kwargs is None:
+        pytest.skip("Invalid input strings:" + str(input_strings))
+    result_before = m.forward(*input_args, **input_kwargs)
+    if input_var_only_native:
+        return
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    #option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(*input_args, **input_kwargs)
+    #option._out_fx_graphs[0].print_tabular()
+
+    if input_var_check_ttnn:
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        assert any(["ttnn" in str(node) for node in nodes]), "No ttnn ops found in the graph"
+
+    if input_var_check_accu:
+        # Check inference result
+        accuracy = calculate_accuracy(result_before, result_after)
+        assert accuracy >= 0.99

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -1,0 +1,101 @@
+import os
+from pathlib import Path
+from tools.collect_metrics import load_pickle, InputVarPerOp
+
+
+class InputVarTestExporter(InputVarPerOp):
+    def export_tests(self, basedir: Path):
+        # undo _join_br
+        def _unjoin_br(str_br: str):
+            return str_br.split(",<br>")
+
+        sort_by_opname = dict(sorted(self.items()))
+        basedir.mkdir(parents=True, exist_ok=True)
+        for opname, inputs_variations in sort_by_opname.items():
+            inputs_strings = [_unjoin_br(input_variations) for input_variations in inputs_variations.keys()]
+            opname_ = opname.replace(".", "_")
+            filename = f"test_{opname_}.py"
+            text = f"""
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+from tests.utils import calculate_accuracy, get_input_vals_from_metric_str
+
+class AtenModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *args, **kwargs):
+        return torch.ops.{opname}(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "input_strings",
+    {inputs_strings}
+)
+def test_aten(device, input_strings, input_var_only_native, input_var_check_ttnn, input_var_check_accu):
+    m = AtenModule()
+    input_args, input_kwargs = get_input_vals_from_metric_str('{opname}', input_strings)
+    if input_args is None and input_kwargs is None:
+        pytest.skip("Invalid input strings:" + str(input_strings))
+    result_before = m.forward(*input_args, **input_kwargs)
+    if input_var_only_native:
+        return
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    #option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(*input_args, **input_kwargs)
+    #option._out_fx_graphs[0].print_tabular()
+
+    if input_var_check_ttnn:
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        assert any(["ttnn" in str(node) for node in nodes]), "No ttnn ops found in the graph"
+
+    if input_var_check_accu:
+        # Check inference result
+        accuracy = calculate_accuracy(result_before, result_after)
+        assert accuracy >= 0.99
+"""
+            with open(basedir / filename, "w") as f:
+                f.write(text)
+
+
+# Generate input variation tests only contain single op, it will
+#  - check the graph has been rewritten and contain ttnn ops
+#  - check inference result
+if __name__ == "__main__":
+    cumulative_input_vars = InputVarTestExporter()
+
+    # Assumed directory structure example. Some files will not exist if test failed.
+    """
+    pytorch2.0_ttnn
+    ├── metrics
+        ├── BERT
+        │   ├── compiled-run_time_metrics.pickle
+        │   ├── compiled-schema_list.pickle
+        │   ├── original-runtime_metrics.pickle
+        │   └── original-schema_list.pickle
+        └── ResNet18
+            ├── compiled-run_time_metrics.pickle
+            └── compiled-schema_list.pickle
+    """
+    if not os.path.isdir("metrics"):
+        raise ValueError("metrics directory not found. Please run models to generate metrics first.")
+
+    # Support subdirectories
+    all_model_paths = sorted([Path(dirpath) for dirpath, dirnames, filenames in os.walk("metrics") if not dirnames])
+
+    for model_path in all_model_paths:
+        # Remove the "metrics" root directory and convert to string
+        model = str(Path(*model_path.parts[1:]))
+
+        # Only collect input variations from original models
+        original_schema_metrics_path = model_path / "original-schema_list.pickle"
+        original_schema_metrics = load_pickle(original_schema_metrics_path) or {}
+        input_var_per_op = InputVarTestExporter(original_schema_metrics, compiled_schema_metrics={})
+        cumulative_input_vars.merge(input_var_per_op)
+
+    cumulative_input_vars.export_tests(Path("tests/input_variation/"))

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -1,5 +1,8 @@
 import os
 from pathlib import Path
+
+tmp = Path(os.path.abspath(__file__))
+sys.path.append(str(tmp.parent.parent))
 from tools.collect_metrics import load_pickle, InputVarPerOp
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/249
### Problem description
To implement the script of generate input variations test

### What's changed

As the ticket says, it want to make all input varations as tests from [the input variations doc](https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main/docs/cumulative_input_variations.md#atenrepeatdefault)

I study the code of collect-metrics job, seems it use `InputVarPerOp::write_md_for_input_variations` to generate the input variations doc, so I think use `InputVarPerOp` to collect all model metrics, and its recorded input variations will consistent with the input variations doc, so I reuse these data structure of `InputVarPerOp`.

Currently, the test flow of generated input variation test is:

0. convert input variation string as randomized value
1. inference before compiled (native inference)
2. compile with ttnn backend
3. inference after compiled
4. check ttnn op is in compiled graph
5. check accuracy between before/after inference

And as my observation, every stage will have someone who makes a mistake, for example

0. convert input variation string as randomized value
 - for `aten.add.Tensor`, one of its input variation is `['Tensor<[s0 + 1, s0 + 1]> self = ?', 'Tensor<> other = 16']`, which `s0` is unknown from the input variations doc, so cannot randomize input value. These type of case already mark as SKIP

1. inference before compiled (native inference)
Should every test pass this stage, but not
 - for `aten._unsafe_index.Tensor`, one of its input variation is `['Tensor<[1, 64, 15, 20]> self = ?', "List[Optional[Tensor]]<> indices = [None, None, 'torch.Size([30, 1])', 'torch.Size([40])']"]`, and will cause` IndexError: index 30 is out of bounds for dimension 0 with size 15`,  not sure why these illegal input shape appear in the input variations doc

4. check ttnn op is in compiled graph
If the target aten op of this input variation test is not support of conversion to ttnn, then this stage will failed

I'm not sure what the PASS standard of these input variation test is
 - for example, `aten._native_batch_norm_legit_functional.default` will not convert to ttnn op, but it can successfullly inference and pass accuracy, so it should not cause model broken, but should it mark as pass or failed?

So currently I'm not add the input variation test into CI.

But I add the job of "generate" input variation test into CI, it will be triggered after model-tests job, and will make `tests/input_variation/` as downloadable artifacts.

btw, current pytest option of input variation test has:
 - pytest --input_var_check_ttnn: check has ttnn op if enable
 - pytest --input_var_check_accu: check accuracy if enable
 - pytest --input_var_only_native: only inference before compiled if enable

c.c. @cthsieh 