### PR TITLE
Enable `aten.t.default` conversion for more cases

### DIFF
--- a/tests/lowering/tensor_manipulation/test_transpose.py
+++ b/tests/lowering/tensor_manipulation/test_transpose.py
@@ -1,7 +1,6 @@
 import torch
 import torch_ttnn
 import pytest
-import ttnn
 
 from tests.utils import assert_with_pcc
 
@@ -21,6 +20,11 @@ class TransposeModule(torch.nn.Module):
         # If not, this runtime error will be thrown:
         # RuntimeError: TT_FATAL @ ../tt_metal/impl/buffers/buffer.cpp:41: page_size % sizeof(uint32_t) == 0
         ((5, 3, 2), 0, 2),
+        ((5, 3, 1), 0, 2),
+        ((5, 3, 1), 1, 2),
+        ((5, 3, 1), 0, 1),
+        ((1, 3), 0, 1),
+        pytest.param((3, 1), 1, 0, marks=pytest.mark.xfail(reason="inner-most dim can't be 1 (#377)")),
     ],
 )
 def test_transpose(device, input_shape, dim0, dim1):
@@ -34,8 +38,8 @@ def test_transpose(device, input_shape, dim0, dim1):
     ttnn_result = m.forward(input, dim0, dim1)
     option._out_fx_graphs[0].print_tabular()
 
-    # Check the graph has be rewritten and contain ttnn ops
+    # Check the graph has be rewritten and aten ops are replaced
     nodes = list(option._out_fx_graphs[0].nodes)
-    [node.target for node in nodes].count(ttnn.permute) == 1
+    assert not any(node.target == torch.ops.aten.transpose.int for node in nodes)
     # Check inference result
     assert_with_pcc(torch_result, ttnn_result)

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -538,9 +538,7 @@ aten_mean_dim_blocklist += [["Tensor<[1, 196, 1024]> self = ?", "Optional[List[i
 # function_kwargs = {}
 # RuntimeError: TT_FATAL @ .../buffers/buffer.cpp:41: page_size % sizeof(uint32_t) == 0
 
-aten_t_default_blocklist += [["Tensor<[768, 21843]> self = ?"]]
 # shape=Shape([1[32], 21843[21856]] same issue
-aten_t_default_blocklist += [["Tensor<[1, 21843]> self = ?"]]
 # ttnn.add
 # shape=Shape([1, 196[224], 768])
 aten_add_Tensor_blocklist += [["Tensor<[1, 196, 768]> self = ?", "Tensor<[1, 196, 768]> other = ?"]]

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -509,12 +509,6 @@ aten_split_Tensor_blocklist = [
     ["Tensor<[768]> self = ?", "int split_size = 256"],
     ["Tensor<[1, 7, 2304]> self = ?", "int split_size = 768", "int dim = 2"],
 ]
-aten_t_default_blocklist = [
-    ["Tensor<[12, 3]> self = ?"],
-    ["Tensor<[1, 3]> self = ?"],
-    ["Tensor<[2, 1]> self = ?"],
-    ["Tensor<[512, 1]> self = ?"],
-]
 aten_ones_default_blocklist = [
     [
         "List[int] size = [7, 7]",
@@ -665,7 +659,6 @@ GUARD = {
     torch.ops.aten.sub.Tensor: partial(guard_aten, aten_sub_Tensor_blocklist),
     torch.ops.aten.exp.default: partial(guard_aten, aten_exp_default_blocklist),
     torch.ops.aten.split.Tensor: partial(guard_aten, aten_split_Tensor_blocklist),
-    torch.ops.aten.t.default: partial(guard_aten, aten_t_default_blocklist),
     torch.ops.aten.ones.default: partial(guard_aten, aten_ones_default_blocklist),
     torch.ops.aten.where.self: partial(guard_aten, aten_where_self_blocklist),
     torch.ops.aten.empty.memory_format: partial(guard_aten, aten_empty_memory_format_blocklist),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -634,16 +634,27 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                     return g.call_function(ttnn.reshape, args=(args[0], output_size))
                 return None
 
-            if node.target == torch.ops.aten.transpose.int:
-                dim0 = args[1]
-                dim1 = args[2]
+            if node.target in [torch.ops.aten.transpose.int, torch.ops.aten.t.default]:
                 output_size = node.meta["val"].size()
                 rank = len(output_size)
+                if node.target == torch.ops.aten.t.default:
+                    assert rank >= 0 and rank <= 2, "Input tensor can only be 0D, 1D or 2D"
+                    if rank < 2:
+                        # Less 2D transpose is no-op
+                        return args[0]
+                    dim0 = 0
+                    dim1 = 1
+                else:
+                    dim0 = args[1]
+                    dim1 = args[2]
                 permutation = list(range(rank))
                 permutation[dim0], permutation[dim1] = (
                     permutation[dim1],
                     permutation[dim0],
                 )
+                # TODO(#377): ttnn.permute fails when swapping inner-most dim = 1 for 2D
+                if rank == 2 and output_size[0] == 1:
+                    return None
                 new_nodes = list()
                 new_nodes.append(g.call_function(ttnn.permute, args=(args[0], permutation)))
                 new_nodes[-1].meta["val"] = node.meta["val"]
@@ -651,15 +662,6 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 # TODO(bdrazic): remove workaround when permute issue is fixed https://github.com/tenstorrent/tt-metal/issues/11191
                 new_nodes = workaround_permute_3d_first_out_dim_is_one(g, new_nodes, rank, output_size)
                 return new_nodes[-1]
-
-            if node.target == torch.ops.aten.t.default:
-                permutation = list()
-                rank = len(node.meta["val"].size())
-                assert rank >= 0 and rank <= 2, "Input tensor can only be 0D, 1D or 2D"
-                if rank == 2:
-                    permutation = [1, 0]
-                    return g.call_function(ttnn.permute, args=(args[0], permutation))
-                return None
 
             if node.target == torch.ops.aten.permute.default:
                 new_nodes = list()


### PR DESCRIPTION
### Ticket
#377

### Problem description
Enable `aten.t.default` conversion for more cases and fallback for the issue mentioned in #377

### What's changed
- Explicitly handle unsupported cases in `to_tt_pass.py`
- Remove `aten.t.default` from blocklist
- Add tests to verify support and unsupported cases
