### PR TITLE
Fix before_merge

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -233,7 +233,7 @@ jobs:
           fi
 
   push-autogen-op-tests:
-    needs: model-autogen-op-tests
+    needs: model-tests
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_report != 'None'}}
     runs-on: ["in-service"]
     env:
@@ -242,22 +242,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/common_repo_setup
 
-      - name: Remove current autogen-op tests
-        run: |
-          rm -rf tests/autogen_op/
-          exit 0
-
-      - name: Download All Input Variations Tests Artifacts
+      - name: Download All Metrics Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: model-autogen-op-tests-group-*
+          pattern: model-tests-metrics-group-*
           merge-multiple: true
-          path: tests/autogen_op/
+          path: metrics/
 
       - name: Collect Metrics Report
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+          rm -rf tests/autogen_op/ # Remove old tests
+          python3 tools/generate_input_variation_test_from_models.py
+          python3 tools/generate_input_variation_test_from_models.py --merge=True
           echo "Remove these files because it's heavy for running"
           rm -f tests/autogen_op/Stable_Diffusion_V2/test_Stable_Diffusion_V2_aten_convolution_default.py
           rm -f tests/autogen_op/ALL/test_ALL_aten_convolution_default.py

--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -111,8 +111,8 @@ jobs:
       - name: Run Model Input Variations Tests
         run: |
           set +e
-          rm -rf tests/autogen-op/ALL
-          python3 -m pytest --github-report tests/autogen-op -s
+          rm -rf tests/autogen_op/ALL
+          python3 -m pytest --github-report tests/autogen_op --splits 40 --group ${{ matrix.group }} -s
           exit_code=$?  # Capture the exit code, but ignore any errors for now.
           ls -l
           cd metrics-autogen-op

--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -244,7 +244,7 @@ jobs:
 
       - name: Remove current autogen-op tests
         run: |
-          rm -rf tests/autogen-op/
+          rm -rf tests/autogen_op/
           exit 0
 
       - name: Download All Input Variations Tests Artifacts
@@ -252,16 +252,16 @@ jobs:
         with:
           pattern: model-autogen-op-tests-group-*
           merge-multiple: true
-          path: tests/autogen-op/
+          path: tests/autogen_op/
 
       - name: Collect Metrics Report
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           echo "Remove these files because it's heavy for running"
-          rm -f tests/autogen-op/Stable_Diffusion_V2/test_Stable_Diffusion_V2_aten_convolution_default.py
-          rm -f tests/autogen-op/ALL/test_ALL_aten_convolution_default.py
-          rm -f tests/autogen-op/ALL/test_ALL_aten_convolution_backward_default.py
+          rm -f tests/autogen_op/Stable_Diffusion_V2/test_Stable_Diffusion_V2_aten_convolution_default.py
+          rm -f tests/autogen_op/ALL/test_ALL_aten_convolution_default.py
+          rm -f tests/autogen_op/ALL/test_ALL_aten_convolution_backward_default.py
           if [ "${{ github.event.inputs.commit_report }}" == "All" ]; then
             git add --all
           elif [ "${{ github.event.inputs.commit_report }}" == "Tests" ]; then

--- a/tools/generate_guard_function_from_input_var_metric.py
+++ b/tools/generate_guard_function_from_input_var_metric.py
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     template_path = os.path.dirname(os.path.abspath(__file__)) + "/to_tt_guard_autogen.tmpl"
 
     if not os.path.isdir("metrics-autogen-op"):
-        print("metrics-autogen-op directory not found. Please run tests/autogen-op")
+        print("metrics-autogen-op directory not found. Please run tests/autogen_op")
         exit(0)
 
     exporter = GuardFuncExporter(Path("metrics-autogen-op"))

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -83,8 +83,8 @@ if __name__ == "__main__":
         model_ = model.replace(" ", "_").replace("(", "").replace(")", "").replace(".", "_")
 
         if not args.merge:
-            input_var_per_op.export_tests(template_path, Path(f"tests/autogen-op/{model_}"), model, model_)
+            input_var_per_op.export_tests(template_path, Path(f"tests/autogen_op/{model_}"), model, model_)
         else:
             all_exporter.merge(input_var_per_op)
     if args.merge:
-        all_exporter.export_tests(template_path, Path(f"tests/autogen-op/ALL"), "ALL", "ALL")
+        all_exporter.export_tests(template_path, Path(f"tests/autogen_op/ALL"), "ALL", "ALL")


### PR DESCRIPTION
### Ticket
N/A

### Problem description
 - I wrongly push single op test as `tests/autogen_op` (it should be `tests/autogen-op`), but I don't want to rename it again, so edit the script to align `tests/autogen_op`
 - add splits & group to fix model-autogen-op-tests
 - gen single op tests in push-autogen-op-tests

### What's changed
 - Rename `tests/autogen-op` as `tests/autogen_op`
 - Fix model-autogen-op-tests
 - Fix push-autogen-op-tests