### PR TITLE
Refactor test model

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,24 +83,13 @@ def compile_and_run(device, reset_torch_dynamo, request):
 
     if "torch_ttnn" in record:
         model, inputs, outputs = record["torch_ttnn"]
+        model_tester = None
+        if "model_tester" in record:
+            from tests.utils import ModelTester
 
-        try:
-            # Why `inputs.requires_grad`?
-            #
-            # Backward pass computes gradients for all trainable weight tensors.
-            # However, verifying every gradient can be costly, especially for
-            # large models with many parameters.
-            #
-            # Instead of checking each gradient, we check the gradient
-            # of the "model input" tensor only. Computing the input gradient
-            # serves as an indicator for the health of all other gradients.
-            # Based on the "chain rule", the input gradient depends on all other
-            # gradients, so any incorrect gradient computation should reflect here.
-            is_backward_checked = True if model.training and inputs.requires_grad else False
-        except Exception as e:
-            # Exception to handle unsupported case of multiple model inputs.
-            # Currently, we assume the model has a single input for backward pass checks.
-            is_backward_checked = False
+            model_tester, outputs = record["model_tester"]
+            if not isinstance(model_tester, ModelTester):
+                raise TypeError("model_tester must be instance of ModelTester")
 
         try:
             # Compile model with ttnn backend
@@ -111,42 +100,12 @@ def compile_and_run(device, reset_torch_dynamo, request):
                 metrics_path=model_name,
                 verbose=True,
             )
-            m = torch.compile(model, backend=torch_ttnn.backend, options=option)
-
             start = time.perf_counter() * 1000
 
-            if is_backward_checked:
-                # Reset gradients before each backward pass.
-                #
-                # Gradients are accumulated by default.
-                # Without resetting, two backward passes with the same input values
-                # may yield different gradients, making it impossible to compare against
-                # the expected (golden) results.
-                inputs.grad = None
-                m.zero_grad()
-
-                # Forward pass
-                forward_output = m(inputs)
-
-                # Using `torch.mean` as the loss function for testing purposes.
-                #
-                # Loss functions typically produce a scalar loss, and `torch.mean`
-                # is one valid option in this category. While it may not be the best
-                # choice for training effective models, it simplifies our testing process.
-                #
-                # Since our goal is to verify gradient computation rather than to
-                # train a high-performing model, applying `torch.mean` uniformly
-                # across all models under test eases the testing procedure.
-                loss = torch.mean(forward_output)
-
-                # Backward pass
-                loss.backward()
-
-                # Using the gradient of the model input as the output data for comparison.
-                # This gradient serves as the basis for comparing against the golden values,
-                # helping to verify the correctness of gradient computations during testing.
-                outputs_after = inputs.grad
+            if model_tester:
+                outputs_after = model_tester.test_model(as_ttnn=True, option=option)
             else:
+                m = torch.compile(model, backend=torch_ttnn.backend, options=option)
                 outputs_after = run_model(m, inputs)
 
             end = time.perf_counter() * 1000
@@ -201,8 +160,11 @@ def compile_and_run(device, reset_torch_dynamo, request):
                 torch._dynamo.reset()
                 option.bypass_compile = True
                 option.reset_containers()
-                m = torch.compile(model, backend=torch_ttnn.backend, options=option)
-                run_model(m, inputs)
+                if model_tester:
+                    model_tester.test_model(as_ttnn=True, option=option)
+                else:
+                    m = torch.compile(model, backend=torch_ttnn.backend, options=option)
+                    run_model(m, inputs)
             except Exception as e2:
                 err_msg = f"{model_name} - Torch run with bypass compilation failed. "
                 err_msg += "Please check whether `model` or `model.generate` is passed to `record_property`."

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -5,6 +5,7 @@ from torch.utils.data import DataLoader
 
 import torch.nn as nn
 import torch.nn.functional as F
+from tests.utils import ModelTester
 
 
 # adapted from https://github.com/pytorch/examples/blob/main/mnist/main.py
@@ -34,67 +35,28 @@ class MnistModel(torch.nn.Module):
         return output
 
 
-def test_mnist_train(record_property):
-    record_property("model_name", "Mnist (Train)")
+class MnistTester(ModelTester):
+    def _load_model(self):
+        return MnistModel()
 
