### PR TITLE
Fix generate_input_variation_test_from_models.py

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -91,7 +91,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: model-tests-metrics-group-${{ matrix.group }}
-          merge-multiple: true
           path: metrics/
 
   model-autogen-op-tests:
@@ -112,6 +111,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: model-tests-metrics-group-${{ matrix.group }}
+          merge-multiple: true
           path: metrics/
       - name: Run Model Input Variations Tests
         run: |

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from pathlib import Path
+import argparse
 
 tmp = Path(os.path.abspath(__file__))
 sys.path.append(str(tmp.parent.parent))
@@ -12,20 +13,20 @@ class AtenOpTestExporter(InputVarPerOp):
         result = template.replace("{" + key + "}", replacement)
         return result
 
-    def export_tests(self, template_path: Path, basedir: Path, model_name: str):
+    def export_tests(self, template_path: Path, basedir: Path, model_name: str, model_name_: str):
         # undo _join_br
         def _unjoin_br(str_br: str):
             return str_br.split(",<br>")
 
         sort_by_opname = dict(sorted(self.items()))
-        mdoel_name = basedir.parts[-1]
         basedir.mkdir(parents=True, exist_ok=True)
         for opname, inputs_variations in sort_by_opname.items():
             inputs_strings = [_unjoin_br(input_variations) for input_variations in inputs_variations.keys()]
             opname_ = opname.replace(".", "_")
             metrics_dir = f"metrics-autogen-op/{model_name}"
             metrics_filename = opname
-            filename = f"test_{mdoel_name}_{opname_}.py"
+            model_name_ = model_name_.replace("/", "_")
+            filename = f"test_{model_name_}_{opname_}.py"
             with open(template_path, "r") as f:
                 text = f.read()
             text = self.render_string(text, "opname", opname)
@@ -34,12 +35,19 @@ class AtenOpTestExporter(InputVarPerOp):
             text = self.render_string(text, "metrics_filename", metrics_filename)
             with open(basedir / filename, "w") as f:
                 f.write(text)
+        os.system(f"pre-commit run --files {basedir}/* > /dev/null")
 
 
 # Generate input variation tests only contain single op, it will
 #  - check the graph has been rewritten and contain ttnn ops
 #  - check inference result
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--merge", type=bool, default=False)
+    args = parser.parse_args()
+
+    if args.merge:
+        all_exporter = AtenOpTestExporter()
     template_path = os.path.dirname(os.path.abspath(__file__)) + "/aten_test.tmpl"
 
     # Assumed directory structure example. Some files will not exist if test failed.
@@ -63,13 +71,20 @@ if __name__ == "__main__":
     all_model_paths = sorted([Path(dirpath) for dirpath, dirnames, filenames in os.walk("metrics") if not dirnames])
 
     for model_path in all_model_paths:
-        # Remove the "metrics" root directory and convert to string
-        model = str(Path(*model_path.parts[1:]))
-        model_ = model.replace(" ", "_").replace("(", "").replace(")", "")
-
         # Only collect input variations from original models
         original_schema_metrics_path = model_path / "original-schema_list.pickle"
         original_schema_metrics = load_pickle(original_schema_metrics_path) or {}
+        if not original_schema_metrics:
+            continue
         input_var_per_op = AtenOpTestExporter(original_schema_metrics, compiled_schema_metrics={})
-        input_var_per_op.export_tests(template_path, Path(f"tests/autogen-op/{model_}"), model)
-        os.system(f"pre-commit run --files tests/autogen-op/{model_}/* > /dev/null")
+
+        # Remove the "metrics" root directory and convert to string
+        model = str(Path(*model_path.parts[1:]))
+        model_ = model.replace(" ", "_").replace("(", "").replace(")", "").replace(".", "_")
+
+        if not args.merge:
+            input_var_per_op.export_tests(template_path, Path(f"tests/autogen-op/{model_}"), model, model_)
+        else:
+            all_exporter.merge(input_var_per_op)
+    if args.merge:
+        all_exporter.export_tests(template_path, Path(f"tests/autogen-op/ALL"), "ALL", "ALL")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
for example, `ghostnet_100.in1k.py` is not a legal script name for pytest, fix it to `ghostnet_100_in1k.py`

### What's changed
 - fix `generate_input_variation_test_from_models.py` and add merge feature
 - fix typo of `before_merge.yaml`