### PR TITLE
General conversion for `aten.embedding`

### DIFF
--- a/tests/lowering/embedding/test_embedding.py
+++ b/tests/lowering/embedding/test_embedding.py
@@ -72,8 +72,6 @@ def test_embedding_tile_layout(device, batch_size, sentence_size, vocabulary_siz
     assert torch.allclose(result_before, result_after)
 
 
-# NOTE(bdrazic) This is unit test for embedding layer from SqueezeBERT. Enable when ttnn.embedding supports any input shape.
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "batch_size, sentence_size, vocabulary_size, hidden_embedding_dim",
     [

--- a/tests/lowering/embedding/test_embedding.py
+++ b/tests/lowering/embedding/test_embedding.py
@@ -21,15 +21,12 @@ class EmbeddingTileLayoutModule(torch.nn.Module):
         return torch.nn.functional.embedding(input, weights)
 
 
-# NOTE(kevinwuTT) Re-enable after conversion to ttnn.embedding with both ROW_MAJOR_LAYOUT and TILE_LAYOUT
-@pytest.mark.xfail
 @pytest.mark.parametrize(
     "input_shapes",
     [[((1, 2, 4, 5), (4, 3, 2, 9)), (10, 4)]],
 )
 def test_embedding(device, input_shapes):
     m = EmbeddingModule()
-    input_shapes = m.input_shapes()
     input = torch.tensor(input_shapes[0])
     weight = torch.rand(input_shapes[1], dtype=torch.bfloat16)
     result_before = m.forward(input, weight)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -515,7 +515,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
             if node.target == torch.ops.aten.embedding.default:
                 tiled = args[1].meta["val"].size()[-1] % ttnn.TILE_SIZE == 0
                 layout = TtnnTileLayout() if tiled else TtnnRowMajorLayout()
-                return g.call_function(ttnn.embedding, args=(args[1], args[0]), kwargs={"layout": layout})
+                tensor = g.call_function(ttnn.embedding, args=(args[1], args[0]), kwargs={"layout": layout})
+                return tensor if tiled else g.call_function(ttnn.to_layout, args=(tensor, TtnnTileLayout()))
 
             if node.target == torch.ops.aten._log_softmax.default:
                 softmax_node = g.call_function(

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -515,8 +515,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
             if node.target == torch.ops.aten.embedding.default:
                 tiled = args[1].meta["val"].size()[-1] % ttnn.TILE_SIZE == 0
                 layout = TtnnTileLayout() if tiled else TtnnRowMajorLayout()
-                tensor = g.call_function(ttnn.embedding, args=(args[1], args[0]), kwargs={"layout": layout})
-                return tensor if tiled else g.call_function(ttnn.to_layout, args=(tensor, TtnnTileLayout()))
+                tensor = g.call_function(ttnn.embedding, (args[1], args[0]), {"layout": layout})
+                return tensor if tiled else g.call_function(ttnn.to_layout, (tensor, TtnnTileLayout()))
 
             if node.target == torch.ops.aten._log_softmax.default:
                 softmax_node = g.call_function(


### PR DESCRIPTION
### Ticket
None

### Problem description
For `aten.embedding`, support tensors with innermost dimension not a multiple of the tile.

### What's changed
Keep using tile layout if the size is a multiple of the tile.  Use row-major layout otherwise, for previously unsupported cases.