-    # Fixing the random seed for reproducibility to ease debugging.
-    #
-    # Training processes involve more randomness compared to evaluation,
-    # such as random initialization of weights.
-    # Setting a fixed random seed is crucial for consistent testing
-    # and debugging during the training process.
-    torch.manual_seed(99)
-
-    transform = transforms.Compose([transforms.ToTensor()])
-
-    train_dataset = datasets.MNIST(root="./data", train=True, transform=transform, download=True)
-    dataloader = DataLoader(train_dataset, batch_size=1)
-
-    m = MnistModel()
-    m = m.to(torch.bfloat16)
-    m.train()
-
-    # Eliminating randomness from Dropout to ensure consistent results.
-    #
-    # This is necessary for comparing the two training rounds:
-    # one using PyTorch native code and the other using the PyTorch Dynamo TT backend.
-    # Without this, the results would differ, making it impossible to compare the two implementations.
-    for layer in m.modules():
-        if isinstance(layer, nn.Dropout):
-            layer.p = 0  # Set dropout probability to 0
-
-    test_input, _ = next(iter(dataloader))
-    test_input = test_input.to(torch.bfloat16)
-
-    # Setting input tensor's `requires_grad` attribute to true.
-    #
-    # This allows us to use the gradient of the input as the golden result for the training process.
-    # For further details, refer to the file `conftest.py` regarding the rationale behind.
-    test_input.requires_grad = True
-
-    outputs = m(test_input)  # Forward pass
-    loss = torch.mean(outputs)  # Loss function
-    loss.backward()  # Backward pass
-
-    # Again, use the gradient of the input (`test_input.grad`) as the golden result for the training process.
-    record_property("torch_ttnn", (m, test_input, test_input.grad))
+    def _load_inputs(self):
+        transform = transforms.Compose([transforms.ToTensor()])
+        test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
+        dataloader = DataLoader(test_dataset, batch_size=1)
+        test_input, _ = next(iter(dataloader))
+        return test_input
 
 
-def test_mnist_eval(record_property):
-    record_property("model_name", "Mnist (Eval)")
+@pytest.mark.parametrize(
+    "mode",
+    ["train", "eval"],
+)
+def test_mnist_train(record_property, mode):
+    model_name = f"Mnist ({mode})"
+    record_property("model_name", model_name)
 
-    transform = transforms.Compose([transforms.ToTensor()])
+    mnist_tester = MnistTester(mode)
+    results = mnist_tester.test_model()
 
-    test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
-    dataloader = DataLoader(test_dataset, batch_size=1)
-
-    m = MnistModel()
-    m = m.to(torch.bfloat16)
-    m.eval()
-
-    test_input, _ = next(iter(dataloader))
-    test_input = test_input.to(torch.bfloat16)
-    with torch.no_grad():
-        outputs = m(test_input)
-
-    record_property("torch_ttnn", (m, test_input, outputs))
+    record_property("torch_ttnn", (None, None, None))
+    record_property("model_tester", (mnist_tester, results))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,150 @@
 import torch
 import numpy as np
