### PR TITLE
Enhance mnist training test.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,25 @@ def compile_and_run(device, reset_torch_dynamo, request):
 
     if "torch_ttnn" in record:
         model, inputs, outputs = record["torch_ttnn"]
+
+        try:
+            # Why `inputs.requires_grad`?
+            #
+            # Backward pass computes gradients for all trainable weight tensors.
+            # However, verifying every gradient can be costly, especially for
+            # large models with many parameters.
+            #
+            # Instead of checking each gradient, we check the gradient
+            # of the "model input" tensor only. Computing the input gradient
+            # serves as an indicator for the health of all other gradients.
+            # Based on the "chain rule", the input gradient depends on all other
+            # gradients, so any incorrect gradient computation should reflect here.
+            is_backward_checked = True if model.training and inputs.requires_grad else False
+        except Exception as e:
+            # Exception to handle unsupported case of multiple model inputs.
+            # Currently, we assume the model has a single input for backward pass checks.
+            is_backward_checked = False
+
         try:
             # Compile model with ttnn backend
             option = torch_ttnn.TorchTtnnOption(
@@ -95,7 +114,41 @@ def compile_and_run(device, reset_torch_dynamo, request):
             m = torch.compile(model, backend=torch_ttnn.backend, options=option)
 
             start = time.perf_counter() * 1000
-            outputs_after = run_model(m, inputs)
+
+            if is_backward_checked:
+                # Reset gradients before each backward pass.
+                #
+                # Gradients are accumulated by default.
+                # Without resetting, two backward passes with the same input values
+                # may yield different gradients, making it impossible to compare against
+                # the expected (golden) results.
+                inputs.grad = None
+                m.zero_grad()
+
+                # Forward pass
+                forward_output = m(inputs)
+
+                # Using `torch.mean` as the loss function for testing purposes.
+                #
+                # Loss functions typically produce a scalar loss, and `torch.mean`
+                # is one valid option in this category. While it may not be the best
+                # choice for training effective models, it simplifies our testing process.
+                #
+                # Since our goal is to verify gradient computation rather than to
+                # train a high-performing model, applying `torch.mean` uniformly
+                # across all models under test eases the testing procedure.
+                loss = torch.mean(forward_output)
+
+                # Backward pass
+                loss.backward()
+
+                # Using the gradient of the model input as the output data for comparison.
+                # This gradient serves as the basis for comparing against the golden values,
+                # helping to verify the correctness of gradient computations during testing.
+                outputs_after = inputs.grad
+            else:
+                outputs_after = run_model(m, inputs)
+
             end = time.perf_counter() * 1000
             comp_runtime_metrics = {"success": True, "run_time": round(end - start, 2)}
             option._out_fx_graphs[0].print_tabular()

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -37,6 +37,14 @@ class MnistModel(torch.nn.Module):
 def test_mnist_train(record_property):
     record_property("model_name", "Mnist (Train)")
 
+    # Fixing the random seed for reproducibility to ease debugging.
+    #
+    # Training processes involve more randomness compared to evaluation,
+    # such as random initialization of weights.
+    # Setting a fixed random seed is crucial for consistent testing
+    # and debugging during the training process.
+    torch.manual_seed(99)
+
     transform = transforms.Compose([transforms.ToTensor()])
 
     train_dataset = datasets.MNIST(root="./data", train=True, transform=transform, download=True)
@@ -46,14 +54,30 @@ def test_mnist_train(record_property):
     m = m.to(torch.bfloat16)
     m.train()
 
-    test_input, target = next(iter(dataloader))
+    # Eliminating randomness from Dropout to ensure consistent results.
+    #
+    # This is necessary for comparing the two training rounds:
+    # one using PyTorch native code and the other using the PyTorch Dynamo TT backend.
+    # Without this, the results would differ, making it impossible to compare the two implementations.
+    for layer in m.modules():
+        if isinstance(layer, nn.Dropout):
+            layer.p = 0  # Set dropout probability to 0
+
+    test_input, _ = next(iter(dataloader))
     test_input = test_input.to(torch.bfloat16)
-    outputs = m(test_input)
 
-    # TODO: Since only one loop of training is done, the outputs could have greater differences.
-    # Consider adding more loops.
+    # Setting input tensor's `requires_grad` attribute to true.
+    #
+    # This allows us to use the gradient of the input as the golden result for the training process.
+    # For further details, refer to the file `conftest.py` regarding the rationale behind.
+    test_input.requires_grad = True
 
-    record_property("torch_ttnn", (m, test_input, outputs))
+    outputs = m(test_input)  # Forward pass
+    loss = torch.mean(outputs)  # Loss function
+    loss.backward()  # Backward pass
+
+    # Again, use the gradient of the input (`test_input.grad`) as the golden result for the training process.
+    record_property("torch_ttnn", (m, test_input, test_input.grad))
 
 
 def test_mnist_eval(record_property):


### PR DESCRIPTION
### Ticket
None

### Problem description
After reviewing `test_mnist.py` as an example of testing the training mode, I noticed that it lacks a test for the backward pass, which calculates the gradients. I've rewritten the test, and if you agree with this change, I plan to apply the same approach to all other training tests.

### What's changed
* The training test in `test_mnist.py`.
* The training process in `conftest.py`.
