### PR TITLE
TM Lowering Group C

### DIFF
--- a/tests/lowering/tensor_manipulation/test_squeeze.py
+++ b/tests/lowering/tensor_manipulation/test_squeeze.py
@@ -31,9 +31,13 @@ def test_squeeze_dim(device, input_shape, dim):
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
     result_after = m.forward(inputs, dim)
     option._out_fx_graphs[0].print_tabular()
-    # Check the graph has be rewritten and contain ttnn ops (squeeze is lowered to reshape)
+    # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.reshape) == 1
+    if option.use_less_ttnn_op_types:
+        # squeeze is lowered to reshape
+        assert [node.target for node in nodes].count(ttnn.reshape) == 1
+    else:
+        assert [node.target for node in nodes].count(ttnn.squeeze) == 1
     # Check inference result
     assert torch.allclose(result_before, result_after)
 

--- a/tests/lowering/tensor_manipulation/test_squeeze.py
+++ b/tests/lowering/tensor_manipulation/test_squeeze.py
@@ -17,6 +17,8 @@ class SqueezeDimModule(torch.nn.Module):
     [
         ((1, 32, 16), 0),
         ((1, 256, 1), -1),
+        ((33, 44, 1, 32, 16), 1),
+        ((33, 44, 1, 32, 16), 2),
     ],
 )
 def test_squeeze_dim(device, input_shape, dim):
@@ -29,9 +31,42 @@ def test_squeeze_dim(device, input_shape, dim):
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
     result_after = m.forward(inputs, dim)
     option._out_fx_graphs[0].print_tabular()
-
-    # Check the graph has be rewritten and contain ttnn ops
+    # Check the graph has be rewritten and contain ttnn ops (squeeze is lowered to reshape)
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.squeeze) == 1
+    assert [node.target for node in nodes].count(ttnn.reshape) == 1
+    # Check inference result
+    assert torch.allclose(result_before, result_after)
+
+
+class SqueezeNoneDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return torch.squeeze(input)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        ((64, 1, 32, 16, 1, 32, 32)),
+        ((1, 1, 55, 23, 44, 32, 32)),
+        ((22, 1, 55, 23, 44, 32, 1)),
+        ((1, 1, 55, 1, 1, 1, 1)),
+    ],
+)
+def test_squeeze_none_dim(device, input_shape):
+    m = SqueezeNoneDimModule()
+    inputs = torch.zeros(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(inputs)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(inputs)
+    option._out_fx_graphs[0].print_tabular()
+    # Check the graph has be rewritten and contain ttnn ops (squeeze without provided dim is lowered to reshape)
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.reshape) == 1
     # Check inference result
     assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -27,6 +27,7 @@ class TorchTtnnOption:
         metrics_path="",
         tracer_option=None,
         bypass_compile=False,
+        use_less_ttnn_op_types=True,
     ):
         self.device = device
         self.gen_graphviz = gen_graphviz
@@ -39,6 +40,7 @@ class TorchTtnnOption:
 
         self.metrics_path = metrics_path
         self.bypass_compile = bypass_compile
+        self.use_less_ttnn_op_types = use_less_ttnn_op_types
         self.original_schema_list = list()
         self.compiled_schema_list = list()
 
@@ -116,7 +118,7 @@ def aten_backend(
     from torch_ttnn.passes.memory_pass import MemoryPass
 
     passes = [
-        ToTtPass(option.device),
+        ToTtPass(option.device, option.use_less_ttnn_op_types),
         AddDataMovePass(),
         EliminateCoreopsPass(),
         CSEPass(),


### PR DESCRIPTION
Lower OPs from Group C to fewer TTNN OPs. OPs in this group are
```
aten.view.default.md
aten.unsqueeze.default.md
aten.squeeze.dim.md
aten._unsafe_view.default.md
```

In `to_ttnn_pass` `unsqueeze`, `view` and `unsafe_view` are already lowered to `ttnn.reshape`.

Added lowering of `squeeze` to `ttnn.reshape`  and added flag `use_less_ttnn_op_types` to class `TorchTtnnOption` to enable this lowering.

