### PR TITLE
Leverage CI running time of autogen-op test 

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -91,7 +91,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: model-tests-metrics-group-${{ matrix.group }}
-          merge-multiple: true
           path: metrics/
 
   model-autogen-op-tests:
@@ -108,10 +107,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/common_repo_setup
 
-      - name: Download Metrics Artifacts for Generate Input Variations Tests
+      - name: Download All Metrics Artifacts for Generate Input Variations Tests
         uses: actions/download-artifact@v4
         with:
-          pattern: model-tests-metrics-group-${{ matrix.group }}
+          pattern: model-tests-metrics-group-*
+          merge-multiple: true
           path: metrics/
       - name: Run Model Input Variations Tests
         run: |
@@ -123,20 +123,13 @@ jobs:
             echo "Failed to generate input variation test : exit code $exit_code.";
             exit 1;  # Fail the workflow for other errors
           fi
-          python3 -m pytest --github-report tests/autogen-op -s
+          python3 -m pytest --github-report tests/autogen-op/ --splits 40 --group ${{ matrix.group }} -s
           exit_code=$?  # Capture the exit code, but ignore any errors for now.
           ls -l
           cd metrics-autogen-op
           ls -l
           cd ..
           exit 0;
-
-      - name: Upload Input Variations Tests Artifact
-        if: success()  # Only run if tests passed
-        uses: actions/upload-artifact@v4
-        with:
-          name: model-autogen-op-tests-group-${{ matrix.group }}
-          path: tests/autogen-op/
 
       - name: Upload Input Variations Metrics Artifact
         if: success()  # Only run if tests passed
@@ -161,19 +154,33 @@ jobs:
           merge-multiple: true
           path: metrics/
 
-      - name: Download All Input Variations Tests Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: model-autogen-op-tests-group-*
-          merge-multiple: true
-          path: tests/autogen-op/
-
       - name: Download All Input Variations Metrics Artifacts
         uses: actions/download-artifact@v4
         with:
           pattern: model-autogen-op-tests-metrics-group-*
           merge-multiple: true
           path: metrics-autogen-op/
+
+      - name: Generate Model Input Variations Tests
+        run: |
+          set +e
+          rm -rf tests/autogen-op/
+          python3 tools/generate_input_variation_test_from_models.py
+          exit_code=$?  # Capture the exit code
+          if [ $exit_code -ne 0 ]; then
+            echo "Failed to generate input variation test : exit code $exit_code.";
+            exit 1;  # Fail the workflow for other errors
+          fi
+          python3 tools/generate_input_variation_test_from_models.py --merge=True
+          exit_code=$?  # Capture the exit code
+          if [ $exit_code -ne 0 ]; then
+            echo "Failed to generate input variation test all : exit code $exit_code.";
+            exit 1;  # Fail the workflow for other errors
+          fi
+          cd metrics-autogen-op
+          ls -l
+          cd ..
+          exit 0;
 
       - name: Upload Metrics Artifact
         if: success()  # Only run if tests passed
@@ -269,8 +276,7 @@ jobs:
       - name: Download All Input Variations Tests Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: model-autogen-op-tests-group-*
-          merge-multiple: true
+          pattern: model-autogen-op-tests
           path: tests/autogen-op/
 
       - name: Collect Metrics Report

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+import argparse
 
 tmp = Path(os.path.abspath(__file__))
 sys.path.append(str(tmp.parent.parent))
@@ -12,20 +13,20 @@ class AtenOpTestExporter(InputVarPerOp):
         result = template.replace("{" + key + "}", replacement)
         return result
 
-    def export_tests(self, template_path: Path, basedir: Path, model_name: str):
+    def export_tests(self, template_path: Path, basedir: Path, model_name: str, model_name_: str):
         # undo _join_br
         def _unjoin_br(str_br: str):
             return str_br.split(",<br>")
 
         sort_by_opname = dict(sorted(self.items()))
-        mdoel_name = basedir.parts[-1]
         basedir.mkdir(parents=True, exist_ok=True)
         for opname, inputs_variations in sort_by_opname.items():
             inputs_strings = [_unjoin_br(input_variations) for input_variations in inputs_variations.keys()]
             opname_ = opname.replace(".", "_")
             metrics_dir = f"metrics-autogen-op/{model_name}"
             metrics_filename = opname
-            filename = f"test_{mdoel_name}_{opname_}.py"
+            model_name_ = model_name_.replace("/", "_")
+            filename = f"test_{model_name_}_{opname_}.py"
             with open(template_path, "r") as f:
                 text = f.read()
             text = self.render_string(text, "opname", opname)
@@ -34,12 +35,19 @@ class AtenOpTestExporter(InputVarPerOp):
             text = self.render_string(text, "metrics_filename", metrics_filename)
             with open(basedir / filename, "w") as f:
                 f.write(text)
+        os.system(f"pre-commit run --files {basedir}/* > /dev/null")
 
 
 # Generate input variation tests only contain single op, it will
 #  - check the graph has been rewritten and contain ttnn ops
 #  - check inference result
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--merge", type=bool, default=False)
+    args = parser.parse_args()
+
+    if args.merge:
+        all_exporter = AtenOpTestExporter()
     template_path = os.path.dirname(os.path.abspath(__file__)) + "/aten_test.tmpl"
 
     # Assumed directory structure example. Some files will not exist if test failed.
@@ -63,13 +71,20 @@ if __name__ == "__main__":
     all_model_paths = sorted([Path(dirpath) for dirpath, dirnames, filenames in os.walk("metrics") if not dirnames])
 
     for model_path in all_model_paths:
-        # Remove the "metrics" root directory and convert to string
-        model = str(Path(*model_path.parts[1:]))
-        model_ = model.replace(" ", "_").replace("(", "").replace(")", "")
-
         # Only collect input variations from original models
         original_schema_metrics_path = model_path / "original-schema_list.pickle"
         original_schema_metrics = load_pickle(original_schema_metrics_path) or {}
+        if not original_schema_metrics:
+            continue
         input_var_per_op = AtenOpTestExporter(original_schema_metrics, compiled_schema_metrics={})
-        input_var_per_op.export_tests(template_path, Path(f"tests/autogen-op/{model_}"), model)
-        os.system(f"pre-commit run --files tests/autogen-op/{model_}/* > /dev/null")
+
+        # Remove the "metrics" root directory and convert to string
+        model = str(Path(*model_path.parts[1:]))
+        model_ = model.replace(" ", "_").replace("(", "").replace(")", "").replace(".", "_")
+
+        if not args.merge:
+            input_var_per_op.export_tests(template_path, Path(f"tests/autogen-op/{model_}"), model, model_)
+        else:
+            all_exporter.merge(input_var_per_op)
+    if args.merge:
+        all_exporter.export_tests(template_path, Path(f"tests/autogen-op/ALL"), "ALL", "ALL")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
The `tests/autogen-op/Stable_Diffusion_V2` tests is running in same CI job, but `Stable_Diffusion_V2` spent many time, want to leverage it

### What's changed
 - Original method of autogen-op is split CI job model by model, now change to split op by op, so tests in `tests/autogen-op/Stable_Diffusion_V2` will be dispatch to all 40 job, not only run at same CI job
 - Fix and add feature in `tools/generate_input_variation_test_from_models.py`
### Question
The test scope of autogen-op basically same with model test and it just used in `docs/`, so or I just let autogen-op enable only if `${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_report != 'None'}}` ?