### PR TITLE
Model test value type set to bf16

### DIFF
--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -13,7 +13,7 @@ class ThisTester(ModelTester):
         # Load the MobileNetV2 model with updated API
         self.weights = models.MobileNet_V2_Weights.DEFAULT
         model = models.mobilenet_v2(weights=self.weights)
-        return model
+        return model.to(torch.bfloat16)
 
     def _load_inputs(self):
         # Define a transformation to preprocess the input image using the weights transforms
@@ -24,14 +24,13 @@ class ThisTester(ModelTester):
         image = Image.open(requests.get(url, stream=True).raw)
         img_t = preprocess(image)
         batch_t = torch.unsqueeze(img_t, 0)
-        return batch_t
+        return batch_t.to(torch.bfloat16)
 
 
 @pytest.mark.parametrize(
     "mode",
     ["eval"],
 )
-@pytest.mark.compilation_xfail
 def test_MobileNetV2(record_property, mode):
     model_name = "MobileNetV2"
     record_property("model_name", model_name)

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -8,10 +8,10 @@ from tests.utils import ModelTester
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return AlbertForMaskedLM.from_pretrained(self.model_name)
+        return AlbertForMaskedLM.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
 
     def _load_inputs(self):
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.text = "The capital of [MASK] is Paris."
         self.inputs = self.tokenizer(self.text, return_tensors="pt")
         return self.inputs

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -8,11 +8,11 @@ from tests.utils import ModelTester
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = AlbertForQuestionAnswering.from_pretrained(self.model_name)
+        model = AlbertForQuestionAnswering.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.question, self.text = "Who was Jim Henson?", "Jim Henson was a nice puppet"
         inputs = self.tokenizer(self.question, self.text, return_tensors="pt")
         return inputs

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -8,10 +8,10 @@ from tests.utils import ModelTester
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return AlbertForSequenceClassification.from_pretrained(self.model_name)
+        return AlbertForSequenceClassification.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
 
     def _load_inputs(self):
-        self.tokenizer = AlbertTokenizer.from_pretrained(self.model_name)
+        self.tokenizer = AlbertTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.input_text = "Hello, my dog is cute."
         self.inputs = self.tokenizer(self.input_text, return_tensors="pt")
         return self.inputs

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -8,10 +8,10 @@ from tests.utils import ModelTester
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        return AlbertForTokenClassification.from_pretrained(self.model_name)
+        return AlbertForTokenClassification.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
 
     def _load_inputs(self):
-        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.text = "HuggingFace is a company based in Paris and New York."
         self.inputs = self.tokenizer(self.text, add_special_tokens=False, return_tensors="pt")
         return self.inputs

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -3,23 +3,23 @@
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         checkpoint = "Salesforce/codegen-350M-mono"
-        model = AutoModelForCausalLM.from_pretrained(checkpoint)
+        model = AutoModelForCausalLM.from_pretrained(checkpoint, torch_dtype=torch.bfloat16)
         self.tokenizer = AutoTokenizer.from_pretrained(checkpoint)
-        return model
+        return model.generate
 
     def _load_inputs(self):
         text = "def hello_world():"
         inputs = self.tokenizer(text, return_tensors="pt")
         return inputs
 
