### PR TITLE
Convert `aten.sum.dim_IntList` to `ttnn.sum`

### DIFF
--- a/tests/lowering/reduction/test_sum.py
+++ b/tests/lowering/reduction/test_sum.py
@@ -1,0 +1,37 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+from tests.utils import assert_with_pcc
+
+
+class SumDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim, keepdim=False):
+        return torch.sum(input, dim, keepdim=keepdim)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [((1, 32, 32), (-1, -2))],
+)
+def test_sum_dim(device, input_shape, dim):
+    m = SumDimModule()
+    input = torch.zeros(input_shape, dtype=torch.bfloat16).uniform_(-1, 1)
+    keepdim = True
+    result_before = m.forward(input, dim, keepdim)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, dim, keepdim)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has been rewritten and contains ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.sum) == 1
+    # Check inference result
+    assert_with_pcc(result_before, result_after)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -163,6 +163,7 @@ def is_tt_compute(node) -> bool:
             ttnn.tril,
             ttnn.arange,
             ttnn.zeros_like,
+            ttnn.sum,
             ttnn.mean,
             ttnn.global_avg_pool2d,
             ttnn.clip,


### PR DESCRIPTION
### Ticket
None

### Problem description
To support `aten.sum.dim_IntList`, we need `ttnn.sum` to support a tuple of dims.  I'm investigating how to patch the kernel.

### What's changed