### PR TITLE
Implement tool to automatically generate guard function

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -421,6 +421,7 @@ class MetricStringListHandler:
             "aten.index_select.default": self._adjust_index_select_default,
             "aten.index.Tensor": self._adjust_index_tensor,
             "aten.index_put.default": self._adjust_index_tensor,
+            "aten._unsafe_index.Tensor": self._adjust_index_tensor,
         }
 
     def _adjust_bitwise_not_default(self, input_vals):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -417,7 +417,10 @@ class MetricStringListHandler:
             "aten.masked_fill.Scalar": self._adjust_masked_fill_Scalar,
             "aten.where.self": self._adjust_where_self,
             "aten.embedding.default": self._adjust_embedding_default,
+            "aten.embedding_dense_backward.default": self._adjust_embedding_dense_backward_default,
             "aten.index_select.default": self._adjust_index_select_default,
+            "aten.index.Tensor": self._adjust_index_tensor,
+            "aten.index_put.default": self._adjust_index_tensor,
         }
 
     def _adjust_bitwise_not_default(self, input_vals):
@@ -452,6 +455,17 @@ class MetricStringListHandler:
                 break
         return input_vals
 
+    def _adjust_embedding_dense_backward_default(self, input_vals):
+        for input_val in input_vals:
+            if input_val["name"] == "grad_output":
+                grad_output_shape0 = input_val["val"].shape[0]
+                break
+        for input_val in input_vals:
+            if input_val["name"] == "indices":
+                input_val["val"] = torch.randint(0, grad_output_shape0, input_val["val"].shape)
+                break
+        return input_vals
+
     def _adjust_index_select_default(self, input_vals):
         for input_val in input_vals:
             if input_val["name"] == "self":
@@ -464,6 +478,26 @@ class MetricStringListHandler:
         for input_val in input_vals:
             if input_val["name"] == "index":
                 input_val["val"] = torch.randint(0, self_shape[dim], input_val["val"].shape)
+                break
+        return input_vals
+
+    def _adjust_index_tensor(self, input_vals):
+        for input_val in input_vals:
+            if input_val["name"] == "self":
+                self_shape = input_val["val"].shape
+                break
+        for input_val in input_vals:
+            if input_val["name"] == "indices":
+                indices = input_val["val"]
+                new_indices = []
+                for i in range(len(indices)):
+                    indice = indices[i]
+                    new_indice = []
+                    for j in range(len(indice)):
+                        new_indice.append(torch.randint(0, self_shape[i], [1]))
+                    new_indice = torch.tensor(new_indice)
+                    new_indices.append(new_indice)
+                input_val["val"] = new_indices
                 break
         return input_vals
 

--- a/tools/aten_test.tmpl
+++ b/tools/aten_test.tmpl
@@ -80,7 +80,7 @@ def test_aten(device, input_strings, input_var_only_native, input_var_check_accu
             nodes = list(option._out_fx_graphs[0].nodes)
             if any(["ttnn" in str(node) for node in nodes]):
                 metric["convert_to_ttnn"] = True
-            else
+            else:
                 metric["convert_to_ttnn"] = False
         except Exception as e:
             print(f"Failed to check the graph has ttnn op. Raised exception: {e}")

--- a/tools/generate_guard_function_from_input_var_metric.py
+++ b/tools/generate_guard_function_from_input_var_metric.py
@@ -1,0 +1,87 @@
+import os
+import sys
+import argparse
+import pickle
+from pathlib import Path
+
+
+class GuardFuncExporter:
+    def __init__(self, metric_input_var_path: Path):
+        self.metric_input_var_path = metric_input_var_path
+        self.input_vars_result = self.load_input_varations_test_result()
+
+    def render_string(self, template: str, key: str, replacement: str) -> str:
+        result = template.replace("{" + key + "}", replacement)
+        return result
+
+    def load_pickle(self, path: str):
+        if os.path.isfile(path):
+            with open(path, "rb") as f:
+                return pickle.load(f)
+        else:
+            return None
+
+    def load_input_varations_test_result(self):
+        input_vars_result = {}
+        for dirpath, dirnames, filenames in os.walk(self.metric_input_var_path):
+            input_vars_result_model = []
+            for filename in filenames:
+                if filename.endswith(".pickle"):
+                    path = Path(dirpath) / filename
+                    input_vars_result_model += self.load_pickle(path)
+            model_name = dirpath.split("/")[-1].replace(" ", "_")
+            if input_vars_result_model:
+                input_vars_result[model_name] = input_vars_result_model
+        return input_vars_result
+
+    def get_op_blocklist(self, threshold: list):
+        def need_block(input_var: dict, threshold: list):
+            for key in threshold:
+                if input_var[key] == False:
+                    return True
+
+        op_blocklist = {}
+        for model_name, input_vars in self.input_vars_result.items():
+            for input_var in input_vars:
+                if need_block(input_var, threshold):
+                    opname = input_var["opname"]
+                    if opname not in op_blocklist:
+                        op_blocklist[opname] = []
+                    if input_var["input_strings"] not in op_blocklist[opname]:
+                        op_blocklist[opname].append(input_var["input_strings"])
+        return op_blocklist
+
+    def export_guard_function(self, template_path: Path, threshold: list = ["run", "accuracy"]):
+        blocklist_list = []
+        guardfunc_list = []
+        op_blocklist = self.get_op_blocklist(threshold)
+        for opname, blocklist in op_blocklist.items():
+            op_name_ = opname.replace(".", "_")
+            op_blocklist_name = f"{op_name_}_blocklist"
+            blocklist = f"{op_blocklist_name} = {str(blocklist)}"
+            guardfunc = f"torch.ops.{opname}: partial(guard_aten, {op_blocklist_name}),"
+            blocklist_list.append(blocklist)
+            guardfunc_list.append(guardfunc)
+
+        with open(template_path, "r") as f:
+            text = f.read()
+
+        text = self.render_string(text, "BLOCKLIST", "\n".join(blocklist_list))
+        text = self.render_string(text, "GUARD", "\n".join(guardfunc_list))
+
+        guard_path = "to_tt_guard.py"
+        with open(guard_path, "w") as f:
+            f.write(text)
+        os.system(f"pre-commit run --files {guard_path} > /dev/null")
+        print(f"Guard function generated: ./{guard_path}")
+
+
+if __name__ == "__main__":
+    template_path = os.path.dirname(os.path.abspath(__file__)) + "/to_tt_guard.tmpl"
+
+    if not os.path.isdir("metrics-input-variations"):
+        print("metrics-input-variations directory not found. Please run tests/input-variations")
+        exit(0)
+
+    exporter = GuardFuncExporter(Path("metrics-input-variations"))
+    exporter.export_guard_function(template_path, threshold=["run", "accuracy"])

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -34,6 +34,7 @@ class AtenOpTestExporter(InputVarPerOp):
             text = self.render_string(text, "metrics_filename", metrics_filename)
             with open(basedir / filename, "w") as f:
                 f.write(text)
+            os.system(f"pre-commit run --files {basedir / filename} > /dev/null")
 
 
 # Generate input variation tests only contain single op, it will

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -34,7 +34,6 @@ class AtenOpTestExporter(InputVarPerOp):
             text = self.render_string(text, "metrics_filename", metrics_filename)
             with open(basedir / filename, "w") as f:
                 f.write(text)
-            os.system(f"pre-commit run --files {basedir / filename} > /dev/null")
 
 
 # Generate input variation tests only contain single op, it will
@@ -73,3 +72,4 @@ if __name__ == "__main__":
         original_schema_metrics = load_pickle(original_schema_metrics_path) or {}
         input_var_per_op = AtenOpTestExporter(original_schema_metrics, compiled_schema_metrics={})
         input_var_per_op.export_tests(template_path, Path(f"tests/input-variations/{model_}"), model)
+        os.system(f"pre-commit run --files tests/input-variations/{model_}/* > /dev/null")

--- a/tools/to_tt_guard.tmpl
+++ b/tools/to_tt_guard.tmpl
@@ -1,0 +1,32 @@
+import torch
+import torch_ttnn.metrics as metrics
+from functools import partial
+
+{BLOCKLIST}
+
+def get_inputs(node):
+    node_inputs = metrics.collect_input_variation_from_node(node)
+    if type(node_inputs) == metrics.InputVariation:
+        return node_inputs.inputs
+    elif type(node_inputs) == metrics.ConvertedInput:
+        return node_inputs.original_input_variation.inputs
+    else:
+        return None
+
+def guard_aten(blocklist, node):
+    inputs = get_inputs(node)
+    inputs_str = [str(i) for i in inputs]
+    if inputs_str in blocklist:
+        return False
+    return True
+
+GUARD = {
+{GUARD}
+}
+
+
+def can_lowering_to_ttnn(node):
+    if node.target in GUARD:
+        return GUARD[node.target](node)
+
+    return True

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -505,6 +505,9 @@ aten_native_layer_norm_default_blocklist += [
     ],
 ]
 
