### PR TITLE
Disable gen_graphviz in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ def compile_and_run(device, reset_torch_dynamo, request):
             # Compile model with ttnn backend
             option = torch_ttnn.TorchTtnnOption(
                 device=device,
-                gen_graphviz=True,
+                gen_graphviz=False,
                 run_mem_analysis=False,
                 metrics_path=model_name,
                 verbose=True,


### PR DESCRIPTION
### Ticket
N/A

### Problem description
I need to download `model-tests-metrics` from CI to refresh google sheet report, but its size is 400 MB and spent me 10 min. Most of the size is from the graphviz, I want to disable it to speed up the download time

### What's changed
Disable gen_graphviz in conftest
