### PR TITLE
Allow lowering pass to handle squeeze beyond dim 0

### DIFF
--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -303,11 +303,8 @@ class ReplaceMoreTt(torch.fx.Transformer):
             # assumes output size is (1, 1)
             return self.call_function_prop_meta(ttnn.global_avg_pool2d, (args[0],), kwargs)
 
-        if target == torch.ops.aten.squeeze.dim:
-            # NOTE(kevinwuTT): ttnn.squeeze only supports dim 0 currently
-            if args[1] == 0:
-                return self.call_function_prop_meta(ttnn.squeeze, args, kwargs)
-            return self.call_function_prop_meta(target, args, kwargs)
+        if target == torch.ops.aten.squeeze.dim:            
+            return self.call_function_prop_meta(ttnn.squeeze, args, kwargs)            
 
         return self.call_function_prop_meta(target, args, kwargs)
 


### PR DESCRIPTION
### Ticket
None

### Problem description
aten.squeeze is only converted to ttnn when dim is 0

### What's changed
After ttnn wheel update it should be ok to call it for dim beyond 0
