### PR TITLE
Enable SqueezeBert

### DIFF
--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -5,14 +5,21 @@ import torch
 import pytest
 
 
-@pytest.mark.compilation_xfail
 def test_squeeze_bert(record_property):
     record_property("model_name", "SqueezeBERT")
 
-    tokenizer = AutoTokenizer.from_pretrained("squeezebert/squeezebert-mnli")
-    model = AutoModelForSequenceClassification.from_pretrained("squeezebert/squeezebert-mnli")
+    tokenizer = AutoTokenizer.from_pretrained("squeezebert/squeezebert-mnli", torch_dtype=torch.bfloat16)
+    model = AutoModelForSequenceClassification.from_pretrained("squeezebert/squeezebert-mnli", torch_dtype=torch.bfloat16)
 
-    inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
+    inputs = tokenizer.encode_plus(
+        "Hello, my dog is cute",
+        add_special_tokens=True,
+        return_tensors='pt',
+        max_length=256,
+        padding="max_length",
+        truncation=True,
+    )
+
     with torch.no_grad():
         outputs = model(**inputs)
         logits = outputs.logits

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -9,12 +9,14 @@ def test_squeeze_bert(record_property):
     record_property("model_name", "SqueezeBERT")
 
     tokenizer = AutoTokenizer.from_pretrained("squeezebert/squeezebert-mnli", torch_dtype=torch.bfloat16)
-    model = AutoModelForSequenceClassification.from_pretrained("squeezebert/squeezebert-mnli", torch_dtype=torch.bfloat16)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "squeezebert/squeezebert-mnli", torch_dtype=torch.bfloat16
+    )
 
     inputs = tokenizer.encode_plus(
         "Hello, my dog is cute",
         add_special_tokens=True,
-        return_tensors='pt',
+        return_tensors="pt",
         max_length=256,
         padding="max_length",
         truncation=True,


### PR DESCRIPTION
### Ticket
n/a

### Problem description
SqueezeBert model test is labeled as xfail, it should be enabled.

### What's changed
Tokenization of input to model has changed so that input are padded to 256 and model weights are loaded as bfloat16.
As a result, embedding layer receives inputs that are bfloat16 and multiple of tile size on last dimension ... and the model passes the test.