### PR TITLE
Add fallback for embedding in to_tt_pass

### DIFF
--- a/tests/lowering/embedding/test_embedding.py
+++ b/tests/lowering/embedding/test_embedding.py
@@ -70,3 +70,35 @@ def test_embedding_tile_layout(device, batch_size, sentence_size, vocabulary_siz
     assert [node.target for node in nodes].count(ttnn.embedding) == 1
     # Check inference result
     assert torch.allclose(result_before, result_after)
+
+
+# NOTE(bdrazic) This is unit test for embedding layer from SqueezeBERT. Enable when ttnn.embedding supports any input shape.
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "batch_size, sentence_size, vocabulary_size, hidden_embedding_dim",
+    [
+        (1, 8, 30528, 768),
+    ],
+)
+def test_embedding_squeezebert(device, batch_size, sentence_size, vocabulary_size, hidden_embedding_dim):
+    input = torch.randint(0, vocabulary_size - 1, (batch_size, sentence_size))
+    weights = torch.zeros((vocabulary_size, hidden_embedding_dim), dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+
+    m = EmbeddingModule()
+    result_before = m.forward(input, weights)
+
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, weights)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(
+        ttnn.embedding
+    ) == 1, "Compiled graph does not contain ttnn.embedding; likely torch fallback OP was used instead."
+
+    # Check inference result
+    assert torch.allclose(result_before, result_after)

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -5,12 +5,13 @@ import torch
 import pytest
 
 
-@pytest.mark.compilation_xfail
 def test_squeeze_bert(record_property):
     record_property("model_name", "SqueezeBERT")
 
-    tokenizer = AutoTokenizer.from_pretrained("squeezebert/squeezebert-mnli")
-    model = AutoModelForSequenceClassification.from_pretrained("squeezebert/squeezebert-mnli")
+    tokenizer = AutoTokenizer.from_pretrained("squeezebert/squeezebert-mnli", torch_dtype=torch.bfloat16)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        "squeezebert/squeezebert-mnli", torch_dtype=torch.bfloat16
+    )
 
     inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
     with torch.no_grad():


### PR DESCRIPTION
### Ticket
n/a

### Problem description
ttnn embedding does not support input where the last dimension is not a multiple of TILE_SIZE.

### What's changed
In to_tt_pass use ttnn embedding only if input does have last dim a multiple of TILE_SIZE, otherwise use torch fallback.