+import collections
+
+
+class ModelTester:
+    def __init__(self, mode):
+        if mode not in ["train", "eval"]:
+            raise ValueError(f"Current mode is not supported: {mode}")
+        self.mode = mode
+        self.model = self._load_model()
+        self.inputs = self._load_inputs()
+
+    def _load_model(self):
+        raise NotImplementedError("This method should be implemented in the derived class")
+
+    def _load_inputs(self):
+        raise NotImplementedError("This method should be implemented in the derived class")
+
+    def set_model_train(self, model):
+        model = model.to(torch.bfloat16)
+        model.train()
+        model.zero_grad()
+
+        # Eliminating randomness from Dropout to ensure consistent results.
+        #
+        # This is necessary for comparing the two training rounds:
+        # one using PyTorch native code and the other using the PyTorch Dynamo TT backend.
+        # Without this, the results would differ, making it impossible to compare the two implementations.
+        for layer in model.modules():
+            if isinstance(layer, torch.nn.Dropout):
+                layer.p = 0  # Set dropout probability to 0
+        return model
+
+    def set_model_eval(self, model):
+        model = model.to(torch.bfloat16)
+        model.eval()
+        return model
+
+    def set_inputs_train(self, inputs):
+        if type(inputs) == torch.Tensor:
+            inputs = inputs.to(torch.bfloat16)
+            # Setting input tensor's `requires_grad` attribute to true.
+            #
+            # This allows us to use the gradient of the input as the golden result for the training process.
+            # For further details, refer to the file `conftest.py` regarding the rationale behind.
+            inputs.requires_grad_(True)
+        else:
+            raise ValueError(f"Current inputs type is not supported: {type(inputs)}")
+        return inputs
+
+    def set_inputs_eval(self, inputs):
+        if type(inputs) == torch.Tensor:
+            inputs = inputs.to(torch.bfloat16)
+        else:
+            raise ValueError(f"Current inputs type is not supported: {type(inputs)}")
+        return inputs
+
+    def compile_model(self, model, option):
+        import torch_ttnn
+
+        # Compile model with ttnn backend
+        model = torch.compile(model, backend=torch_ttnn.backend, options=option)
+        return model
+
+    def run_model(self, model, inputs):
+        if isinstance(inputs, collections.Mapping):
+            return model(**inputs)
+        elif isinstance(inputs, collections.Sequence):
+            return model(*inputs)
+        else:
+            return model(inputs)
+
+    def append_fake_loss_function(self, outputs):
+        # Using `torch.mean` as the loss function for testing purposes.
+        #
+        # Loss functions typically produce a scalar loss, and `torch.mean`
+        # is one valid option in this category. While it may not be the best
+        # choice for training effective models, it simplifies our testing process.
+        #
+        # Since our goal is to verify gradient computation rather than to
+        # train a high-performing model, applying `torch.mean` uniformly
+        # across all models under test eases the testing procedure.
+        if str(type(outputs)) in ["<class 'torch.Tensor'>", "<class 'core.TorchTensor'>"]:
+            return torch.mean(outputs)
+        else:
+            raise ValueError(f"Current outputs type is not supported: {type(outputs)}")
+
+    def get_results_train(self, inputs):
+        # Why `inputs.requires_grad`?
+        #
+        # Backward pass computes gradients for all trainable weight tensors.
+        # However, verifying every gradient can be costly, especially for
+        # large models with many parameters.
+        #
+        # Instead of checking each gradient, we check the gradient
+        # of the "model input" tensor only. Computing the input gradient
+        # serves as an indicator for the health of all other gradients.
+        # Based on the "chain rule", the input gradient depends on all other
+        # gradients, so any incorrect gradient computation should reflect here.
+        if type(inputs) == torch.Tensor:
+            results = inputs.grad
+        elif type(inputs) == dict:
+            results = {k: v.grad for k, v in inputs.items()}
+        else:
+            raise ValueError(f"Current inputs type is not supported: {type(inputs)}")
+        return results
+
+    def get_results_eval(self, outputs):
+        return outputs
+
+    def test_model_train(self, as_ttnn=False, option=None):
+        # Fixing the random seed for reproducibility to ease debugging.
+        #
+        # Training processes involve more randomness compared to evaluation,
+        # such as random initialization of weights.
+        # Setting a fixed random seed is crucial for consistent testing
+        # and debugging during the training process.
+        torch.manual_seed(99)
+        model = self.set_model_train(self.model)
+        inputs = self.set_inputs_train(self.inputs)
+        if as_ttnn == True:
+            model = self.compile_model(model, option)
+        outputs = self.run_model(model, inputs)
+        loss = self.append_fake_loss_function(outputs)
+        loss.backward()
+        # Again, use the gradient of the input (`test_input.grad`) as the golden result for the training process.
+        results = self.get_results_train(inputs)
+        return results
+
+    @torch.no_grad()
+    def test_model_eval(self, as_ttnn=False, option=None):
+        model = self.set_model_eval(self.model)
+        inputs = self.set_inputs_eval(self.inputs)
+        if as_ttnn == True:
+            model = self.compile_model(model, option)
+        outputs = self.run_model(model, inputs)
+        results = self.get_results_eval(outputs)
+        return results
+
+    def test_model(self, as_ttnn=False, option=None):
+        if self.mode == "train":
+            return self.test_model_train(as_ttnn, option)
+        elif self.mode == "eval":
+            return self.test_model_eval(as_ttnn, option)
+        else:
+            raise ValueError(f"Current mode is not supported: {self.mode}")
 
 
 # Testing utils copied from tt-metal/tests/ttnn/utils_for_testing.py


### PR DESCRIPTION
### Ticket
#269

### Problem description
The `compile_and_run` fixture will run model with torch_ttnn backend if set torch_ttnn property, but for the training mode it needs to append fake loss function and do the backward, which may differ from models, so needs a method to deal this part.

### What's changed
Implement `ModelTester` class, which handle the `test_model` method, and which do the forward for eval mode and do both forward & backward for training mode, and do the compilation if true the `as_ttnn` arg.`test_model` method also handle the model & input adjustment from different mode.

After this refactor, the testcase under `tests/models` should inherit `ModelTester` class and implement the `_load_model` & `_load_input` method. If other method like `append_fake_loss_function` is not appropriate for current test, can also override it.

So the the testcase under `tests/models` can just use the inherited `ModelTester.test_model()` to run the forward(& backward), and the `compile_and_run` can call it, too.

I want to change the usage from `record_property("torch_ttnn", (model, input, output)` to `record_property("torch_ttnn", (model_test, model_test.test_model()))`, but this change will impact all the `tests/model/` testcase, and I just want to change it all after this PR(i.e. agree usage changed by this refactor) merged, so currently I just adapt `ModelTester` with `tests/models/mnist/mnist.py` and keep the old usage work(so I will remove the old record_property usage after all `tests/model/` adapt the `ModelTester` class)


