### PR TITLE
TM Lowering Group B

### DIFF
--- a/tests/lowering/tensor_manipulation/test_permute.py
+++ b/tests/lowering/tensor_manipulation/test_permute.py
@@ -22,45 +22,148 @@ def test_permute(device, input_shapes):
     m = PermuteModule()
     inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
     order = (1, 0)
-    result_before = m.forward(*inputs, order)
+    torch_result = m.forward(*inputs, order)
     option = torch_ttnn.TorchTtnnOption(device=device)
     option.gen_graphviz = True
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    result_after = m.forward(*inputs, order)
+    ttnn_result = m.forward(*inputs, order)
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.permute) == 1
     # Check shape or result
-    assert result_before.size() == result_after.size()
+    assert torch_result.size() == ttnn_result.size()
     # Check inference result
-    assert torch.allclose(result_before, result_after)
+    assert torch.allclose(torch_result, ttnn_result)
 
 
 # This tests tests the workaround for issue https://github.com/tenstorrent/tt-metal/issues/11191
 @pytest.mark.parametrize(
-    "input_shapes",
+    "input_shape, permute_order",
     [
-        [(5, 1, 2)],
+        (
+            (5, 1, 2),
+            (1, 0, 2),
+        ),
+        (
+            (1, 1024, 160),
+            (0, 2, 1),
+        ),
+        (
+            (1, 1024, 196),
+            (0, 2, 1),
+        ),
+        (
+            (1, 1024, 256),
+            (0, 2, 1),
+        ),
+        pytest.param(
+            (1, 1024, 49),
+            (0, 2, 1),
+            marks=pytest.mark.xfail(
+                reason="Page size must be divisible by sizeof(uint32_t) because buffers hold uint32_t values"
+            ),
+        ),
+        (
+            (1, 1200, 320),
+            (0, 2, 1),
+        ),
+        (
+            (1, 128, 300),
+            (0, 2, 1),
+        ),
+        pytest.param(
+            (1, 1280, 1369),
+            (0, 2, 1),
+            marks=pytest.mark.xfail(
+                reason="Page size must be divisible by sizeof(uint32_t) because buffers hold uint32_t values"
+            ),
+        ),
+        (
+            (1, 160, 256),
+            (0, 2, 1),
+        ),
+        (
+            (1, 16384, 256),
+            (0, 2, 1),
+        ),
+        (
+            (1, 16384, 32),
+            (0, 2, 1),
+        ),
+        (
+            (1, 19200, 64),
+            (0, 2, 1),
+        ),
+        (
+            (1, 256, 256),
+            (0, 2, 1),
+        ),
+        (
+            (1, 256, 512),
+            (0, 2, 1),
+        ),
+        (
+            (1, 32, 256),
+            (0, 2, 1),
+        ),
+        (
+            (1, 320, 300),
+            (0, 2, 1),
+        ),
+        (
+            (1, 4096, 256),
+            (0, 2, 1),
+        ),
+        (
+            (1, 4096, 64),
+            (0, 2, 1),
+        ),
+        (
+            (1, 4800, 128),
+            (0, 2, 1),
+        ),
+        (
+            (1, 64, 256),
+            (0, 2, 1),
+        ),
+        (
+            (1, 64, 300),
+            (0, 2, 1),
+        ),
+        (
+            (1, 768, 1500),
+            (0, 2, 1),
+        ),
+        (
+            (1, 768, 196),
+            (0, 2, 1),
+        ),
+        pytest.param(
+            (1, 768, 49),
+            (0, 2, 1),
+            marks=pytest.mark.xfail(
+                reason="Page size must be divisible by sizeof(uint32_t) because buffers hold uint32_t values"
+            ),
+        ),
     ],
 )
-def test_permute_missing_dim(device, input_shapes):
+def test_permute_missing_dim(device, input_shape, permute_order):
     m = PermuteModule()
-    inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
-    order = (1, 0, 2)
-    result_before = m.forward(*inputs, order)
+    inputs = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_result = m.forward(inputs, permute_order)
     option = torch_ttnn.TorchTtnnOption(device=device)
     option.gen_graphviz = True
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    result_after = m.forward(*inputs, order)
+    ttnn_result = m.forward(inputs, permute_order)
     option._out_fx_graphs[0].print_tabular()
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.permute) == 1
     # Check shape or result
-    assert result_before.size() == result_after.size()
+    assert torch_result.size() == ttnn_result.size()
     # Check inference result
-    assert torch.allclose(result_before, result_after)
+    assert torch.allclose(torch_result, ttnn_result)

--- a/tests/lowering/tensor_manipulation/test_permute.py
+++ b/tests/lowering/tensor_manipulation/test_permute.py
@@ -33,5 +33,34 @@ def test_permute(device, input_shapes):
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.permute) == 1
+    # Check shape or result
+    assert result_before.size() == result_after.size()
+    # Check inference result
+    assert torch.allclose(result_before, result_after)
+
+
+# This tests tests the workaround for issue https://github.com/tenstorrent/tt-metal/issues/11191
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        [(5, 1, 2)],
+    ],
+)
+def test_permute_missing_dim(device, input_shapes):
+    m = PermuteModule()
+    inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+    order = (1, 0, 2)
+    result_before = m.forward(*inputs, order)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(*inputs, order)
+    option._out_fx_graphs[0].print_tabular()
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.permute) == 1
+    # Check shape or result
+    assert result_before.size() == result_after.size()
     # Check inference result
     assert torch.allclose(result_before, result_after)

