### PR TITLE
Remove xfail from Clip model

### DIFF
--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -44,7 +44,6 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.compilation_xfail
 def test_clip(record_property, mode):
     model_name = "CLIP"
     record_property("model_name", f"{model_name} {mode}")

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -22,6 +22,7 @@ class ThisTester(ModelTester):
             return_tensors="pt",
             padding=True,
         )
+        inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
         return inputs
 
     def set_inputs_train(self, inputs):
@@ -42,7 +43,13 @@ class ThisTester(ModelTester):
 
 @pytest.mark.parametrize(
     "mode",
-    ["train", "eval"],
+    [
+        pytest.param(
+            "train",
+            marks=pytest.mark.compilation_xfail,
+        ),
+        "eval",
+    ],
 )
 def test_clip(record_property, mode):
     model_name = "CLIP"

--- a/tools/aten_test.tmpl
+++ b/tools/aten_test.tmpl
@@ -63,15 +63,22 @@ def test_aten(device, input_strings, input_var_only_native, input_var_check_accu
             print(f"Failed to run. Raised exception: {e}")
 
     if metric["run"] == True:
-        # Check inference result
-        accuracy = calculate_accuracy(result_before, result_after)
-        if accuracy >= 0.99:
-            metric["accuracy"] = True
+        try:
+            # Check inference result
+            accuracy = calculate_accuracy(result_before, result_after)
+            if accuracy >= 0.99:
+                metric["accuracy"] = True
+        except Exception as e:
+            print(f"Failed to check inference result. Raised exception: {e}")
 
-        # Check the graph has be rewritten and contain ttnn ops
-        nodes = list(option._out_fx_graphs[0].nodes)
-        if any(["ttnn" in str(node) for node in nodes]):
-            metric["convert_to_ttnn"] = True
+        try:
+            # Check the graph has be rewritten and contain ttnn ops
+            nodes = list(option._out_fx_graphs[0].nodes)
+            if any(["ttnn" in str(node) for node in nodes]):
+                metric["convert_to_ttnn"] = True
+        except Exception as e:
+            print(f"Failed to check the graph has ttnn op. Raised exception: {e}")
+
 
     metrics.append(metric)
 

--- a/torch_ttnn/metrics.py
+++ b/torch_ttnn/metrics.py
@@ -40,7 +40,8 @@ class Inputs:
     def __init__(self, dtype, name, shape, value):
         self.dtype = dtype
         self.name = name
-        self.shape = shape
+        self.shape_ = shape
+        self.value_ = value
 
         self.shape = f"<{_get_shape_from_fake_tensor(shape)}>" if shape is not None else ""
         self.value = f"{str(_sanitize_value(value))}" if value is not None else "?"

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -1,0 +1,126 @@
+import torch
+import torch_ttnn.metrics as metrics
+
+
+def get_inputs(node):
+    node_inputs = metrics.collect_input_variation_from_node(node)
+    if type(node_inputs) == metrics.InputVariation:
+        return node_inputs.inputs
+    elif type(node_inputs) == metrics.ConvertedInput:
+        return node_inputs.original_input_variation.inputs
+    else:
+        return None
+
+
+def aten_exp_default(node):
+    inputs = get_inputs(node)
+    size_len = len(inputs[0].shape_.size())
+    # ttnn seems not accept scalar now
+    if size_len == 0:
+        return False
+    return True
+
+
+def aten_expand_default(node):
+    # TODO: find root cause
+    blacklist = [[[768], [1, 1, -1]], [[1, 1, 7, 7], [2, 1, 7, 7]], [[2, 1, 1, 7], [2, 1, 7, 7]]]
+    inputs = get_inputs(node)
+    self_shape = list(inputs[0].shape_.size())
+    size = inputs[1].value_
+    if [self_shape, size] in blacklist:
+        return False
+    return True
+
+
+def aten_full_default(node):
+    # For valid non-interleaved buffers page size 2048 must equal buffer size 96.
+    # For interleaved-buffers page size should be divisible by buffer size
+    # TODO: find root cause
+    blacklist = [[7, 7]]
+    inputs = get_inputs(node)
+    size = inputs[0].value_
+    if size in blacklist:
+        return False
+    return True
+
+
+def aten_mul_tensor(node):
+    inputs = get_inputs(node)
+    # ttnn seems not accept scalar now
+    try:
+        size0_len = len(inputs[0].shape_.size())
+        if size0_len == 0:
+            return False
+    except:
+        pass
+    try:
+        size1_len = len(inputs[1].shape_.size())
+        if size1_len == 0:
+            return False
+    except:
+        pass
+    return True
+
+
+def aten_rsub_scalar(node):
+    # TODO: find root cause
+    blacklist = [[2, 1, 7, 7]]
+    inputs = get_inputs(node)
+    shape = list(inputs[0].shape_.size())
+    if shape in blacklist:
+        return False
+    return True
+
+
+def aten_slice_tensor(node):
+    # TODO: find root cause
+    blacklist = [[[1, 77], 1]]
+    inputs = get_inputs(node)
+    # ttnn seems not accept scalar now
+    shape = list(inputs[0].shape_.size())
+    dim = inputs[1].value_
+    if [shape, dim] in blacklist:
+        return False
+    return True
+
+
+def aten_t_default(node):
+    # TODO: find root cause
+    blacklist = [[2, 1]]
+    inputs = get_inputs(node)
+    shape = list(inputs[0].shape_.size())
+    if shape in blacklist:
+        return False
+    return True
+
+
+def aten_transpose_int(node):
+    # TODO: find root cause
+    blacklist = [[[1, 768, 49], 1, 2]]
+    inputs = get_inputs(node)
+    # ttnn seems not accept scalar now
+    shape = list(inputs[0].shape_.size())
+    dim0 = inputs[1].value_
+    dim1 = inputs[2].value_
+    if [shape, dim0, dim1] in blacklist:
+        return False
+    return True
+
+
+OPLIST = {
+    torch.ops.aten.exp.default: aten_exp_default,
+    torch.ops.aten.expand.default: aten_expand_default,
+    torch.ops.aten.full.default: aten_full_default,
+    torch.ops.aten.mul.Tensor: aten_mul_tensor,
+    torch.ops.aten.rsub.Scalar: aten_rsub_scalar,
+    torch.ops.aten.slice.Tensor: aten_slice_tensor,
+    torch.ops.aten.t.default: aten_t_default,
+    torch.ops.aten.transpose.int: aten_transpose_int,
+}
+
+
+def can_lowering_to_ttnn(node):
+    if node.target in OPLIST:
+        return OPLIST[node.target](node)
+
+    return True

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -74,7 +74,7 @@ def aten_rsub_scalar(node):
 
 def aten_slice_tensor(node):
     # TODO: find root cause
-    blacklist = [[[1, 77], 1]]
+    blacklist = [[[1, 77], 1], [[1, 50, 768], 1]]
     inputs = get_inputs(node)
     # ttnn seems not accept scalar now
     shape = list(inputs[0].shape_.size())
@@ -86,7 +86,7 @@ def aten_slice_tensor(node):
 
 def aten_t_default(node):
     # TODO: find root cause
-    blacklist = [[2, 1]]
+    blacklist = [[2, 1], [512, 1]]
     inputs = get_inputs(node)
     shape = list(inputs[0].shape_.size())
     if shape in blacklist:
@@ -96,7 +96,7 @@ def aten_t_default(node):
 
 def aten_transpose_int(node):
     # TODO: find root cause
-    blacklist = [[[1, 768, 49], 1, 2]]
+    blacklist = [[[1, 768, 49], 1, 2], [[1, 49, 768], 1, 2], [[16, 64, 7], 1, 2], [[16, 7, 7], 1, 2]]
     inputs = get_inputs(node)
     # ttnn seems not accept scalar now
     shape = list(inputs[0].shape_.size())
@@ -107,15 +107,199 @@ def aten_transpose_int(node):
     return True
 
 
+def aten__softmax_default(node):
+    # TODO: find root cause
+    blacklist = [
+        ["Tensor<[12, 50, 50]> self = ?", "int dim = -1", "bool half_to_float = False"],
+        ["Tensor<[16, 7, 7]> self = ?", "int dim = -1", "bool half_to_float = False"],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
+def aten__unsafe_view_default(node):
+    # TODO: find root cause
+    blacklist = [
+        ["Tensor<[1, 50, 12, 64]> self = ?", "List[int] size = [1, 50, 768]"],
+        ["Tensor<[2, 7, 8, 64]> self = ?", "List[int] size = [2, 7, 512]"],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
+def aten_view_default(node):
+    # TODO: find root cause
+    blacklist = [
+        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, -1, 12, 64]"],
+        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, 50, 12, 64]"],
+        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, -1, 8, 64]"],
+        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, 7, 8, 64]"],
+        ["Tensor<[1, 50, 12, 64]> self = ?", "List[int] size = [1, 50, 768]"],
+        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, -1, 12, 64]"],
+        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, 50, 12, 64]"],
+        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, -1, 8, 64]"],
+        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, 7, 8, 64]"],
+        ["Tensor<[2, 7, 8, 64]> self = ?", "List[int] size = [2, 7, 512]"],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
+def aten_embedding_dense_backward_default(node):
+    # TODO: find root cause
+    blacklist = [
+        [
+            "Tensor<[1, 7, 512]> grad_output = ?",
+            "Tensor<[1, 7]> indices = ?",
+            "int num_weights = 77",
+            "int padding_idx = -1",
+            "bool scale_grad_by_freq = False",
+        ],
+        [
+            "Tensor<[2, 7, 512]> grad_output = ?",
+            "Tensor<[2, 7]> indices = ?",
+            "int num_weights = 49408",
+            "int padding_idx = -1",
+            "bool scale_grad_by_freq = False",
+        ],
+        [
+            "Tensor<[1, 50, 768]> grad_output = ?",
+            "Tensor<[1, 50]> indices = ?",
+            "int num_weights = 50",
+            "int padding_idx = -1",
+            "bool scale_grad_by_freq = False",
+        ],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
+def blocked_aten_mul_tensor(node):
+    # TODO: block all input variations from CLIP eval, find root cause
+    blacklist = [
+        ["Tensor<[1, 50, 768]> self = ?", "Tensor other = 0.125"],
+        ["Tensor<[1, 50, 3072]> self = ?", "Tensor other = 1.702"],
+        ["Tensor<[1, 50, 3072]> self = ?", "Tensor<[1, 50, 3072]> other = ?"],
+        ["Tensor<[2, 7, 512]> self = ?", "Tensor other = 0.125"],
+        ["Tensor<[2, 7, 2048]> self = ?", "Tensor other = 1.702"],
+        ["Tensor<[2, 7, 2048]> self = ?", "Tensor<[2, 7, 2048]> other = ?"],
+        ["Tensor<[2, 1]> self = ?", "Tensor<[]> other = ?"],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
+def blocked_aten_view_default(node):
+    # TODO: block all input variations from CLIP eval, find root cause
+    blacklist = [
+        ["Tensor<[1, 768, 7, 7]> self = ?", "List[int] size = [1, 768, 49]"],
+        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [50, 768]"],
+        ["Tensor<[50, 768]> self = ?", "List[int] size = [1, 50, 768]"],
+        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, -1, 12, 64]"],
+        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, 50, 12, 64]"],
+        ["Tensor<[1, 12, 50, 64]> self = ?", "List[int] size = [12, -1, 64]"],
+        ["Tensor<[12, 50, 64]> self = ?", "List[int] size = [1, 12, 50, 64]"],
+        ["Tensor<[50, 3072]> self = ?", "List[int] size = [1, 50, 3072]"],
+        ["Tensor<[1, 50, 3072]> self = ?", "List[int] size = [50, 3072]"],
+        ["Tensor<[2, 7]> self = ?", "List[int] size = [-1, 7]"],
+        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [14, 512]"],
+        ["Tensor<[14, 512]> self = ?", "List[int] size = [2, 7, 512]"],
+        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, -1, 8, 64]"],
+        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, 7, 8, 64]"],
+        ["Tensor<[2, 8, 7, 64]> self = ?", "List[int] size = [16, -1, 64]"],
+        ["Tensor<[16, 7, 7]> self = ?", "List[int] size = [2, 8, 7, 7]"],
+        ["Tensor<[2, 8, 7, 7]> self = ?", "List[int] size = [16, 7, 7]"],
+        ["Tensor<[16, 7, 64]> self = ?", "List[int] size = [2, 8, 7, 64]"],
+        ["Tensor<[14, 2048]> self = ?", "List[int] size = [2, 7, 2048]"],
+        ["Tensor<[2, 7, 2048]> self = ?", "List[int] size = [14, 2048]"],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
+def blocked_aten__to_copy_default(node):
+    # TODO: block all input variations from CLIP eval, find root cause
+    blacklist = [
+        ["Tensor<[1, 3, 224, 224]> self = ?", "Optional[int] dtype = torch.bfloat16"],
+        ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
+        ["Tensor<[2, 1, 7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
+        ["Tensor<[2, 1, 7, 7]> self = ?", "Optional[int] dtype = torch.bool"],
+        ["Tensor<[2, 7]> self = ?", "Optional[int] dtype = torch.int32", "Optional[Device] device = cpu"],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
+def blocked_aten_native_layer_norm_default(node):
+    # TODO: block all input variations from CLIP eval, find root cause
+    blacklist = [
+        [
+            "Tensor<[1, 50, 768]> input = ?",
+            "List[int] normalized_shape = [768]",
+            "Optional[Tensor]<[768]> weight = ?",
+            "Optional[Tensor]<[768]> bias = ?",
+            "float eps = 1e-05",
+        ],
+        [
+            "Tensor<[1, 768]> input = ?",
+            "List[int] normalized_shape = [768]",
+            "Optional[Tensor]<[768]> weight = ?",
+            "Optional[Tensor]<[768]> bias = ?",
+            "float eps = 1e-05",
+        ],
+        [
+            "Tensor<[2, 7, 512]> input = ?",
+            "List[int] normalized_shape = [512]",
+            "Optional[Tensor]<[512]> weight = ?",
+            "Optional[Tensor]<[512]> bias = ?",
+            "float eps = 1e-05",
+        ],
+    ]
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blacklist:
+        return False
+    return True
+
+
 OPLIST = {
     torch.ops.aten.exp.default: aten_exp_default,
     torch.ops.aten.expand.default: aten_expand_default,
     torch.ops.aten.full.default: aten_full_default,
-    torch.ops.aten.mul.Tensor: aten_mul_tensor,
     torch.ops.aten.rsub.Scalar: aten_rsub_scalar,
     torch.ops.aten.slice.Tensor: aten_slice_tensor,
     torch.ops.aten.t.default: aten_t_default,
     torch.ops.aten.transpose.int: aten_transpose_int,
+    torch.ops.aten._softmax.default: aten__softmax_default,
+    torch.ops.aten._unsafe_view.default: aten__unsafe_view_default,
+    # TODO: With CLIP model of eval mode, these four ops are passed in single op tests
+    # but failed in model tests, and because don't know which input variation caused the model
+    # failed, so block all input variations of these ops
+    torch.ops.aten.mul.Tensor: blocked_aten_mul_tensor,
+    torch.ops.aten.view.default: blocked_aten_view_default,
+    torch.ops.aten._to_copy.default: blocked_aten__to_copy_default,
+    torch.ops.aten.native_layer_norm.default: blocked_aten_native_layer_norm_default,
 }
 
 


### PR DESCRIPTION
### Ticket
#302

### Problem description
Let `test_clip.py` pass

### What's changed
  - Add `torch_ttnn/passes/lowering/to_tt_guard.py` to check if node can lowering to ttnn op by its input shape
  - Based on `tests/input-variations/CLIP/`, write the guard function
  - remove `pytest.mark.compilation_xfail` from `test_clip.py`

Before this PR, the status of single op test is
```
tests/input-variations/CLIP/test_aten__softmax_default.py ..                                               [  1%]
tests/input-variations/CLIP/test_aten__to_copy_default.py .....                                            [  6%]
tests/input-variations/CLIP/test_aten__unsafe_view_default.py ..                                           [  8%]
tests/input-variations/CLIP/test_aten_add_Tensor.py ....                                                   [ 11%]
tests/input-variations/CLIP/test_aten_addmm_default.py ......                                              [ 16%]
tests/input-variations/CLIP/test_aten_arange_default.py .                                                  [ 17%]
tests/input-variations/CLIP/test_aten_argmax_default.py .                                                  [ 18%]
tests/input-variations/CLIP/test_aten_bmm_default.py ....                                                  [ 22%]
tests/input-variations/CLIP/test_aten_cat_default.py s                                                     [ 23%]
tests/input-variations/CLIP/test_aten_clone_default.py ......                                              [ 28%]
tests/input-variations/CLIP/test_aten_convolution_default.py .                                             [ 29%]
tests/input-variations/CLIP/test_aten_div_Tensor.py ..                                                     [ 31%]
tests/input-variations/CLIP/test_aten_embedding_default.py ...                                             [ 33%]
tests/input-variations/CLIP/test_aten_exp_default.py F                                                     [ 34%]
tests/input-variations/CLIP/test_aten_expand_default.py FFF                                                [ 37%]
tests/input-variations/CLIP/test_aten_full_default.py F                                                    [ 38%]
tests/input-variations/CLIP/test_aten_index_Tensor.py s                                                    [ 39%]
tests/input-variations/CLIP/test_aten_linalg_vector_norm_default.py ..                                     [ 41%]
tests/input-variations/CLIP/test_aten_masked_fill_Scalar.py .                                              [ 41%]
tests/input-variations/CLIP/test_aten_mm_default.py ...                                                    [ 44%]
tests/input-variations/CLIP/test_aten_mul_Tensor.py ......F                                                [ 50%]
tests/input-variations/CLIP/test_aten_native_layer_norm_default.py FFF                                     [ 53%]
tests/input-variations/CLIP/test_aten_rsub_Scalar.py F                                                     [ 54%]
tests/input-variations/CLIP/test_aten_select_int.py .                                                      [ 55%]
tests/input-variations/CLIP/test_aten_sigmoid_default.py ..                                                [ 57%]
tests/input-variations/CLIP/test_aten_slice_Tensor.py ...F....                                             [ 64%]
tests/input-variations/CLIP/test_aten_t_default.py ........F                                               [ 72%]
tests/input-variations/CLIP/test_aten_transpose_int.py F......                                             [ 78%]
tests/input-variations/CLIP/test_aten_unsqueeze_default.py ....                                            [ 82%]
tests/input-variations/CLIP/test_aten_view_default.py ....................                                 [100%]
```
After this PR, the status of single op test is
```
tests/input-variations/CLIP/test_aten__softmax_default.py ..                                               [  1%]
tests/input-variations/CLIP/test_aten__to_copy_default.py .....                                            [  6%]
tests/input-variations/CLIP/test_aten__unsafe_view_default.py ..                                           [  8%]
tests/input-variations/CLIP/test_aten_add_Tensor.py ....                                                   [ 11%]
tests/input-variations/CLIP/test_aten_addmm_default.py ......                                              [ 16%]
tests/input-variations/CLIP/test_aten_arange_default.py .                                                  [ 17%]
tests/input-variations/CLIP/test_aten_argmax_default.py .                                                  [ 18%]
tests/input-variations/CLIP/test_aten_bmm_default.py ....                                                  [ 22%]
tests/input-variations/CLIP/test_aten_cat_default.py s                                                     [ 23%]
tests/input-variations/CLIP/test_aten_clone_default.py ......                                              [ 28%]
tests/input-variations/CLIP/test_aten_convolution_default.py .                                             [ 29%]
tests/input-variations/CLIP/test_aten_div_Tensor.py ..                                                     [ 31%]
tests/input-variations/CLIP/test_aten_embedding_default.py ...                                             [ 33%]
tests/input-variations/CLIP/test_aten_exp_default.py .                                                     [ 34%]
tests/input-variations/CLIP/test_aten_expand_default.py ...                                                [ 37%]
tests/input-variations/CLIP/test_aten_full_default.py .                                                    [ 38%]
tests/input-variations/CLIP/test_aten_index_Tensor.py s                                                    [ 39%]
tests/input-variations/CLIP/test_aten_linalg_vector_norm_default.py ..                                     [ 41%]
tests/input-variations/CLIP/test_aten_masked_fill_Scalar.py .                                              [ 41%]
tests/input-variations/CLIP/test_aten_mm_default.py ...                                                    [ 44%]
tests/input-variations/CLIP/test_aten_mul_Tensor.py .......                                                [ 50%]
tests/input-variations/CLIP_eval/test_aten_native_layer_norm_default.py ...                                [ 53%]
tests/input-variations/CLIP/test_aten_rsub_Scalar.py .                                                     [ 54%]
tests/input-variations/CLIP/test_aten_select_int.py .                                                      [ 55%]
tests/input-variations/CLIP/test_aten_sigmoid_default.py ..                                                [ 57%]
tests/input-variations/CLIP/test_aten_slice_Tensor.py ........                                             [ 64%]
tests/input-variations/CLIP/test_aten_t_default.py .........                                               [ 72%]
tests/input-variations/CLIP/test_aten_transpose_int.py .......                                             [ 78%]
tests/input-variations/CLIP/test_aten_unsqueeze_default.py ....                                            [ 82%]
tests/input-variations/CLIP/test_aten_view_default.py ....................                                 [100%]
```

needs to merge #300 first