### PR TITLE
Simply op report

### DIFF
--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -321,16 +321,24 @@ class InputVarPerOp(defaultdict):
                 na,
             )
 
-        input_vars_dict["Single-native-run"] = []
-        input_vars_dict["Single-run"] = []
-        input_vars_dict["Single-accuracy"] = []
-        input_vars_dict["Single-converted"] = []
+        input_vars_dict["Isolated"] = []
+        input_vars_dict["PCC"] = []
         for input_variation in input_variations:
             single_status = _filter_single_status(opname, input_variation)
-            input_vars_dict["Single-native-run"].append(single_status["native_run"])
-            input_vars_dict["Single-run"].append(single_status["run"])
-            input_vars_dict["Single-accuracy"].append(single_status["accuracy"])
-            input_vars_dict["Single-converted"].append(single_status["convert_to_ttnn"])
+            status = "None"
+            # aten ir should run success, or the single op testcase is illegal
+            if single_status["native_run"] != True:
+                status = "Unknown"
+            # if compiled graph run fail, then the status is failed
+            elif single_status["run"] == False:
+                status = "Failed"
+            # or status is done or fallback according to the convert_to_ttnn
+            elif single_status["run"] == True and single_status["convert_to_ttnn"] == True:
+                status = "Done"
+            elif single_status["run"] == True and single_status["convert_to_ttnn"] == False:
+                status = "Fallback"
+            input_vars_dict["Isolated"].append(status)
+            input_vars_dict["PCC"].append(single_status["accuracy"])
 
     def generate_md_for_input_variations(self) -> str:
         """


### PR DESCRIPTION
### Ticket
N/A

### Problem description
To simpify the report of single op column

### What's changed
mapping old single op column as
```
Isolated:
 Unknown => single-native-run failed
 Fail => single-run failed
 Done => single-run pass & single-converted pass
 Fallback => single-run pass & single-converted failed
 None => Don't have result of single op test

PCC => status of single-accuracy
```