--- a/tests/lowering/tensor_manipulation/test_transpose.py
+++ b/tests/lowering/tensor_manipulation/test_transpose.py
@@ -26,16 +26,16 @@ class TransposeModule(torch.nn.Module):
 def test_transpose(device, input_shape, dim0, dim1):
     m = TransposeModule()
     input = torch.rand(input_shape, dtype=torch.bfloat16)
-    result_before = m.forward(input, dim0, dim1)
+    torch_result = m.forward(input, dim0, dim1)
     option = torch_ttnn.TorchTtnnOption(device=device)
     option.gen_graphviz = True
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    result_after = m.forward(input, dim0, dim1)
+    ttnn_result = m.forward(input, dim0, dim1)
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     [node.target for node in nodes].count(ttnn.permute) == 1
     # Check inference result
-    assert_with_pcc(result_before, result_after)
+    assert_with_pcc(torch_result, ttnn_result)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -55,6 +55,21 @@ def create_call_function(transformer, target, args, kwargs):
     transformer.call_function(target, args, kwargs)
 
 
+# Workaround for issue https://github.com/tenstorrent/tt-metal/issues/11191
+def workaround_permute_3d_first_out_dim_is_one(g, new_nodes, rank, output_size):
+    if rank == 3 and output_size[0] == 1:
+        if output_size[1] % 32 or output_size[2] % 32:
+            new_nodes.append(
+                g.call_function(
+                    ttnn.to_layout,
+                    (new_nodes[-1],),
+                    {"layout": TtnnRowMajorLayout()},
+                )
+            )
+        new_nodes.append(g.call_function(ttnn.reshape, args=(new_nodes[-1], output_size)))
+    return new_nodes
+
+
 class ReplaceMoreTt(torch.fx.Transformer):
     def __init__(self, module, device):
         super().__init__(module)
@@ -294,12 +309,6 @@ class ReplaceMoreTt(torch.fx.Transformer):
 
         if target == torch.ops.aten.min.default:
             return self.call_function_prop_meta(ttnn.min, args, kwargs)
-
-        ############################################################
-        # Data movement
-        ############################################################
-        if target == torch.ops.aten.permute.default:
-            return self.call_function_prop_meta(ttnn.permute, args, kwargs)
 
         ############################################################
         # Other ops
@@ -610,16 +619,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_nodes.append(g.call_function(ttnn.permute, args=(args[0], permutation)))
                 new_nodes[-1].meta["val"] = node.meta["val"]
                 # strange workaround when dim 0 is 1 for rank 3
-                if rank == 3 and output_size[0] == 1:
-                    if output_size[1] % 32 or output_size[2] % 32:
-                        new_nodes.append(
-                            g.call_function(
-                                ttnn.to_layout,
-                                (new_nodes[-1],),
-                                {"layout": TtnnRowMajorLayout()},
-                            )
-                        )
-                    new_nodes.append(g.call_function(ttnn.reshape, args=(new_nodes[-1], output_size)))
+                # TODO(bdrazic): remove workaround when permute issue is fixed https://github.com/tenstorrent/tt-metal/issues/11191
+                new_nodes = workaround_permute_3d_first_out_dim_is_one(g, new_nodes, rank, output_size)
                 return new_nodes[-1]
 
             if node.target == torch.ops.aten.t.default:
@@ -630,6 +631,20 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     permutation = [1, 0]
                     return g.call_function(ttnn.permute, args=(args[0], permutation))
                 return None
+
+            if node.target == torch.ops.aten.permute.default:
+                new_nodes = list()
+                new_nodes.append(g.call_function(ttnn.permute, args=(args[0], args[1])))
+                new_nodes[-1].meta["val"] = node.meta["val"]
+
+                # strange workaround when dim 0 is 1 for rank 3
+                # TODO(bdrazic): remove workaround when permute issue is fixed https://github.com/tenstorrent/tt-metal/issues/11191
+                # and this can then go to ReplaceMoreTt class.
+                output_size = node.meta["val"].size()
+                rank = len(output_size)
+                new_nodes = workaround_permute_3d_first_out_dim_is_one(g, new_nodes, rank, output_size)
+                return new_nodes[-1]
+
             if node.target == torch.ops.aten.constant_pad_nd.default:
                 input, pad, value = args
                 input_shape = input.meta["val"].size()

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -58,14 +58,6 @@ def create_call_function(transformer, target, args, kwargs):
 # Workaround for issue https://github.com/tenstorrent/tt-metal/issues/11191
 def workaround_permute_3d_first_out_dim_is_one(g, new_nodes, rank, output_size):
     if rank == 3 and output_size[0] == 1:
-        if output_size[1] % 32 or output_size[2] % 32:
-            new_nodes.append(
-                g.call_function(
-                    ttnn.to_layout,
-                    (new_nodes[-1],),
-                    {"layout": TtnnRowMajorLayout()},
-                )
-            )
         new_nodes.append(g.call_function(ttnn.reshape, args=(new_nodes[-1], output_size)))
     return new_nodes
 


### PR DESCRIPTION
Lower OPs from Group B to fewer TTNN OPs. OPs in this group are
aten.t.default.md
aten.transpose.int.md
aten.permute.default.md

In `to_tt_pass` all three are already lowered to `ttnn.permute`. 
This PR adds workaround for issue https://github.com/tenstorrent/tt-metal/issues/11191 that is used for `transpose` also to `permute`.