+# Need to remove this from the blocklist so that yolos can pass
+aten_view_default_blocklist.remove(["Tensor<[1, 192, 32, 42]> self = ?", "List[int] size = [1, 192, 1344]"])
+
 
 def get_inputs(node):
     node_inputs = metrics.collect_input_variation_from_node(node)

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -1,5 +1,509 @@
 import torch
 import torch_ttnn.metrics as metrics
+from functools import partial
+
+aten_permute_default_blocklist = [
+    ["Tensor<[1, 3, 16, 16, 16, 16]> self = ?", "List[int] dims = [0, 2, 4, 3, 5, 1]"],
+    ["Tensor<[1, 16, 16, 16, 16, 3]> self = ?", "List[int] dims = [0, 5, 1, 3, 2, 4]"],
+    ["Tensor<[1, 6, 4, 20, 20]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 4, 10, 10]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 4, 5, 5]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 4, 3, 3]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 4, 2, 2]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 4, 1, 1]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 91, 20, 20]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 91, 10, 10]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 91, 5, 5]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 91, 3, 3]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 91, 2, 2]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 91, 1, 1]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[64, 64, 3]> self = ?", "List[int] dims = [2, 0, 1]"],
+    ["Tensor<[1, 8, 8, 8, 8, 96]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[64, 64, 3, 3, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 4, 8, 4, 8, 192]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[16, 64, 3, 6, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 4, 4, 8, 8, 192]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 2, 8, 2, 8, 384]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[4, 64, 3, 12, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 2, 2, 8, 8, 384]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 1, 8, 1, 8, 768]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 64, 3, 24, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 1, 1, 8, 8, 768]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 9, 91, 100, 136]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 91, 50, 68]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 91, 25, 34]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 91, 13, 17]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 91, 7, 9]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 4, 100, 136]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 4, 50, 68]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 4, 25, 34]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 4, 13, 17]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 9, 4, 7, 9]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[49, 49, 3]> self = ?", "List[int] dims = [2, 0, 1]"],
+    ["Tensor<[1, 8, 7, 8, 7, 96]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[64, 49, 3, 3, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 8, 8, 7, 7, 96]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[8, 7, 8, 7]> self = ?", "List[int] dims = [0, 2, 1, 3]"],
+    ["Tensor<[1, 4, 7, 4, 7, 192]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[16, 49, 3, 6, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 4, 4, 7, 7, 192]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[4, 7, 4, 7]> self = ?", "List[int] dims = [0, 2, 1, 3]"],
+    ["Tensor<[1, 2, 7, 2, 7, 384]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[4, 49, 3, 12, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 2, 2, 7, 7, 384]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[2, 7, 2, 7]> self = ?", "List[int] dims = [0, 2, 1, 3]"],
+    ["Tensor<[1, 1, 7, 1, 7, 768]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 49, 3, 24, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 1, 1, 7, 7, 768]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[12, 197, 197]> self = ?", "List[int] dims = [1, 2, 0]"],
+    ["Tensor<[1, 3, 85, 64, 64]> self = ?", "List[int] dims = [0, 1, 3, 4, 2]"],
+    ["Tensor<[1, 3, 85, 32, 32]> self = ?", "List[int] dims = [0, 1, 3, 4, 2]"],
+    ["Tensor<[1, 3, 85, 16, 16]> self = ?", "List[int] dims = [0, 1, 3, 4, 2]"],
+    ["Tensor<[1, 4, 4, 38, 38]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 4, 19, 19]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 4, 4, 3, 3]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 4, 4, 1, 1]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 4, 91, 38, 38]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 6, 91, 19, 19]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 4, 91, 3, 3]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 4, 91, 1, 1]> self = ?", "List[int] dims = [0, 3, 4, 1, 2]"],
+    ["Tensor<[1, 8, 8, 8, 8, 128]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[64, 64, 3, 4, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 4, 8, 4, 8, 256]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[16, 64, 3, 8, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 4, 4, 8, 8, 256]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 2, 8, 2, 8, 512]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[4, 64, 3, 16, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 2, 2, 8, 8, 512]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 1, 8, 1, 8, 1024]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 64, 3, 32, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 1, 1, 8, 8, 1024]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 8, 7, 8, 7, 128]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[64, 49, 3, 4, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 8, 8, 7, 7, 128]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 4, 7, 4, 7, 256]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[16, 49, 3, 8, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 4, 4, 7, 7, 256]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 2, 7, 2, 7, 512]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[4, 49, 3, 16, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 2, 2, 7, 7, 512]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 1, 7, 1, 7, 1024]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 49, 3, 32, 32]> self = ?", "List[int] dims = [2, 0, 3, 1, 4]"],
+    ["Tensor<[1, 1, 1, 7, 7, 1024]> self = ?", "List[int] dims = [0, 1, 3, 2, 4, 5]"],
+    ["Tensor<[1, 1024, 49]> self = ?", "List[int] dims = [0, 2, 1]"],
+    ["Tensor<[1, 768, 49]> self = ?", "List[int] dims = [0, 2, 1]"],
+    ["Tensor<[1, 1280, 1369]> self = ?", "List[int] dims = [0, 2, 1]"],
+    ["Tensor<[16, 197, 197]> self = ?", "List[int] dims = [1, 2, 0]"],
+]
+aten_view_default_blocklist = [
+    ["Tensor<[1, 3, 256, 256]> self = ?", "List[int] size = [1, 3, 16, 16, 16, 16]"],
+    ["Tensor<[1, 256, 768]> self = ?", "List[int] size = [1, 16, 16, 16, 16, 3]"],
+    ["Tensor<[1, 32, 16, 16]> self = ?", "List[int] size = [1, 32, 256]"],
+    ["Tensor<[1, 16384, 1, 32]> self = ?", "List[int] size = [1, 16384, 32]"],
+    ["Tensor<[1, 64, 16, 16]> self = ?", "List[int] size = [1, 64, 256]"],
+    ["Tensor<[1, 160, 16, 16]> self = ?", "List[int] size = [1, 160, 256]"],
+    ["Tensor<[1, 256, 16, 16]> self = ?", "List[int] size = [1, 256, 256]"],
+    ["Tensor<[1, 1024, 16, 16]> self = ?", "List[int] size = [1, 1024, 256]"],
+    ["Tensor<[1, 16, 16, 256]> self = ?", "List[int] size = [1, 256, 256]"],
+    ["Tensor<[1, 256, 1, 32]> self = ?", "List[int] size = [1, 256, 32]"],
+    ["Tensor<[1, 192, 32, 42]> self = ?", "List[int] size = [1, 192, 1344]"],
+    ["Tensor<[1, 19200, 1, 64]> self = ?", "List[int] size = [1, 19200, 64]"],
+    ["Tensor<[1, 128, 60, 80]> self = ?", "List[int] size = [1, 128, 4800]"],
+    ["Tensor<[1, 512, 60, 80]> self = ?", "List[int] size = [1, 512, 4800]"],
+    ["Tensor<[64, 64, 288]> self = ?", "List[int] size = [64, 64, 3, 3, 32]"],
+    ["Tensor<[16, 64, 576]> self = ?", "List[int] size = [16, 64, 3, 6, 32]"],
+    ["Tensor<[1, 16, 16, 768]> self = ?", "List[int] size = [256, 768]"],
+    ["Tensor<[4, 64, 1152]> self = ?", "List[int] size = [4, 64, 3, 12, 32]"],
+    ["Tensor<[1, 16, 16, 384]> self = ?", "List[int] size = [256, 384]"],
+    ["Tensor<[1, 16, 16, 1536]> self = ?", "List[int] size = [256, 1536]"],
+    ["Tensor<[1, 8, 8, 1536]> self = ?", "List[int] size = [64, 1536]"],
+    ["Tensor<[1, 1, 1, 8, 8, 768]> self = ?", "List[int] size = [1, 64, 768]"],
+    ["Tensor<[1, 64, 2304]> self = ?", "List[int] size = [1, 64, 3, 24, 32]"],
+    ["Tensor<[1, 8, 8, 768]> self = ?", "List[int] size = [64, 768]"],
+    ["Tensor<[1, 8, 8, 3072]> self = ?", "List[int] size = [64, 3072]"],
+    ["Tensor<[0, 1, 4]> self = ?", "List[int] size = [0, 4]"],
+    ["Tensor<[0, 2, 2]> self = ?", "List[int] size = [0, 4]"],
+    ["Tensor<[1, 2048]> self = ?", "List[int] size = [1, 2048, 1, 1]"],
+    ["Tensor<[64, 49, 96]> self = ?", "List[int] size = [3136, 96]"],
+    ["Tensor<[64, 49, 288]> self = ?", "List[int] size = [64, 49, 3, 3, 32]"],
+    ["Tensor<[1, 56, 56, 96]> self = ?", "List[int] size = [3136, 96]"],
+    ["Tensor<[1, 56, 56, 384]> self = ?", "List[int] size = [3136, 384]"],
+    ["Tensor<[16, 49, 576]> self = ?", "List[int] size = [16, 49, 3, 6, 32]"],
+    ["Tensor<[4, 49, 1152]> self = ?", "List[int] size = [4, 49, 3, 12, 32]"],
+    ["Tensor<[1, 49, 2304]> self = ?", "List[int] size = [1, 49, 3, 24, 32]"],
+    ["Tensor<[1, 1024]> self = ?", "List[int] size = [1, 1024, 1, 1]"],
+    ["Tensor<[1, 32, 4608]> self = ?", "List[int] size = [1, 32, 16, 3, 96]"],
+    ["Tensor<[1, 768, 12, 16]> self = ?", "List[int] size = [1, 768, 192]"],
+    ["Tensor<[64, 64, 384]> self = ?", "List[int] size = [64, 64, 3, 4, 32]"],
+    ["Tensor<[16, 64, 768]> self = ?", "List[int] size = [16, 64, 3, 8, 32]"],
+    ["Tensor<[1, 16, 16, 1024]> self = ?", "List[int] size = [256, 1024]"],
+    ["Tensor<[4, 64, 1536]> self = ?", "List[int] size = [4, 64, 3, 16, 32]"],
+    ["Tensor<[1, 16, 16, 512]> self = ?", "List[int] size = [256, 512]"],
+    ["Tensor<[1, 16, 16, 2048]> self = ?", "List[int] size = [256, 2048]"],
+    ["Tensor<[1, 8, 8, 2048]> self = ?", "List[int] size = [64, 2048]"],
+    ["Tensor<[1, 1, 1, 8, 8, 1024]> self = ?", "List[int] size = [1, 64, 1024]"],
+    ["Tensor<[1, 64, 3072]> self = ?", "List[int] size = [1, 64, 3, 32, 32]"],
+    ["Tensor<[1, 8, 8, 1024]> self = ?", "List[int] size = [64, 1024]"],
+    ["Tensor<[1, 8, 8, 4096]> self = ?", "List[int] size = [64, 4096]"],
+    ["Tensor<[64, 49, 128]> self = ?", "List[int] size = [3136, 128]"],
+    ["Tensor<[64, 49, 384]> self = ?", "List[int] size = [64, 49, 3, 4, 32]"],
+    ["Tensor<[1, 56, 56, 128]> self = ?", "List[int] size = [3136, 128]"],
+    ["Tensor<[1, 56, 56, 512]> self = ?", "List[int] size = [3136, 512]"],
+    ["Tensor<[16, 49, 768]> self = ?", "List[int] size = [16, 49, 3, 8, 32]"],
+    ["Tensor<[4, 49, 1536]> self = ?", "List[int] size = [4, 49, 3, 16, 32]"],
+    ["Tensor<[1, 49, 3072]> self = ?", "List[int] size = [1, 49, 3, 32, 32]"],
+    ["Tensor<[1, 512]> self = ?", "List[int] size = [1, 512, 1, 1]"],
+]
+aten__unsafe_view_default_blocklist = [
+    ["Tensor<[1, 16, 16, 16, 16, 3]> self = ?", "List[int] size = [1, 256, 768]"],
+    ["Tensor<[1, 3, 16, 16, 16, 16]> self = ?", "List[int] size = [1, 3, 256, 256]"],
+    ["Tensor<[1, 8, 8, 8, 8, 96]> self = ?", "List[int] size = [64, 64, 96]"],
+    ["Tensor<[1, 8, 8, 8, 8, 96]> self = ?", "List[int] size = [1, 64, 64, 96]"],
+    ["Tensor<[8, 8, 8, 8]> self = ?", "List[int] size = [64, 64]"],
+    ["Tensor<[1, 4, 4, 8, 8, 192]> self = ?", "List[int] size = [16, 64, 192]"],
+    ["Tensor<[1, 4, 8, 4, 8, 192]> self = ?", "List[int] size = [1, 32, 32, 192]"],
+    ["Tensor<[1, 2, 2, 8, 8, 384]> self = ?", "List[int] size = [4, 64, 384]"],
+    ["Tensor<[1, 8, 8, 8, 8, 128]> self = ?", "List[int] size = [64, 64, 128]"],
+    ["Tensor<[1, 8, 8, 8, 8, 128]> self = ?", "List[int] size = [1, 64, 64, 128]"],
+    ["Tensor<[1, 4, 4, 8, 8, 256]> self = ?", "List[int] size = [16, 64, 256]"],
+    ["Tensor<[1, 4, 8, 4, 8, 256]> self = ?", "List[int] size = [1, 32, 32, 256]"],
+    ["Tensor<[1, 2, 2, 8, 8, 512]> self = ?", "List[int] size = [4, 64, 512]"],
+]
+aten_add_Tensor_blocklist = [
+    ["Tensor<[]> self = ?", "Tensor other = 1"],
+    ["Tensor<[1, 16, 19, 19]> self = ?", "Tensor<[1, 1, 19, 19]> other = ?"],
+    ["Tensor<[1, 64, 3, 64, 64]> self = ?", "Tensor<[1, 64, 1, 64, 64]> other = ?"],
+    ["Tensor<[1, 16, 6, 64, 64]> self = ?", "Tensor<[1, 16, 1, 64, 64]> other = ?"],
+    ["Tensor<[1, 4, 12, 64, 64]> self = ?", "Tensor<[1, 4, 1, 64, 64]> other = ?"],
+    ["Tensor<[13600, 1, 4]> self = ?", "Tensor<[1, 9, 4]> other = ?"],
+    ["Tensor<[3400, 1, 4]> self = ?", "Tensor<[1, 9, 4]> other = ?"],
+    ["Tensor<[850, 1, 4]> self = ?", "Tensor<[1, 9, 4]> other = ?"],
+    ["Tensor<[221, 1, 4]> self = ?", "Tensor<[1, 9, 4]> other = ?"],
+    ["Tensor<[63, 1, 4]> self = ?", "Tensor<[1, 9, 4]> other = ?"],
+    ["Tensor<[0]> self = ?", "Tensor<[0]> other = ?"],
+    ["Tensor<[0, 1]> self = ?", "Tensor<[0, 1]> other = ?"],
+    ["Tensor<[1, 64, 1, 1]> self = ?", "Tensor other = 1e-05"],
+    ["Tensor<[1, 256, 1, 1]> self = ?", "Tensor other = 1e-05"],
+    ["Tensor<[1, 128, 1, 1]> self = ?", "Tensor other = 1e-05"],
+    ["Tensor<[1, 512, 1, 1]> self = ?", "Tensor other = 1e-05"],
+    ["Tensor<[1, 1024, 1, 1]> self = ?", "Tensor other = 1e-05"],
+    ["Tensor<[1, 2048, 1, 1]> self = ?", "Tensor other = 1e-05"],
+    ["Tensor<[920, 1, 256]> self = ?", "Tensor<[256]> other = ?"],
+    ["Tensor<[1, 64, 3, 49, 49]> self = ?", "Tensor<[1, 64, 1, 49, 49]> other = ?"],
+    ["Tensor<[1, 16, 6, 49, 49]> self = ?", "Tensor<[1, 16, 1, 49, 49]> other = ?"],
+    ["Tensor<[1, 4, 12, 49, 49]> self = ?", "Tensor<[1, 4, 1, 49, 49]> other = ?"],
+    ["Tensor<[2, 7, 512]> self = ?", "Tensor<[1, 7, 512]> other = ?"],
+    ["Tensor<[2, 8, 7, 7]> self = ?", "Tensor<[2, 1, 7, 7]> other = ?"],
+    ["Tensor<[1, 71, 7, 7]> self = ?", "Tensor<[7, 7]> other = ?"],
+    ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 64, 4, 64, 64]> self = ?", "Tensor<[1, 64, 1, 64, 64]> other = ?"],
+    ["Tensor<[1, 16, 8, 64, 64]> self = ?", "Tensor<[1, 16, 1, 64, 64]> other = ?"],
+    ["Tensor<[1, 4, 16, 64, 64]> self = ?", "Tensor<[1, 4, 1, 64, 64]> other = ?"],
+    ["Tensor<[1, 64, 4, 49, 49]> self = ?", "Tensor<[1, 64, 1, 49, 49]> other = ?"],
+    ["Tensor<[1, 16, 8, 49, 49]> self = ?", "Tensor<[1, 16, 1, 49, 49]> other = ?"],
+    ["Tensor<[1, 4, 16, 49, 49]> self = ?", "Tensor<[1, 4, 1, 49, 49]> other = ?"],
+    ["Tensor<[1, 64, 1, 1]> self = ?", "Tensor other = 0.0"],
+    ["Tensor<[1, 256, 1, 1]> self = ?", "Tensor other = 0.0"],
+    ["Tensor<[1, 128, 1, 1]> self = ?", "Tensor other = 0.0"],
+    ["Tensor<[1, 512, 1, 1]> self = ?", "Tensor other = 0.0"],
+    ["Tensor<[1, 1024, 1, 1]> self = ?", "Tensor other = 0.0"],
+    ["Tensor<[1, 2048, 1, 1]> self = ?", "Tensor other = 0.0"],
+]
+aten_clamp_default_blocklist = [
+    ["Tensor<[128]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[128]> self = ?", "Optional[number] min = ?", "Optional[number] max = 127"],
+    ["Tensor<[128]> self = ?", "Optional[number] min = ?", "Optional[number] max = 63"],
+    ["Tensor<[128]> self = ?", "Optional[number] min = ?", "Optional[number] max = 31"],
+    ["Tensor<[128]> self = ?", "Optional[number] min = ?", "Optional[number] max = 15"],
+    ["Tensor<[320]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[320]> self = ?", "Optional[number] min = ?", "Optional[number] max = 479"],
+    ["Tensor<[320]> self = ?", "Optional[number] min = ?", "Optional[number] max = 639"],
+    ["Tensor<[3234, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.135166556742356"],
+    ["Tensor<[30]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[40]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[30]> self = ?", "Optional[number] min = ?", "Optional[number] max = 14"],
+    ["Tensor<[40]> self = ?", "Optional[number] min = ?", "Optional[number] max = 19"],
+    ["Tensor<[60]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[80]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[60]> self = ?", "Optional[number] min = ?", "Optional[number] max = 29"],
+    ["Tensor<[80]> self = ?", "Optional[number] min = ?", "Optional[number] max = 39"],
+    ["Tensor<[120]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[160]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[120]> self = ?", "Optional[number] min = ?", "Optional[number] max = 59"],
+    ["Tensor<[160]> self = ?", "Optional[number] min = ?", "Optional[number] max = 79"],
+    ["Tensor<[240]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[240]> self = ?", "Optional[number] min = ?", "Optional[number] max = 119"],
+    ["Tensor<[320]> self = ?", "Optional[number] min = ?", "Optional[number] max = 159"],
+    ["Tensor<[480]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[640]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[480]> self = ?", "Optional[number] min = ?", "Optional[number] max = 239"],
+    ["Tensor<[640]> self = ?", "Optional[number] min = ?", "Optional[number] max = 319"],
+    ["Tensor<[3, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+    ["Tensor<[6, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+    ["Tensor<[12, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+    ["Tensor<[24, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+    ["Tensor<[800]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[1066]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[800]> self = ?", "Optional[number] min = ?", "Optional[number] max = 479"],
+    ["Tensor<[1066]> self = ?", "Optional[number] min = ?", "Optional[number] max = 639"],
+    ["Tensor<[0, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.135166556742356"],
+    ["Tensor<[0, 2]> self = ?", "Optional[number] min = 0", "Optional[number] max = 1066"],
+    ["Tensor<[0, 2]> self = ?", "Optional[number] min = 0", "Optional[number] max = 800"],
+    ["Tensor<[320]> self = ?", "Optional[number] min = ?", "Optional[number] max = 319"],
+    ["Tensor<[300]> self = ?", "Optional[number] min = 0.0"],
+    ["Tensor<[300]> self = ?", "Optional[number] min = ?", "Optional[number] max = 479"],
+    ["Tensor<[300]> self = ?", "Optional[number] min = ?", "Optional[number] max = 639"],
+    ["Tensor<[8732, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.135166556742356"],
+    ["Tensor<[4, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+    ["Tensor<[8, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+    ["Tensor<[16, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+    ["Tensor<[32, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
+]
+aten_maximum_default_blocklist = [["Tensor<[1, 16, 19, 19]> self = ?", "Tensor<[]> other = ?"]]
+aten__log_softmax_default_blocklist = [["Tensor<[19, 256008]> self = ?", "int dim = 1", "bool half_to_float = False"]]
+aten_expand_default_blocklist = [
+    ["Tensor<[1, 1, 1, 19]> self = ?", "List[int] size = [1, 1, 19, 19]"],
+    ["Tensor<[256, 1280]> self = ?", "List[int] size = [1, -1, -1]"],
+    ["Tensor<[2048, 768]> self = ?", "List[int] size = [1, -1, -1]"],
+    ["Tensor<[1, 5]> self = ?", "List[int] size = [5, 5]"],
+    ["Tensor<[1, 3]> self = ?", "List[int] size = [3, 3]"],
+    ["Tensor<[1, 17]> self = ?", "List[int] size = [13, 17]"],
+    ["Tensor<[1, 9]> self = ?", "List[int] size = [7, 9]"],
+    ["Tensor<[768]> self = ?", "List[int] size = [1, 1, -1]"],
+    ["Tensor<[1, 1, 7, 7]> self = ?", "List[int] size = [2, 1, 7, 7]"],
+    ["Tensor<[2, 1, 1, 7]> self = ?", "List[int] size = [2, 1, 7, 7]"],
+    ["Tensor<[1, 1, 64, 7]> self = ?", "List[int] size = [1, 71, 64, 7]"],
+    ["Tensor<[1, 19]> self = ?", "List[int] size = [19, 19]"],
+]
+aten_full_default_blocklist = [
+    [
+        "List[int] size = [19, 19]",
+        "number fill_value = -3.4028234663852886e+38",
+        "Optional[Device] device = cpu",
+        "Optional[bool] pin_memory = False",
+    ],
+    [
+        "List[int] size = [7, 7]",
+        "number fill_value = -3.3895313892515355e+38",
+        "Optional[Device] device = cpu",
+        "Optional[bool] pin_memory = False",
+    ],
+]
+aten_rsub_Scalar_blocklist = [
+    ["Tensor<[1, 1, 19, 19]> self = ?", "number other = 1.0"],
+    ["Tensor<[1, 1, 1, 9]> self = ?", "number other = 1.0"],
+    ["Tensor<[1, 1, 1, 25]> self = ?", "number other = 1.0"],
+    ["Tensor<[2, 1, 7, 7]> self = ?", "number other = 1.0"],
+    ["Tensor<[1, 1, 1, 7]> self = ?", "number other = 1.0"],
+]
+aten_addmm_default_blocklist = [
+    ["Tensor<[4096]> self = ?", "Tensor<[1, 25088]> mat1 = ?", "Tensor<[25088, 4096]> mat2 = ?"]
+]
+aten__scaled_dot_product_flash_attention_default_blocklist = [
+    ["Tensor<[1, 16, 197, 64]> query = ?", "Tensor<[1, 16, 197, 64]> key = ?", "Tensor<[1, 16, 197, 64]> value = ?"],
+    ["Tensor<[1, 12, 197, 64]> query = ?", "Tensor<[1, 12, 197, 64]> key = ?", "Tensor<[1, 12, 197, 64]> value = ?"],
+    ["Tensor<[1, 16, 50, 64]> query = ?", "Tensor<[1, 16, 50, 64]> key = ?", "Tensor<[1, 16, 50, 64]> value = ?"],
+    ["Tensor<[1, 8, 4096, 40]> query = ?", "Tensor<[1, 8, 4096, 40]> key = ?", "Tensor<[1, 8, 4096, 40]> value = ?"],
+    ["Tensor<[1, 8, 1024, 80]> query = ?", "Tensor<[1, 8, 9, 80]> key = ?", "Tensor<[1, 8, 9, 80]> value = ?"],
+    ["Tensor<[1, 8, 256, 160]> query = ?", "Tensor<[1, 8, 256, 160]> key = ?", "Tensor<[1, 8, 256, 160]> value = ?"],
+    ["Tensor<[1, 8, 64, 160]> query = ?", "Tensor<[1, 8, 64, 160]> key = ?", "Tensor<[1, 8, 64, 160]> value = ?"],
+]
+aten_transpose_int_blocklist = [
+    ["Tensor<[1, 197, 1, 3, 1024]> self = ?", "int dim0 = 0", "int dim1 = -2"],
+    ["Tensor<[12, 197, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
+    ["Tensor<[12, 64, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
+    ["Tensor<[1, 12, 64, 197]> self = ?", "int dim0 = -1", "int dim1 = -2"],
+    ["Tensor<[1, 197, 1, 3, 768]> self = ?", "int dim0 = 0", "int dim1 = -2"],
+    ["Tensor<[1, 768, 49]> self = ?", "int dim0 = 1", "int dim1 = 2"],
+    ["Tensor<[16, 7, 7]> self = ?", "int dim0 = 1", "int dim1 = 2"],
+    ["Tensor<[16, 64, 7]> self = ?", "int dim0 = 1", "int dim1 = 2"],
+    ["Tensor<[1, 50, 1, 3, 1024]> self = ?", "int dim0 = 0", "int dim1 = -2"],
+    ["Tensor<[1, 50, 1, 3, 768]> self = ?", "int dim0 = 0", "int dim1 = -2"],
+    ["Tensor<[1, 1370, 1, 3, 1280]> self = ?", "int dim0 = 0", "int dim1 = -2"],
+    ["Tensor<[16, 197, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
+    ["Tensor<[16, 64, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
+    ["Tensor<[1, 16, 64, 197]> self = ?", "int dim0 = -1", "int dim1 = -2"],
+]
+aten_embedding_default_blocklist = [["Tensor<[2048, 768]> weight = ?", "Tensor<[2048]> indices = ?"]]
+aten_zeros_like_default_blocklist = [
+    ["Tensor<[13685]> self = ?", "Optional[int] dtype = torch.bool", "Optional[bool] pin_memory = False"],
+    ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
+]
+aten_div_Tensor_blocklist = [
+    ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 12, 9, 9]> self = ?", "Tensor other = 8.0"],
+    ["Tensor<[1, 64, 9, 9]> self = ?", "Tensor other = 8.0"],
+    ["Tensor<[1, 23, 40, 1]> self = ?", "Tensor<[128]> other = ?"],
+    ["Tensor<[1, 12, 25, 25]> self = ?", "Tensor other = 8.0"],
+    ["Tensor<[1, 16, 9, 9]> self = ?", "Tensor other = 11.313708498984761"],
+    ["Tensor<[1, 16, 9, 9]> self = ?", "Tensor other = 8.0"],
+    ["Tensor<[1, 12, 7, 7]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 1280, 8, 8]> self = ?", "Tensor other = 1"],
+]
+aten_mul_Tensor_blocklist = [
+    ["Tensor<[]> self = ?", "Tensor<[3234, 1]> other = ?"],
+    ["Tensor<[300]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 64, 30, 40]> self = ?", "Tensor<[1, 1, 30, 40]> other = ?"],
+    ["Tensor<[1, 64, 60, 80]> self = ?", "Tensor<[1, 1, 60, 80]> other = ?"],
+    ["Tensor<[1, 64, 120, 160]> self = ?", "Tensor<[1, 1, 120, 160]> other = ?"],
+    ["Tensor<[64, 3, 64, 64]> self = ?", "Tensor<[3, 1, 1]> other = ?"],
+    ["Tensor<[16, 6, 64, 64]> self = ?", "Tensor<[6, 1, 1]> other = ?"],
+    ["Tensor<[4, 12, 64, 64]> self = ?", "Tensor<[12, 1, 1]> other = ?"],
+    ["Tensor<[136]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[100]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[68]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[50]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[34]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[25]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[17]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[13]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[9]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[7]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[0]> self = ?", "Tensor other = 0.5"],
+    ["Tensor<[0, 1]> self = ?", "Tensor<[0, 1]> other = ?"],
+    ["Tensor<[]> self = ?", "Tensor<[0, 1]> other = ?"],
+    ["Tensor<[0]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[16, 1]> self = ?", "Tensor<[1, 1, 32]> other = ?"],
+    ["Tensor<[2, 1]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 71, 7, 64]> self = ?", "Tensor<[1, 1, 7, 64]> other = ?"],
+    ["Tensor<[1, 3, 64, 64, 2]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 3, 32, 32, 2]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 3, 16, 16, 2]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[]> self = ?", "Tensor<[8732, 1]> other = ?"],
+    ["Tensor<[12]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[64, 4, 64, 64]> self = ?", "Tensor<[4, 1, 1]> other = ?"],
+    ["Tensor<[16, 8, 64, 64]> self = ?", "Tensor<[8, 1, 1]> other = ?"],
+    ["Tensor<[4, 16, 64, 64]> self = ?", "Tensor<[16, 1, 1]> other = ?"],
+]
+aten_slice_Tensor_blocklist = [
+    ["Tensor<[1, 512]> self = ?", "int dim = 1", "Optional[int] start = 0", "Optional[int] end = 9"],
+    ["Tensor<[1, 512]> self = ?", "int dim = 1", "Optional[int] start = 0", "Optional[int] end = 25"],
+    ["Tensor<[1, 1, 7, 1024]> self = ?", "int dim = 3", "Optional[int] start = 0", "Optional[int] end = 7"],
+]
+aten_native_layer_norm_default_blocklist = [
+    [
+        "Tensor<[1, 9, 4096]> input = ?",
+        "List[int] normalized_shape = [4096]",
+        "Optional[Tensor]<[4096]> weight = ?",
+        "Optional[Tensor]<[4096]> bias = ?",
+        "float eps = 1e-12",
+    ],
+    [
+        "Tensor<[1, 7, 4544]> input = ?",
+        "List[int] normalized_shape = [4544]",
+        "Optional[Tensor]<[4544]> weight = ?",
+        "Optional[Tensor]<[4544]> bias = ?",
+        "float eps = 1e-05",
+    ],
+]
+aten_sub_Tensor_blocklist = [
+    ["Tensor<[64, 1, 64]> self = ?", "Tensor<[64, 64, 1]> other = ?"],
+    ["Tensor<[16, 1, 64]> self = ?", "Tensor<[16, 64, 1]> other = ?"],
+    ["Tensor<[4, 1, 64]> self = ?", "Tensor<[4, 64, 1]> other = ?"],
+    ["Tensor<[0]> self = ?", "Tensor<[0]> other = ?"],
+    ["Tensor<[0, 1]> self = ?", "Tensor<[0, 1]> other = ?"],
+    ["Tensor<[64, 1, 49]> self = ?", "Tensor<[64, 49, 1]> other = ?"],
+    ["Tensor<[16, 1, 49]> self = ?", "Tensor<[16, 49, 1]> other = ?"],
+    ["Tensor<[4, 1, 49]> self = ?", "Tensor<[4, 49, 1]> other = ?"],
+]
+aten_exp_default_blocklist = [["Tensor<[0, 1]> self = ?"], ["Tensor<[]> self = ?"]]
+aten_split_Tensor_blocklist = [
+    ["Tensor<[768, 256]> self = ?", "int split_size = 256"],
+    ["Tensor<[768]> self = ?", "int split_size = 256"],
+    ["Tensor<[1, 7, 2304]> self = ?", "int split_size = 768", "int dim = 2"],
+]
+aten_t_default_blocklist = [
+    ["Tensor<[12, 3]> self = ?"],
+    ["Tensor<[1, 3]> self = ?"],
+    ["Tensor<[2, 1]> self = ?"],
+    ["Tensor<[512, 1]> self = ?"],
+]
+aten_ones_default_blocklist = [
+    [
+        "List[int] size = [7, 7]",
+        "Optional[int] dtype = torch.bool",
+        "Optional[int] layout = torch.strided",
+        "Optional[Device] device = cpu",
+    ]
+]
+aten_where_self_blocklist = [
+    ["Tensor<[1, 1, 7, 7]> condition = ?", "Tensor<[1, 12, 7, 7]> self = ?", "Tensor<[]> other = ?"]
+]
+aten_empty_memory_format_blocklist = [
+    [
+        "List[int] size = []",
+        "Optional[int] dtype = torch.int64",
+        "Optional[Device] device = cpu",
+        "Optional[bool] pin_memory = False",
+    ]
+]
+
+# Add for pass CLIP eval
+aten_mul_Tensor_blocklist += [
+    ["Tensor<[1, 50, 768]> self = ?", "Tensor other = 0.125"],
+    ["Tensor<[1, 50, 3072]> self = ?", "Tensor other = 1.702"],
+    ["Tensor<[1, 50, 3072]> self = ?", "Tensor<[1, 50, 3072]> other = ?"],
+    ["Tensor<[2, 7, 512]> self = ?", "Tensor other = 0.125"],
+    ["Tensor<[2, 7, 2048]> self = ?", "Tensor other = 1.702"],
+    ["Tensor<[2, 7, 2048]> self = ?", "Tensor<[2, 7, 2048]> other = ?"],
+    ["Tensor<[2, 1]> self = ?", "Tensor<[]> other = ?"],
+]
+
+aten_view_default_blocklist += [
+    ["Tensor<[1, 768, 7, 7]> self = ?", "List[int] size = [1, 768, 49]"],
+    ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [50, 768]"],
+    ["Tensor<[50, 768]> self = ?", "List[int] size = [1, 50, 768]"],
+    ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, -1, 12, 64]"],
+    ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, 50, 12, 64]"],
+    ["Tensor<[1, 12, 50, 64]> self = ?", "List[int] size = [12, -1, 64]"],
+    ["Tensor<[12, 50, 64]> self = ?", "List[int] size = [1, 12, 50, 64]"],
+    ["Tensor<[50, 3072]> self = ?", "List[int] size = [1, 50, 3072]"],
+    ["Tensor<[1, 50, 3072]> self = ?", "List[int] size = [50, 3072]"],
+    ["Tensor<[2, 7]> self = ?", "List[int] size = [-1, 7]"],
+    ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [14, 512]"],
+    ["Tensor<[14, 512]> self = ?", "List[int] size = [2, 7, 512]"],
+    ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, -1, 8, 64]"],
+    ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, 7, 8, 64]"],
+    ["Tensor<[2, 8, 7, 64]> self = ?", "List[int] size = [16, -1, 64]"],
+    ["Tensor<[16, 7, 7]> self = ?", "List[int] size = [2, 8, 7, 7]"],
+    ["Tensor<[2, 8, 7, 7]> self = ?", "List[int] size = [16, 7, 7]"],
+    ["Tensor<[16, 7, 64]> self = ?", "List[int] size = [2, 8, 7, 64]"],
+    ["Tensor<[14, 2048]> self = ?", "List[int] size = [2, 7, 2048]"],
+    ["Tensor<[2, 7, 2048]> self = ?", "List[int] size = [14, 2048]"],
+]
+
+aten__to_copy_default_blocklist = [
+    ["Tensor<[1, 3, 224, 224]> self = ?", "Optional[int] dtype = torch.bfloat16"],
+    ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
+    ["Tensor<[2, 1, 7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
+    ["Tensor<[2, 1, 7, 7]> self = ?", "Optional[int] dtype = torch.bool"],
+    ["Tensor<[2, 7]> self = ?", "Optional[int] dtype = torch.int32", "Optional[Device] device = cpu"],
+]
+
+aten_native_layer_norm_default_blocklist += [
+    [
+        "Tensor<[1, 50, 768]> input = ?",
+        "List[int] normalized_shape = [768]",
+        "Optional[Tensor]<[768]> weight = ?",
+        "Optional[Tensor]<[768]> bias = ?",
+        "float eps = 1e-05",
+    ],
+    [
+        "Tensor<[1, 768]> input = ?",
+        "List[int] normalized_shape = [768]",
+        "Optional[Tensor]<[768]> weight = ?",
+        "Optional[Tensor]<[768]> bias = ?",
+        "float eps = 1e-05",
+    ],
+    [
+        "Tensor<[2, 7, 512]> input = ?",
+        "List[int] normalized_shape = [512]",
+        "Optional[Tensor]<[512]> weight = ?",
+        "Optional[Tensor]<[512]> bias = ?",
+        "float eps = 1e-05",
+    ],
+]
 
 
 def get_inputs(node):
@@ -12,299 +516,50 @@ def get_inputs(node):
         return None
 
 
-def aten_exp_default(node):
-    inputs = get_inputs(node)
-    size_len = len(inputs[0].shape_.size())
-    # ttnn seems not accept scalar now
-    if size_len == 0:
-        return False
-    return True
-
-
-def aten_expand_default(node):
-    # TODO: find root cause
-    blacklist = [[[768], [1, 1, -1]], [[1, 1, 7, 7], [2, 1, 7, 7]], [[2, 1, 1, 7], [2, 1, 7, 7]]]
-    inputs = get_inputs(node)
-    self_shape = list(inputs[0].shape_.size())
-    size = inputs[1].value_
-    if [self_shape, size] in blacklist:
-        return False
-    return True
-
-
-def aten_full_default(node):
-    # For valid non-interleaved buffers page size 2048 must equal buffer size 96.
-    # For interleaved-buffers page size should be divisible by buffer size
-    # TODO: find root cause
-    blacklist = [[7, 7]]
-    inputs = get_inputs(node)
-    size = inputs[0].value_
-    if size in blacklist:
-        return False
-    return True
-
-
-def aten_mul_tensor(node):
-    inputs = get_inputs(node)
-    # ttnn seems not accept scalar now
-    try:
-        size0_len = len(inputs[0].shape_.size())
-        if size0_len == 0:
-            return False
-    except:
-        pass
-    try:
-        size1_len = len(inputs[1].shape_.size())
-        if size1_len == 0:
-            return False
-    except:
-        pass
-    return True
-
-
-def aten_rsub_scalar(node):
-    # TODO: find root cause
-    blacklist = [[2, 1, 7, 7]]
-    inputs = get_inputs(node)
-    shape = list(inputs[0].shape_.size())
-    if shape in blacklist:
-        return False
-    return True
-
-
-def aten_slice_tensor(node):
-    # TODO: find root cause
-    blacklist = [[[1, 77], 1], [[1, 50, 768], 1]]
-    inputs = get_inputs(node)
-    # ttnn seems not accept scalar now
-    shape = list(inputs[0].shape_.size())
-    dim = inputs[1].value_
-    if [shape, dim] in blacklist:
-        return False
-    return True
-
-
-def aten_t_default(node):
-    # TODO: find root cause
-    blacklist = [[2, 1], [512, 1]]
-    inputs = get_inputs(node)
-    shape = list(inputs[0].shape_.size())
-    if shape in blacklist:
-        return False
-    return True
-
-
-def aten_transpose_int(node):
-    # TODO: find root cause
-    blacklist = [[[1, 768, 49], 1, 2], [[1, 49, 768], 1, 2], [[16, 64, 7], 1, 2], [[16, 7, 7], 1, 2]]
-    inputs = get_inputs(node)
-    # ttnn seems not accept scalar now
-    shape = list(inputs[0].shape_.size())
-    dim0 = inputs[1].value_
-    dim1 = inputs[2].value_
-    if [shape, dim0, dim1] in blacklist:
-        return False
-    return True
-
-
-def aten__softmax_default(node):
-    # TODO: find root cause
-    blacklist = [
-        ["Tensor<[12, 50, 50]> self = ?", "int dim = -1", "bool half_to_float = False"],
-        ["Tensor<[16, 7, 7]> self = ?", "int dim = -1", "bool half_to_float = False"],
-    ]
+def guard_aten(blocklist, node):
     inputs = get_inputs(node)
     inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
+    if inputs_str in blocklist:
         return False
     return True
 
 
-def aten__unsafe_view_default(node):
-    # TODO: find root cause
-    blacklist = [
-        ["Tensor<[1, 50, 12, 64]> self = ?", "List[int] size = [1, 50, 768]"],
-        ["Tensor<[2, 7, 8, 64]> self = ?", "List[int] size = [2, 7, 512]"],
-    ]
-    inputs = get_inputs(node)
-    inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
-        return False
-    return True
-
-
-def aten_view_default(node):
-    # TODO: find root cause
-    blacklist = [
-        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, -1, 12, 64]"],
-        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, 50, 12, 64]"],
-        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, -1, 8, 64]"],
-        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, 7, 8, 64]"],
-        ["Tensor<[1, 50, 12, 64]> self = ?", "List[int] size = [1, 50, 768]"],
-        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, -1, 12, 64]"],
-        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, 50, 12, 64]"],
-        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, -1, 8, 64]"],
-        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, 7, 8, 64]"],
-        ["Tensor<[2, 7, 8, 64]> self = ?", "List[int] size = [2, 7, 512]"],
-    ]
-    inputs = get_inputs(node)
-    inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
-        return False
-    return True
-
-
-def aten_embedding_dense_backward_default(node):
-    # TODO: find root cause
-    blacklist = [
-        [
-            "Tensor<[1, 7, 512]> grad_output = ?",
-            "Tensor<[1, 7]> indices = ?",
-            "int num_weights = 77",
-            "int padding_idx = -1",
-            "bool scale_grad_by_freq = False",
-        ],
-        [
-            "Tensor<[2, 7, 512]> grad_output = ?",
-            "Tensor<[2, 7]> indices = ?",
-            "int num_weights = 49408",
-            "int padding_idx = -1",
-            "bool scale_grad_by_freq = False",
-        ],
-        [
-            "Tensor<[1, 50, 768]> grad_output = ?",
-            "Tensor<[1, 50]> indices = ?",
-            "int num_weights = 50",
-            "int padding_idx = -1",
-            "bool scale_grad_by_freq = False",
-        ],
-    ]
-    inputs = get_inputs(node)
-    inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
-        return False
-    return True
-
-
-def blocked_aten_mul_tensor(node):
-    # TODO: block all input variations from CLIP eval, find root cause
-    blacklist = [
-        ["Tensor<[1, 50, 768]> self = ?", "Tensor other = 0.125"],
-        ["Tensor<[1, 50, 3072]> self = ?", "Tensor other = 1.702"],
-        ["Tensor<[1, 50, 3072]> self = ?", "Tensor<[1, 50, 3072]> other = ?"],
-        ["Tensor<[2, 7, 512]> self = ?", "Tensor other = 0.125"],
-        ["Tensor<[2, 7, 2048]> self = ?", "Tensor other = 1.702"],
-        ["Tensor<[2, 7, 2048]> self = ?", "Tensor<[2, 7, 2048]> other = ?"],
-        ["Tensor<[2, 1]> self = ?", "Tensor<[]> other = ?"],
-    ]
-    inputs = get_inputs(node)
-    inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
-        return False
-    return True
-
-
-def blocked_aten_view_default(node):
-    # TODO: block all input variations from CLIP eval, find root cause
-    blacklist = [
-        ["Tensor<[1, 768, 7, 7]> self = ?", "List[int] size = [1, 768, 49]"],
-        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [50, 768]"],
-        ["Tensor<[50, 768]> self = ?", "List[int] size = [1, 50, 768]"],
-        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, -1, 12, 64]"],
-        ["Tensor<[1, 50, 768]> self = ?", "List[int] size = [1, 50, 12, 64]"],
-        ["Tensor<[1, 12, 50, 64]> self = ?", "List[int] size = [12, -1, 64]"],
-        ["Tensor<[12, 50, 64]> self = ?", "List[int] size = [1, 12, 50, 64]"],
-        ["Tensor<[50, 3072]> self = ?", "List[int] size = [1, 50, 3072]"],
-        ["Tensor<[1, 50, 3072]> self = ?", "List[int] size = [50, 3072]"],
-        ["Tensor<[2, 7]> self = ?", "List[int] size = [-1, 7]"],
-        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [14, 512]"],
-        ["Tensor<[14, 512]> self = ?", "List[int] size = [2, 7, 512]"],
-        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, -1, 8, 64]"],
-        ["Tensor<[2, 7, 512]> self = ?", "List[int] size = [2, 7, 8, 64]"],
-        ["Tensor<[2, 8, 7, 64]> self = ?", "List[int] size = [16, -1, 64]"],
-        ["Tensor<[16, 7, 7]> self = ?", "List[int] size = [2, 8, 7, 7]"],
-        ["Tensor<[2, 8, 7, 7]> self = ?", "List[int] size = [16, 7, 7]"],
-        ["Tensor<[16, 7, 64]> self = ?", "List[int] size = [2, 8, 7, 64]"],
-        ["Tensor<[14, 2048]> self = ?", "List[int] size = [2, 7, 2048]"],
-        ["Tensor<[2, 7, 2048]> self = ?", "List[int] size = [14, 2048]"],
-    ]
-    inputs = get_inputs(node)
-    inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
-        return False
-    return True
-
-
-def blocked_aten__to_copy_default(node):
-    # TODO: block all input variations from CLIP eval, find root cause
-    blacklist = [
-        ["Tensor<[1, 3, 224, 224]> self = ?", "Optional[int] dtype = torch.bfloat16"],
-        ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
-        ["Tensor<[2, 1, 7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
-        ["Tensor<[2, 1, 7, 7]> self = ?", "Optional[int] dtype = torch.bool"],
-        ["Tensor<[2, 7]> self = ?", "Optional[int] dtype = torch.int32", "Optional[Device] device = cpu"],
-    ]
-    inputs = get_inputs(node)
-    inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
-        return False
-    return True
-
-
-def blocked_aten_native_layer_norm_default(node):
-    # TODO: block all input variations from CLIP eval, find root cause
-    blacklist = [
-        [
-            "Tensor<[1, 50, 768]> input = ?",
-            "List[int] normalized_shape = [768]",
-            "Optional[Tensor]<[768]> weight = ?",
-            "Optional[Tensor]<[768]> bias = ?",
-            "float eps = 1e-05",
-        ],
-        [
-            "Tensor<[1, 768]> input = ?",
-            "List[int] normalized_shape = [768]",
-            "Optional[Tensor]<[768]> weight = ?",
-            "Optional[Tensor]<[768]> bias = ?",
-            "float eps = 1e-05",
-        ],
-        [
-            "Tensor<[2, 7, 512]> input = ?",
-            "List[int] normalized_shape = [512]",
-            "Optional[Tensor]<[512]> weight = ?",
-            "Optional[Tensor]<[512]> bias = ?",
-            "float eps = 1e-05",
-        ],
-    ]
-    inputs = get_inputs(node)
-    inputs_str = [str(i) for i in inputs]
-    if inputs_str in blacklist:
-        return False
-    return True
-
-
-OPLIST = {
-    torch.ops.aten.exp.default: aten_exp_default,
-    torch.ops.aten.expand.default: aten_expand_default,
-    torch.ops.aten.full.default: aten_full_default,
-    torch.ops.aten.rsub.Scalar: aten_rsub_scalar,
-    torch.ops.aten.slice.Tensor: aten_slice_tensor,
-    torch.ops.aten.t.default: aten_t_default,
-    torch.ops.aten.transpose.int: aten_transpose_int,
-    torch.ops.aten._softmax.default: aten__softmax_default,
-    torch.ops.aten._unsafe_view.default: aten__unsafe_view_default,
-    # TODO: With CLIP model of eval mode, these four ops are passed in single op tests
-    # but failed in model tests, and because don't know which input variation caused the model
-    # failed, so block all input variations of these ops
-    torch.ops.aten.mul.Tensor: blocked_aten_mul_tensor,
-    torch.ops.aten.view.default: blocked_aten_view_default,
-    torch.ops.aten._to_copy.default: blocked_aten__to_copy_default,
-    torch.ops.aten.native_layer_norm.default: blocked_aten_native_layer_norm_default,
+GUARD = {
+    torch.ops.aten.permute.default: partial(guard_aten, aten_permute_default_blocklist),
+    torch.ops.aten.view.default: partial(guard_aten, aten_view_default_blocklist),
+    torch.ops.aten._unsafe_view.default: partial(guard_aten, aten__unsafe_view_default_blocklist),
+    torch.ops.aten.add.Tensor: partial(guard_aten, aten_add_Tensor_blocklist),
+    torch.ops.aten.clamp.default: partial(guard_aten, aten_clamp_default_blocklist),
+    torch.ops.aten.maximum.default: partial(guard_aten, aten_maximum_default_blocklist),
+    torch.ops.aten._log_softmax.default: partial(guard_aten, aten__log_softmax_default_blocklist),
+    torch.ops.aten.expand.default: partial(guard_aten, aten_expand_default_blocklist),
+    torch.ops.aten.full.default: partial(guard_aten, aten_full_default_blocklist),
+    torch.ops.aten.rsub.Scalar: partial(guard_aten, aten_rsub_Scalar_blocklist),
+    torch.ops.aten.addmm.default: partial(guard_aten, aten_addmm_default_blocklist),
+    torch.ops.aten._scaled_dot_product_flash_attention.default: partial(
+        guard_aten, aten__scaled_dot_product_flash_attention_default_blocklist
+    ),
+    torch.ops.aten.transpose.int: partial(guard_aten, aten_transpose_int_blocklist),
+    torch.ops.aten.embedding.default: partial(guard_aten, aten_embedding_default_blocklist),
+    torch.ops.aten.zeros_like.default: partial(guard_aten, aten_zeros_like_default_blocklist),
+    torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
+    torch.ops.aten.mul.Tensor: partial(guard_aten, aten_mul_Tensor_blocklist),
+    torch.ops.aten.slice.Tensor: partial(guard_aten, aten_slice_Tensor_blocklist),
+    torch.ops.aten.native_layer_norm.default: partial(guard_aten, aten_native_layer_norm_default_blocklist),
+    torch.ops.aten.sub.Tensor: partial(guard_aten, aten_sub_Tensor_blocklist),
+    torch.ops.aten.exp.default: partial(guard_aten, aten_exp_default_blocklist),
+    torch.ops.aten.split.Tensor: partial(guard_aten, aten_split_Tensor_blocklist),
+    torch.ops.aten.t.default: partial(guard_aten, aten_t_default_blocklist),
+    torch.ops.aten.ones.default: partial(guard_aten, aten_ones_default_blocklist),
+    torch.ops.aten.where.self: partial(guard_aten, aten_where_self_blocklist),
+    torch.ops.aten.empty.memory_format: partial(guard_aten, aten_empty_memory_format_blocklist),
+    # Add for pass CLIP eval
+    torch.ops.aten._to_copy.default: partial(guard_aten, aten__to_copy_default_blocklist),
 }
 
 
 def can_lowering_to_ttnn(node):
-    if node.target in OPLIST:
-        return OPLIST[node.target](node)
+    if node.target in GUARD:
+        return GUARD[node.target](node)
 
     return True


### PR DESCRIPTION
### Ticket
#320 

### Problem description
see #320

### What's changed
 - Implement `tools/generate_guard_function_from_input_var_metric.py` to parse failed cases from `metrics-input-variations/` folder and export `to_tt_guard.py`
 - Update `to_tt_guard.py`
   - The `metrics-input-variations/` data used is downloaded from [this pipeline](https://github.com/tenstorrent/pytorch2.0_ttnn/actions/runs/11378530820), specifically from `model-input-variations-tests-metrics` artifact
   - The failed threshold is set with ["run", "accuracy"], which mean a case is considered failed if either these checks fail:
     - run: failed to run compiled model
     - accuracy: the accuracy between original and compiled model is not close

I will check how many model tests pass and remove its `compilation_xfail` for the next PR
