### PR TITLE
Sequential collect-metrics and push-autogen-op-tests

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -234,7 +234,7 @@ jobs:
           fi
 
   push-autogen-op-tests:
-    needs: model-tests
+    needs: [model-tests, collect-metrics]
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit_report != 'None'}}
     runs-on: ["in-service"]
     env:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`collect-metrics` and `push-autogen-op-tests` all commit data to report, to avoid race condition (if `collect-metrics` push docs after `push-autogen-op-tests`'s "git pull", then will conflict), so sequential them

### What's changed
Sequential `collect-metrics` and `push-autogen-op-tests`