-    def run_model(self, model, inputs):
-        completion = model.generate(**inputs)
-        return completion
+    def set_model_eval(self, model):
+        return model
 
 
 @pytest.mark.parametrize(

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -13,7 +13,7 @@ class ThisTester(ModelTester):
         The model is from https://github.com/facebookresearch/detr
         """
         # Model
-        model = torch.hub.load("facebookresearch/detr:main", "detr_resnet50", pretrained=True)
+        model = torch.hub.load("facebookresearch/detr:main", "detr_resnet50", pretrained=True).to(torch.bfloat16)
         return model
 
     def _load_inputs(self):
@@ -28,7 +28,7 @@ class ThisTester(ModelTester):
             ]
         )
         input_tensor = preprocess(input_image)
-        input_batch = input_tensor.unsqueeze(0)
+        input_batch = input_tensor.unsqueeze(0).to(torch.bfloat16)
         return input_batch
 
 

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -7,7 +7,7 @@ from tests.utils import ModelTester
 class ThisTester(ModelTester):
     def _load_model(self):
         self.tokenizer = DistilBertTokenizer.from_pretrained(self.model_name)
-        model = DistilBertModel.from_pretrained(self.model_name)
+        model = DistilBertModel.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -3,12 +3,13 @@
 from transformers import DPRReader, DPRReaderTokenizer
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         self.tokenizer = DPRReaderTokenizer.from_pretrained("facebook/dpr-reader-single-nq-base")
-        model = DPRReader.from_pretrained("facebook/dpr-reader-single-nq-base")
+        model = DPRReader.from_pretrained("facebook/dpr-reader-single-nq-base", torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -3,21 +3,21 @@
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         self.tokenizer = AutoTokenizer.from_pretrained("google/flan-t5-small")
-        model = AutoModelForSeq2SeqLM.from_pretrained("google/flan-t5-small")
-        return model
+        model = AutoModelForSeq2SeqLM.from_pretrained("google/flan-t5-small", torch_dtype=torch.bfloat16)
+        return model.generate
 
     def _load_inputs(self):
         inputs = self.tokenizer("A step by step recipe to make bolognese pasta:", return_tensors="pt")
         return inputs
 
-    def run_model(self, model, inputs):
-        outputs = model.generate(**inputs)
-        return outputs
+    def set_model_eval(self, model):
+        return model
 
 
 @pytest.mark.parametrize(

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -10,7 +10,7 @@ from tests.utils import ModelTester
 class ThisTester(ModelTester):
     def _load_model(self):
         self.processor = GLPNImageProcessor.from_pretrained("vinvino02/glpn-kitti")
-        model = GLPNForDepthEstimation.from_pretrained("vinvino02/glpn-kitti")
+        model = GLPNForDepthEstimation.from_pretrained("vinvino02/glpn-kitti", torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):
@@ -18,6 +18,7 @@ class ThisTester(ModelTester):
         self.image = Image.open(requests.get(url, stream=True).raw)
         # prepare image for the model
         inputs = self.processor(images=self.image, return_tensors="pt")
+        inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
         return inputs
 
 
@@ -45,7 +46,7 @@ def test_glpn_kitti(record_property, mode):
         )
 
         # visualize the prediction
-        output = prediction.squeeze().cpu().numpy()
+        output = prediction.squeeze().cpu().to(float).numpy()
         formatted = (output * 255 / np.max(output)).astype("uint8")
         depth = Image.fromarray(formatted)
 

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -3,13 +3,14 @@
 from transformers import GPTNeoForCausalLM, GPT2Tokenizer
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = GPTNeoForCausalLM.from_pretrained("EleutherAI/gpt-neo-125M")
+        model = GPTNeoForCausalLM.from_pretrained("EleutherAI/gpt-neo-125M", torch_dtype=torch.bfloat16)
         self.tokenizer = GPT2Tokenizer.from_pretrained("EleutherAI/gpt-neo-125M")
-        return model
+        return model.generate
 
     def _load_inputs(self):
         prompt = (
@@ -22,9 +23,8 @@ class ThisTester(ModelTester):
         arguments = {"input_ids": input_ids, "do_sample": True, "temperature": 0.9, "max_length": 100}
         return arguments
 
-    def run_model(self, model, inputs):
-        gen_tokens = model.generate(**inputs)
-        return gen_tokens
+    def set_model_eval(self, model):
+        return model
 
 
 @pytest.mark.parametrize(

--- a/tests/models/llama/test_llama.py
+++ b/tests/models/llama/test_llama.py
@@ -35,7 +35,6 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.compilation_xfail
 def test_llama(record_property, mode):
     model_name = "Llama"
     record_property("model_name", model_name)

--- a/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
+++ b/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
@@ -10,12 +10,13 @@ import pytest
 from tests.utils import ModelTester
 
 
+# TODO: RuntimeError: "nms_kernel" not implemented for 'BFloat16'
 class ThisTester(ModelTester):
     def _load_model(self):
         model = torchvision.models.detection.ssdlite320_mobilenet_v3_large(
             weights=torchvision.models.detection.SSDLite320_MobileNet_V3_Large_Weights.DEFAULT
         )
-        return model
+        return model  # .to(torch.bfloat16)
 
     def _load_inputs(self):
         # Image preprocessing
@@ -24,7 +25,7 @@ class ThisTester(ModelTester):
         transform = transforms.Compose([transforms.Resize((320, 320)), transforms.ToTensor()])
         img_tensor = [transform(image).unsqueeze(0)]
         batch_tensor = torch.cat(img_tensor, dim=0)
-        return batch_tensor
+        return batch_tensor  # .to(torch.bfloat16)
 
 
 @pytest.mark.parametrize(

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -9,7 +9,7 @@ class ThisTester(ModelTester):
     def _load_model(self):
         self.processor = AutoProcessor.from_pretrained("facebook/musicgen-small")
         model = MusicgenForConditionalGeneration.from_pretrained("facebook/musicgen-small")
-        return model
+        return model.generate
 
     def _load_inputs(self):
         inputs = self.processor(
@@ -21,9 +21,8 @@ class ThisTester(ModelTester):
         inputs["max_new_tokens"] = 256
         return inputs
 
-    def run_model(self, model, inputs):
-        audio_values = model.generate(**inputs)
-        return audio_values
+    def set_model_eval(self, model):
+        return model
 
 
 @pytest.mark.parametrize(

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -8,9 +8,9 @@ from tests.utils import ModelTester
 
 class ThisTester(ModelTester):
     def _load_model(self):
-        model = OPTForCausalLM.from_pretrained("facebook/opt-350m")
+        model = OPTForCausalLM.from_pretrained("facebook/opt-350m", torch_dtype=torch.bfloat16)
         self.tokenizer = GPT2Tokenizer.from_pretrained("facebook/opt-350m")
-        return model
+        return model.generate
 
     def _load_inputs(self):
         prompt = (
@@ -25,9 +25,8 @@ class ThisTester(ModelTester):
         model_inputs["do_sample"] = False
         return model_inputs
 
-    def run_model(self, model, inputs):
-        generated_ids = model.generate(**inputs)
-        return generated_ids
+    def set_model_eval(self, model):
+        return model
 
 
 @pytest.mark.parametrize(

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -3,12 +3,13 @@
 from transformers import PerceiverTokenizer, PerceiverForMaskedLM
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         self.tokenizer = PerceiverTokenizer.from_pretrained("deepmind/language-perceiver")
-        model = PerceiverForMaskedLM.from_pretrained("deepmind/language-perceiver")
+        model = PerceiverForMaskedLM.from_pretrained("deepmind/language-perceiver", torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -9,7 +9,7 @@ from tests.utils import ModelTester
 class ThisTester(ModelTester):
     def _load_model(self):
         self.tokenizer = AutoTokenizer.from_pretrained("FacebookAI/xlm-roberta-base")
-        model = XLMRobertaForMaskedLM.from_pretrained("FacebookAI/xlm-roberta-base")
+        model = XLMRobertaForMaskedLM.from_pretrained("FacebookAI/xlm-roberta-base", torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):

--- a/tests/models/speecht5_tts/test_speecht5_tts.py
+++ b/tests/models/speecht5_tts/test_speecht5_tts.py
@@ -10,15 +10,15 @@ from tests.utils import ModelTester
 class ThisTester(ModelTester):
     def _load_model(self):
         self.processor = SpeechT5Processor.from_pretrained("microsoft/speecht5_tts")
-        model = SpeechT5ForTextToSpeech.from_pretrained("microsoft/speecht5_tts")
-        self.vocoder = SpeechT5HifiGan.from_pretrained("microsoft/speecht5_hifigan")
-        return model
+        model = SpeechT5ForTextToSpeech.from_pretrained("microsoft/speecht5_tts", torch_dtype=torch.bfloat16)
+        self.vocoder = SpeechT5HifiGan.from_pretrained("microsoft/speecht5_hifigan", torch_dtype=torch.bfloat16)
+        return model.generate_speech
 
     def _load_inputs(self):
         inputs = self.processor(text="Hello, my dog is cute.", return_tensors="pt")
         # load xvector containing speaker's voice characteristics from a dataset
         embeddings_dataset = load_dataset("Matthijs/cmu-arctic-xvectors", split="validation")
-        speaker_embeddings = torch.tensor(embeddings_dataset[7306]["xvector"]).unsqueeze(0)
+        speaker_embeddings = torch.tensor(embeddings_dataset[7306]["xvector"]).unsqueeze(0).to(torch.bfloat16)
         arguments = {
             "input_ids": inputs["input_ids"],
             "speaker_embeddings": speaker_embeddings,
@@ -27,12 +27,7 @@ class ThisTester(ModelTester):
         return arguments
 
     def set_model_eval(self, model):
-        model.eval()
         return model
-
-    def run_model(self, model, inputs):
-        speech = model.generate_speech(**inputs)
-        return speech
 
 
 @pytest.mark.parametrize(

--- a/tests/models/stable_diffusion/test_stable_diffusion_v2.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_v2.py
@@ -10,7 +10,9 @@ class ThisTester(ModelTester):
         # Load the pre-trained model and tokenizer
         self.tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14")
         self.text_encoder = CLIPTextModel.from_pretrained("openai/clip-vit-large-patch14")
-        unet = UNet2DConditionModel.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="unet")
+        unet = UNet2DConditionModel.from_pretrained(
+            "CompVis/stable-diffusion-v1-4", subfolder="unet", torch_dtype=torch.bfloat16
+        )
         self.scheduler = LMSDiscreteScheduler.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="scheduler")
         return unet
 
@@ -34,7 +36,11 @@ class ThisTester(ModelTester):
 
         # Get the model's predicted noise
         latent_model_input = self.scheduler.scale_model_input(latents, 0)
-        arguments = {"sample": latent_model_input, "timestep": 0, "encoder_hidden_states": text_embeddings}
+        arguments = {
+            "sample": latent_model_input.to(torch.bfloat16),
+            "timestep": 0,
+            "encoder_hidden_states": text_embeddings.to(torch.bfloat16),
+        }
         return arguments
 
 

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -1,22 +1,22 @@
 from transformers import T5Tokenizer, T5ForConditionalGeneration
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         self.tokenizer = T5Tokenizer.from_pretrained(self.model_name)
-        model = T5ForConditionalGeneration.from_pretrained(self.model_name)
-        return model
+        model = T5ForConditionalGeneration.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
+        return model.generate
 
     def _load_inputs(self):
         self.input_text = "translate English to French: How are you?"
         input_ids = self.tokenizer.encode(self.input_text, return_tensors="pt")
         return input_ids
 
-    def run_model(self, model, inputs):
-        output_ids = model.generate(inputs)
-        return output_ids
+    def set_model_eval(self, model):
+        return model
 
 
 @pytest.mark.parametrize(

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -34,38 +34,36 @@ class ThisTester(ModelTester):
         return input_batch
 
 
-model_list = [
-    "tf_efficientnet_lite0.in1k",
-    "tf_efficientnet_lite1.in1k",
-    "tf_efficientnet_lite2.in1k",
-    "tf_efficientnet_lite3.in1k",
-    "tf_efficientnet_lite4.in1k",
-    "ghostnet_100.in1k",
-    "ghostnetv2_100.in1k",
-    "inception_v4.tf_in1k",
-    "mixer_b16_224.goog_in21k",
-    "mobilenetv1_100.ra4_e3600_r224_in1k",
-    "ese_vovnet19b_dw.ra_in1k",
-    "xception71.tf_in1k",
-    "dla34.in1k",
-    "hrnet_w18.ms_aug_in1k",
+model_and_mode_list = [
+    pytest.param(["tf_efficientnet_lite0.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite1.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite2.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite3.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite4.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["ghostnet_100.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["ghostnetv2_100.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    ["inception_v4.tf_in1k", "train"],
+    pytest.param(["mixer_b16_224.goog_in21k", "train"], marks=pytest.mark.compilation_xfail),
+    ["mobilenetv1_100.ra4_e3600_r224_in1k", "train"],
+    ["ese_vovnet19b_dw.ra_in1k", "train"],
+    ["xception71.tf_in1k", "train"],
+    ["dla34.in1k", "train"],
+    pytest.param(["hrnet_w18.ms_aug_in1k", "train"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite0.in1k", "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite1.in1k", "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite2.in1k", "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite3.in1k", "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param(["tf_efficientnet_lite4.in1k", "eval"], marks=pytest.mark.compilation_xfail),
+    ["ghostnet_100.in1k", "eval"],
+    pytest.param(["ghostnetv2_100.in1k", "eval"], marks=pytest.mark.compilation_xfail),
+    ["inception_v4.tf_in1k", "eval"],
+    ["mixer_b16_224.goog_in21k", "eval"],
+    ["mobilenetv1_100.ra4_e3600_r224_in1k", "eval"],
+    ["ese_vovnet19b_dw.ra_in1k", "eval"],
+    ["xception71.tf_in1k", "eval"],
+    ["dla34.in1k", "eval"],
+    pytest.param(["hrnet_w18.ms_aug_in1k", "eval"], marks=pytest.mark.compilation_xfail),
 ]
-mode_list = ["train", "eval"]
-model_and_mode_list = []
-for model in model_list:
-    for mode in mode_list:
-        if (
-            (model == "ghostnet_100.in1k" and mode == "eval")
-            or (model == "inception_v4.tf_in1k")
-            or (model == "mixer_b16_224.goog_in21k" and mode == "eval")
-            or (model == "mobilenetv1_100.ra4_e3600_r224_in1k")
-            or (model == "ese_vovnet19b_dw.ra_in1k")
-            or (model == "xception71.tf_in1k")
-            or (model == "dla34.in1k")
-        ):
-            model_and_mode_list.append([model, mode])
-        else:
-            model_and_mode_list.append(pytest.param([model, mode], marks=pytest.mark.compilation_xfail))
 
 
 @pytest.mark.usefixtures("manage_dependencies")

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -19,7 +19,7 @@ class ThisTester(ModelTester):
     def _load_model(self):
         model_name, weights_name = self.model_info
         self.weights = getattr(models, weights_name).DEFAULT
-        model = models.get_model(model_name, weights=self.weights)
+        model = models.get_model(model_name, weights=self.weights).to(torch.bfloat16)
         return model
 
     def _load_inputs(self):
@@ -28,81 +28,64 @@ class ThisTester(ModelTester):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
         img_t = preprocess(image)
-        batch_t = torch.unsqueeze(img_t, 0)
+        batch_t = torch.unsqueeze(img_t, 0).to(torch.bfloat16)
         return batch_t
 
 
-model_info_list = [
-    ("googlenet", "GoogLeNet_Weights"),
-    ("densenet121", "DenseNet121_Weights"),
-    ("densenet161", "DenseNet161_Weights"),
-    ("densenet169", "DenseNet169_Weights"),
-    ("densenet201", "DenseNet201_Weights"),
-    ("mobilenet_v2", "MobileNet_V2_Weights"),
-    ("mobilenet_v3_small", "MobileNet_V3_Small_Weights"),
-    ("mobilenet_v3_large", "MobileNet_V3_Large_Weights"),
-    ("resnet18", "ResNet18_Weights"),
-    ("resnet34", "ResNet34_Weights"),
-    ("resnet50", "ResNet50_Weights"),
-    ("resnet101", "ResNet101_Weights"),
-    ("resnet152", "ResNet152_Weights"),
-    ("resnext50_32x4d", "ResNeXt50_32X4D_Weights"),
-    ("resnext101_32x8d", "ResNeXt101_32X8D_Weights"),
-    ("resnext101_64x4d", "ResNeXt101_64X4D_Weights"),
-    ("vgg11", "VGG11_Weights"),
-    ("vgg11_bn", "VGG11_BN_Weights"),
-    ("vgg13", "VGG13_Weights"),
-    ("vgg13_bn", "VGG13_BN_Weights"),
-    ("vgg16", "VGG16_Weights"),
-    ("vgg16_bn", "VGG16_BN_Weights"),
-    ("vgg19", "VGG19_Weights"),
-    ("vgg19_bn", "VGG19_BN_Weights"),
-    ("vit_b_16", "ViT_B_16_Weights"),
-    ("vit_b_32", "ViT_B_32_Weights"),
-    ("vit_l_16", "ViT_L_16_Weights"),
-    ("vit_l_32", "ViT_L_32_Weights"),
-    ("vit_h_14", "ViT_H_14_Weights"),
-    ("wide_resnet50_2", "Wide_ResNet50_2_Weights"),
-    ("wide_resnet101_2", "Wide_ResNet101_2_Weights"),
-    ("regnet_y_400mf", "RegNet_Y_400MF_Weights"),
-    ("regnet_y_800mf", "RegNet_Y_800MF_Weights"),
-    ("regnet_y_1_6gf", "RegNet_Y_1_6GF_Weights"),
-    ("regnet_y_3_2gf", "RegNet_Y_3_2GF_Weights"),
-    ("regnet_y_8gf", "RegNet_Y_8GF_Weights"),
-    ("regnet_y_16gf", "RegNet_Y_16GF_Weights"),
-    ("regnet_y_32gf", "RegNet_Y_32GF_Weights"),
-    ("regnet_y_128gf", "RegNet_Y_128GF_Weights"),
-    ("regnet_x_400mf", "RegNet_X_400MF_Weights"),
-    ("regnet_x_800mf", "RegNet_X_800MF_Weights"),
-    ("regnet_x_1_6gf", "RegNet_X_1_6GF_Weights"),
-    ("regnet_x_3_2gf", "RegNet_X_3_2GF_Weights"),
-    ("regnet_x_8gf", "RegNet_X_8GF_Weights"),
-    ("regnet_x_16gf", "RegNet_X_16GF_Weights"),
-    ("regnet_x_32gf", "RegNet_X_32GF_Weights"),
-    ("swin_t", "Swin_T_Weights"),
-    ("swin_s", "Swin_S_Weights"),
-    ("swin_b", "Swin_B_Weights"),
-    ("swin_v2_t", "Swin_V2_T_Weights"),
-    ("swin_v2_s", "Swin_V2_S_Weights"),
-    ("swin_v2_b", "Swin_V2_B_Weights"),
+model_info_and_mode_list = [
+    [("googlenet", "GoogLeNet_Weights"), "eval"],
+    [("densenet121", "DenseNet121_Weights"), "eval"],
+    [("densenet161", "DenseNet161_Weights"), "eval"],
+    [("densenet169", "DenseNet169_Weights"), "eval"],
+    [("densenet201", "DenseNet201_Weights"), "eval"],
+    [("mobilenet_v2", "MobileNet_V2_Weights"), "eval"],
+    [("mobilenet_v3_small", "MobileNet_V3_Small_Weights"), "eval"],
+    [("mobilenet_v3_large", "MobileNet_V3_Large_Weights"), "eval"],
+    [("resnet18", "ResNet18_Weights"), "eval"],
+    [("resnet34", "ResNet34_Weights"), "eval"],
+    [("resnet50", "ResNet50_Weights"), "eval"],
+    [("resnet101", "ResNet101_Weights"), "eval"],
+    [("resnet152", "ResNet152_Weights"), "eval"],
+    [("resnext50_32x4d", "ResNeXt50_32X4D_Weights"), "eval"],
+    [("resnext101_32x8d", "ResNeXt101_32X8D_Weights"), "eval"],
+    [("resnext101_64x4d", "ResNeXt101_64X4D_Weights"), "eval"],
+    pytest.param([("vgg11", "VGG11_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("vgg11_bn", "VGG11_BN_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("vgg13", "VGG13_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("vgg13_bn", "VGG13_BN_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("vgg16", "VGG16_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("vgg16_bn", "VGG16_BN_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("vgg19", "VGG19_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("vgg19_bn", "VGG19_BN_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    [("vit_b_16", "ViT_B_16_Weights"), "eval"],
+    [("vit_b_32", "ViT_B_32_Weights"), "eval"],
+    [("vit_l_16", "ViT_L_16_Weights"), "eval"],
+    [("vit_l_32", "ViT_L_32_Weights"), "eval"],
+    [("vit_h_14", "ViT_H_14_Weights"), "eval"],
+    [("wide_resnet50_2", "Wide_ResNet50_2_Weights"), "eval"],
+    [("wide_resnet101_2", "Wide_ResNet101_2_Weights"), "eval"],
+    [("regnet_y_400mf", "RegNet_Y_400MF_Weights"), "eval"],
+    [("regnet_y_800mf", "RegNet_Y_800MF_Weights"), "eval"],
+    [("regnet_y_1_6gf", "RegNet_Y_1_6GF_Weights"), "eval"],
+    [("regnet_y_3_2gf", "RegNet_Y_3_2GF_Weights"), "eval"],
+    [("regnet_y_8gf", "RegNet_Y_8GF_Weights"), "eval"],
+    [("regnet_y_16gf", "RegNet_Y_16GF_Weights"), "eval"],
+    [("regnet_y_32gf", "RegNet_Y_32GF_Weights"), "eval"],
+    [("regnet_y_128gf", "RegNet_Y_128GF_Weights"), "eval"],
+    [("regnet_x_400mf", "RegNet_X_400MF_Weights"), "eval"],
+    [("regnet_x_800mf", "RegNet_X_800MF_Weights"), "eval"],
+    [("regnet_x_1_6gf", "RegNet_X_1_6GF_Weights"), "eval"],
+    [("regnet_x_3_2gf", "RegNet_X_3_2GF_Weights"), "eval"],
+    [("regnet_x_8gf", "RegNet_X_8GF_Weights"), "eval"],
+    [("regnet_x_16gf", "RegNet_X_16GF_Weights"), "eval"],
+    [("regnet_x_32gf", "RegNet_X_32GF_Weights"), "eval"],
+    pytest.param([("swin_t", "Swin_T_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("swin_s", "Swin_S_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("swin_b", "Swin_B_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("swin_v2_t", "Swin_V2_T_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("swin_v2_s", "Swin_V2_S_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
+    pytest.param([("swin_v2_b", "Swin_V2_B_Weights"), "eval"], marks=pytest.mark.compilation_xfail),
 ]
-mode_list = ["eval"]
-
-model_info_and_mode_list = []
-
-for model_info in model_info_list:
-    for mode in mode_list:
-        model_name = model_info[0]
-        if (
-            model_name == "vit_b_16"
-            or model_name == "vit_b_32"
-            or model_name == "vit_h_14"
-            or model_name == "vit_l_16"
-            or model_name == "vit_l_32"
-        ):
-            model_info_and_mode_list.append([model_info, mode])
-        else:
-            model_info_and_mode_list.append(pytest.param([model_info, mode], marks=pytest.mark.compilation_xfail))
 
 
 @pytest.mark.parametrize("model_info_and_mode", model_info_and_mode_list)

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -6,6 +6,7 @@ import pytest
 from tests.utils import ModelTester
 
 
+# TODO: RuntimeError: "nms_kernel" not implemented for 'BFloat16'
 class ThisTester(ModelTester):
     # pass model_info instead of model_name
     def __init__(self, model_info, mode):
@@ -19,7 +20,7 @@ class ThisTester(ModelTester):
     def _load_model(self):
         model_name, weights_name = self.model_info
         self.weights = getattr(models.detection, weights_name).DEFAULT
-        model = getattr(models.detection, model_name)(weights=self.weights)
+        model = getattr(models.detection, model_name)(weights=self.weights)  # .to(torch.bfloat16)
         return model
 
     def _load_inputs(self):
@@ -28,7 +29,7 @@ class ThisTester(ModelTester):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
         img_t = preprocess(image)
-        batch_t = torch.unsqueeze(img_t, 0)
+        batch_t = torch.unsqueeze(img_t, 0)  # .to(torch.bfloat16)
         return batch_t
 
 

--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -5,12 +5,13 @@ import requests
 from PIL import Image
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         self.processor = ViltProcessor.from_pretrained("dandelin/vilt-b32-finetuned-vqa")
-        model = ViltForQuestionAnswering.from_pretrained("dandelin/vilt-b32-finetuned-vqa")
+        model = ViltForQuestionAnswering.from_pretrained("dandelin/vilt-b32-finetuned-vqa", torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):
@@ -20,6 +21,7 @@ class ThisTester(ModelTester):
         text = "How many cats are there?"
         # prepare inputs
         encoding = self.processor(image, text, return_tensors="pt")
+        encoding["pixel_values"] = encoding["pixel_values"].to(torch.bfloat16)
         return encoding
 
 

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -2,15 +2,16 @@ from transformers import WhisperProcessor, WhisperForConditionalGeneration
 from datasets import load_dataset
 import pytest
 from tests.utils import ModelTester
+import torch
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         # load model and processor
-        self.processor = WhisperProcessor.from_pretrained("openai/whisper-small")
-        model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-small")
+        self.processor = WhisperProcessor.from_pretrained("openai/whisper-small", torch_dtype=torch.bfloat16)
+        model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-small", torch_dtype=torch.bfloat16)
         model.config.forced_decoder_ids = None
-        return model
+        return model.generate
 
     def _load_inputs(self):
         # load dummy dataset and read audio files
@@ -19,14 +20,17 @@ class ThisTester(ModelTester):
         input_features = self.processor(
             sample["array"], sampling_rate=sample["sampling_rate"], return_tensors="pt"
         ).input_features
-        return input_features
+        return input_features.to(torch.bfloat16)
 
     def run_model(self, model, input_features):
         # generate token ids
-        predicted_ids = model.generate(input_features)
+        predicted_ids = model(input_features)
         # decode token ids to text
         transcription = self.processor.batch_decode(predicted_ids, skip_special_tokens=True)
         return transcription
+
+    def set_model_eval(self, model):
+        return model
 
 
 @pytest.mark.parametrize(

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -11,7 +11,7 @@ from tests.utils import ModelTester
 class ThisTester(ModelTester):
     def _load_model(self):
         self.tokenizer = XGLMTokenizer.from_pretrained("facebook/xglm-564M")
-        model = XGLMForCausalLM.from_pretrained("facebook/xglm-564M")
+        model = XGLMForCausalLM.from_pretrained("facebook/xglm-564M", torch_dtype=torch.bfloat16)
         return model
 
     def _load_inputs(self):

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -15,9 +15,7 @@ class ThisTester(ModelTester):
         self.image_processor = AutoImageProcessor.from_pretrained(
             model_name,
         )
-        m = AutoModelForObjectDetection.from_pretrained(
-            model_name,
-        )
+        m = AutoModelForObjectDetection.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return m
 
     def _load_inputs(self):
@@ -25,6 +23,7 @@ class ThisTester(ModelTester):
         self.test_input = "http://images.cocodataset.org/val2017/000000039769.jpg"
         self.image = Image.open(requests.get(self.test_input, stream=True).raw)
         inputs = self.image_processor(images=self.image, return_tensors="pt")
+        inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
         return inputs
 
 

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -33,7 +33,7 @@ class ThisTester(ModelTester):
                 map_location=torch.device("cpu"),
             )
         )
-        return model
+        return model.to(torch.bfloat16)
 
     def _load_inputs(self):
         # Image preprocessing
@@ -41,7 +41,7 @@ class ThisTester(ModelTester):
         image = Image.open(requests.get(image_url, stream=True).raw)
         transform = transforms.Compose([transforms.Resize((512, 512)), transforms.ToTensor()])
         img_tensor = [transform(image).unsqueeze(0)]
-        batch_tensor = torch.cat(img_tensor, dim=0)
+        batch_tensor = torch.cat(img_tensor, dim=0).to(torch.bfloat16)
         return batch_tensor
 
 

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -75,7 +75,7 @@ class ThisTester(ModelTester):
             os.remove(downloaded_file)
 
         subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "-y", "opencv-python-headless"])
-        return model
+        return model.to(torch.bfloat16)
 
     def _load_inputs(self):
         # Image preprocessing
@@ -84,7 +84,7 @@ class ThisTester(ModelTester):
         transform = transforms.Compose([transforms.Resize((512, 512)), transforms.ToTensor()])
         img_tensor = [transform(image).unsqueeze(0)]
         batch_tensor = torch.cat(img_tensor, dim=0)
-        return batch_tensor
+        return batch_tensor.to(torch.bfloat16)
 
 
 @pytest.mark.parametrize(
@@ -92,7 +92,6 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.usefixtures("manage_dependencies")
-@pytest.mark.compilation_xfail
 def test_yolov5(record_property, mode):
     model_name = "YOLOv5"
     record_property("model_name", model_name)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
ttnn op is support bf16 type, so if the model not set to bf16, its weight may be float type, then the ttnn op will failed.

There still many model test not set to bf16 type, so set it to bf16 type

### What's changed
 - Model test value type set to bf16
 - Fix model test script which inference method is using model.generate
 - After model set to bf16, some test pass (almost from torchvision). Now the pass rate become `52.6% (80/152)`
