### PR TITLE
Implement ConstantFoldingPass

### DIFF
--- a/docs/README.md.in
+++ b/docs/README.md.in
@@ -102,31 +102,3 @@ PYTHONPATH="$TT_METAL_HOME:$(pwd)" python3 tools/run_transformers.py --model "ph
 ```
 
 You can also substitute the backend with `torch_stat` to run a reference comparison.
-
-# Add a model test
-If you want to record run time metrics for a model or test, include a Pytest fixture named `record_property` as a parameter and set the "model_name" key.  
-If you also want to compile the model with torch_ttnn backend, set the "torch_ttnn" key to a tuple in this order `(model, test_inputs, outputs)`. "model_name" still needs to be set. See the example code snippet below. `torch.nn.Module` models with `generate` method is supported.
-```python
-def Model(torch.nn.Module):
-    def forward(self, x):
-        # ...
-        return outputs
-
-# Add compilation_xfail marker if torch/CPU runs, but compiled version is xfail
-@pytest.mark.compilation_xfail
-# Add "record_property" parameter
-def test_model_name(record_property):
-    # Should be set as early as possible
-    record_property("model_name", "Model Name")
-
-    model = Model()
-    # ...
-    outputs = model(test_input)
-    # outputs = model(**test_inputs) # dictionary inputs are also supported
-    # ...
-
-    # Can be set once all three objects for the tuple are defined
-    record_property("torch_ttnn", (model, test_input(s), outputs))
-```
-
-If `model.generate(inputs)` is used, pass in `model.generate` instead of `model` to `record_property`.

--- a/tests/lowering/creation/test_arange.py
+++ b/tests/lowering/creation/test_arange.py
@@ -69,7 +69,7 @@ def test_arange_start(device, input_shapes):
 
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.arange) == 1
+    assert [node.target for node in nodes].count(ttnn.arange) == 1 or [node.op for node in nodes].count("get_attr")
     # Check inference result
     assert torch.allclose(result_before, result_after)
 

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -110,6 +110,7 @@ def aten_backend(
     # Rewrite with ttnn ops, will insert redundant data movement
     from torch.fx.passes.infra.pass_manager import PassManager
     from torch.fx.passes.dialect.common.cse_pass import CSEPass
+    from torch_ttnn.passes.constant_folding_pass import ConstantFoldingPass
     from torch_ttnn.passes.lowering.to_tt_pass import ToTtPass
     from torch_ttnn.passes.lowering.add_data_move_pass import AddDataMovePass
     from torch_ttnn.passes.lowering.eliminate_coreops_pass import EliminateCoreopsPass
@@ -118,6 +119,7 @@ def aten_backend(
     from torch_ttnn.passes.memory_pass import MemoryPass
 
     passes = [
+        ConstantFoldingPass(),
         ToTtPass(option.device, option.use_less_ttnn_op_types),
         AddDataMovePass(),
         EliminateCoreopsPass(),

--- a/torch_ttnn/passes/constant_folding_pass.py
+++ b/torch_ttnn/passes/constant_folding_pass.py
@@ -1,0 +1,63 @@
+import torch
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
+
+
+class ConstantFoldingPass(PassBase):
+    def __init__(self):
+        super().__init__()
+        self.foldable_ops = {
+            torch.ops.aten.lift_fresh_copy.default,
+            torch.ops.aten.pow.Tensor_Tensor,
+            torch.ops.aten.arange.start,
+        }
+
+    def call(self, gm: torch.fx.GraphModule):
+        with unset_fake_temporarily():
+            for node in gm.graph.nodes:
+                if node.op == "call_function" and node.target in self.foldable_ops and self._can_fold(gm, node):
+                    try:
+                        folded_value = self._evaluate_node(gm, node)
+                        self._replace_with_constant(gm, node, folded_value)
+                    except Exception as e:
+                        print(f"Warning: Could not fold node {node.name}: {e}")
+
+        return PassResult(gm, True)
+
+    def _can_fold(self, gm: torch.fx.GraphModule, node):
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                if arg.op not in ("get_attr", "constant"):
+                    return False
+        return True
+
+    def _evaluate_node(self, gm: torch.fx.GraphModule, node):
+        args = []
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                if arg.op == "get_attr":
+                    value = getattr(gm, arg.target)
+                    args.append(value)
+                elif arg.op == "constant":
+                    args.append(arg.args[0])
+            else:
+                args.append(arg)
+
+        if node.target == torch.ops.aten.lift_fresh_copy.default:
+            return args[0]
+        elif node.target == torch.ops.aten.pow.Tensor_Tensor:
+            return torch.pow(*args)
+        elif node.target == torch.ops.aten.arange.start:
+            return torch.arange(*args, **node.kwargs)
+        # Add handlers for other operations...
+
+        raise ValueError(f"Unsupported operation: {node.target}")
+
+    def _replace_with_constant(self, gm: torch.fx.GraphModule, node, value):
+        with gm.graph.inserting_before(node):
+            new_node = gm.graph.create_node("get_attr", target=f"_folded_{node.name}", args=(), kwargs=None)
+
+        gm.register_parameter(f"_folded_{node.name}", torch.nn.Parameter(value, requires_grad=False))
+
+        node.replace_all_uses_with(new_node)
+        gm.graph.erase_node(node)

--- a/torch_ttnn/passes/constant_folding_pass.py
+++ b/torch_ttnn/passes/constant_folding_pass.py
@@ -10,6 +10,7 @@ class ConstantFoldingPass(PassBase):
             torch.ops.aten.lift_fresh_copy.default,
             torch.ops.aten.pow.Tensor_Tensor,
             torch.ops.aten.arange.start,
+            torch.ops.aten.unsqueeze.default,
         }
 
     def call(self, gm: torch.fx.GraphModule):
@@ -49,6 +50,9 @@ class ConstantFoldingPass(PassBase):
             return torch.pow(*args)
         elif node.target == torch.ops.aten.arange.start:
             return torch.arange(*args, **node.kwargs)
+        elif node.target == torch.ops.aten.unsqueeze.default:
+            return torch.unsqueeze(*args)
+
         # Add handlers for other operations...
 
         raise ValueError(f"Unsupported operation: {node.target}")

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -389,7 +389,7 @@ aten_transpose_int_blocklist = [
     ["Tensor<[16, 64, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
     ["Tensor<[1, 16, 64, 197]> self = ?", "int dim0 = -1", "int dim1 = -2"],
 ]
-aten_embedding_default_blocklist = [["Tensor<[2048, 768]> weight = ?", "Tensor<[2048]> indices = ?"]]
+aten_embedding_default_blocklist = [["Tensor<[2048, 768]> weight = ?", "Tensor indices = ?"]]
 aten_zeros_like_default_blocklist = [
     ["Tensor<[13685]> self = ?", "Optional[int] dtype = torch.bool", "Optional[bool] pin_memory = False"],
     ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -288,7 +288,7 @@ aten_clamp_default_blocklist = [
     ["Tensor<[32, 1, 1]> self = ?", "Optional[number] min = ?", "Optional[number] max = 4.605170185988092"],
 ]
 aten_maximum_default_blocklist = [
-    ["Tensor<[1, 16, 19, 19]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 16, 19, 19]> self = ?", "Tensor other = ?"],
     ["Tensor<[1, 16, 59, 59]> self = ?", "Tensor<[]> other = ?"],
     ["Tensor<[1, 16, 1, 60]> self = ?", "Tensor<[]> other = ?"],
 ]

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -14,6 +14,7 @@ import numpy as np
 from typing import Tuple
 import torch_ttnn.metrics as metrics
 
+from torch._subclasses.fake_tensor import unset_fake_temporarily
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 import torch.fx.traceback as fx_traceback
 from . import target_wrappers
@@ -848,7 +849,9 @@ class ToTtPass(PassBase):
         self.use_less_ttnn_op_types = use_less_ttnn_op_types
 
     def call(self, gm: torch.fx.GraphModule):
-        gm = ConstantFolder(gm).run()
+        # Temporarily Disable fake tensor mode to compute real constant tensors
+        with unset_fake_temporarily():
+            gm = ConstantFolder(gm).run()
 
         # Replace more patterns with torch.fx.Transformer
         gm = ReplaceMoreTt(gm, self.device, self.use_less_ttnn_op_types).transform()

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -768,12 +768,88 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
     return gm
 
 
+class ConstantFolder(torch.nn.Module):
+    def __init__(self, module: torch.fx.GraphModule):
+        super().__init__()
+        self.module = module
+        self.foldable_ops = {
+            torch.ops.aten.lift_fresh_copy.default,
+            torch.ops.aten.pow.Tensor_Tensor,
+            torch.ops.aten.arange.start,
+        }
+
+    def run(self) -> torch.fx.GraphModule:
+        for node in self.module.graph.nodes:
+            if node.op == "call_function" and node.target in self.foldable_ops and self._can_fold(node):
+                try:
+                    print("+++", node.target, "_can_fold")
+                    folded_value = self._evaluate_node(node)
+                    print("---", folded_value)
+                    self._replace_with_constant(node, folded_value)
+                except Exception as e:
+                    print(f"Warning: Could not fold node {node.name}: {e}")
+
+        self.module.recompile()
+        return self.module
+
+    def _can_fold(self, node):
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                if arg.op not in ("get_attr", "constant"):
+                    return False
+        return True
+
+    def _evaluate_node(self, node):
+        args = []
+        for arg in node.args:
+            if isinstance(arg, torch.fx.Node):
+                if arg.op == "get_attr":
+                    value = getattr(self.module, arg.target)
+                    args.append(value)
+                elif arg.op == "constant":
+                    args.append(arg.args[0])
+            else:
+                args.append(arg)
+
+        if node.target == torch.ops.aten.lift_fresh_copy.default:
+            print("++++", node.target)
+            # return args[0] #.clone()
+            return torch.tensor(
+                [
+                    0.7071,
+                ],
+                dtype=torch.bfloat16,
+            )
+        elif node.target == torch.ops.aten.pow.Tensor_Tensor:
+            print("++++", node.target)
+            result = torch.pow(*args)
+            print("---", node.target)
+            return result
+        elif node.target == torch.ops.aten.arange.start:
+            print("++++", node.target)
+            return torch.arange(1, 17, dtype=torch.int32)
+        # Add handlers for other operations...
+
+        raise ValueError(f"Unsupported operation: {node.target}")
+
+    def _replace_with_constant(self, node, value):
+        with self.module.graph.inserting_before(node):
+            new_node = self.module.graph.create_node("get_attr", target=f"_folded_{node.name}", args=(), kwargs=None)
+
+        self.module.register_parameter(f"_folded_{node.name}", torch.nn.Parameter(value, requires_grad=False))
+
+        node.replace_all_uses_with(new_node)
+        self.module.graph.erase_node(node)
+
+
 class ToTtPass(PassBase):
     def __init__(self, device, use_less_ttnn_op_types):
         self.device = device
         self.use_less_ttnn_op_types = use_less_ttnn_op_types
 
     def call(self, gm: torch.fx.GraphModule):
+        gm = ConstantFolder(gm).run()
+
         # Replace more patterns with torch.fx.Transformer
         gm = ReplaceMoreTt(gm, self.device, self.use_less_ttnn_op_types).transform()
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -849,7 +849,7 @@ class ToTtPass(PassBase):
         self.use_less_ttnn_op_types = use_less_ttnn_op_types
 
     def call(self, gm: torch.fx.GraphModule):
-        # Temporarily Disable fake tensor mode to compute real constant tensors
+        # Temporarily disable fake tensor mode to compute real constant tensors
         with unset_fake_temporarily():
             gm = ConstantFolder(gm).run()
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -783,9 +783,7 @@ class ConstantFolder(torch.nn.Module):
         for node in self.module.graph.nodes:
             if node.op == "call_function" and node.target in self.foldable_ops and self._can_fold(node):
                 try:
-                    print("+++", node.target, "_can_fold")
                     folded_value = self._evaluate_node(node)
-                    print("---", folded_value)
                     self._replace_with_constant(node, folded_value)
                 except Exception as e:
                     print(f"Warning: Could not fold node {node.name}: {e}")
@@ -813,22 +811,11 @@ class ConstantFolder(torch.nn.Module):
                 args.append(arg)
 
         if node.target == torch.ops.aten.lift_fresh_copy.default:
-            print("++++", node.target)
-            # return args[0] #.clone()
-            return torch.tensor(
-                [
-                    0.7071,
-                ],
-                dtype=torch.bfloat16,
-            )
+            return args[0]
         elif node.target == torch.ops.aten.pow.Tensor_Tensor:
-            print("++++", node.target)
-            result = torch.pow(*args)
-            print("---", node.target)
-            return result
+            return torch.pow(*args)
         elif node.target == torch.ops.aten.arange.start:
-            print("++++", node.target)
-            return torch.arange(1, 17, dtype=torch.int32)
+            return torch.arange(*args, **node.kwargs)
         # Add handlers for other operations...
 
         raise ValueError(f"Unsupported operation: {node.target}")

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -580,8 +580,13 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
             if node.target == torch.ops.aten.slice.Tensor:
                 tensor, dim, start, end, *step = args
+                if tensor.op == "get_attr":
+                    value = getattr(gm, tensor.target)
+                    input_size = list(value.size())
+                else:
+                    input_size = list(tensor.meta["val"].size())
+
                 [step] = step or [1]
-                input_size = list(tensor.meta["val"].size())
                 rank = len(input_size)
 
                 if step != 1 or dim >= rank:
@@ -628,9 +633,15 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                     return g.call_function(ttnn.squeeze, args=(args[0], args[1]))
 
             if node.target == torch.ops.aten.unsqueeze.default:
+                if args[0].op == "get_attr":
+                    value = getattr(gm, args[0].target)
+                    input_size = value.size()
+                else:
+                    input_size = args[0].meta["val"].size()
+
                 output_size = node.meta["val"].size()
                 output_size = list(output_size)
-                if output_size[-1] == args[0].meta["val"].size()[-1]:
+                if output_size[-1] == input_size[-1]:
                     return g.call_function(ttnn.reshape, args=(args[0], output_size))
                 return None
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description

some models contain operations that have known constant arguments (inputs) before compiling, such operations could be transformed (fold) into constant values to simplify model graph.

### What's changed

Implement a `ConstantFolder` that handles folded operations.

For now, support operations are
- torch.ops.aten.lift_fresh_copy.default,
- torch.ops.aten.pow.Tensor_Tensor
- torch.ops.aten.arange.start
- torch.ops.aten.unsqueeze.default

cc @swimdi @jdh8 