### PR TITLE
 Convert `max_pool2d_with_indices.default` to `ttnn.max_pool2d` for some cases

### DIFF
--- a/tests/autogen_op/ALL/test_ALL_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/ALL/test_ALL_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/Autoencoder_conv/test_Autoencoder_conv_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/Autoencoder_conv/test_Autoencoder_conv_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/DETR/test_DETR_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/DETR/test_DETR_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/HardNet/test_HardNet_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/HardNet/test_HardNet_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/Mnist/test_Mnist_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/Mnist/test_Mnist_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/ResNet18/test_ResNet18_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/ResNet18/test_ResNet18_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/ResNet50/test_ResNet50_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/ResNet50/test_ResNet50_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/U-Net/test_U-Net_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/U-Net/test_U-Net_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/Unet-brain/test_Unet-brain_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/Unet-brain/test_Unet-brain_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/Unet-carvana/test_Unet-carvana_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/Unet-carvana/test_Unet-carvana_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/densenet121/test_densenet121_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/densenet121/test_densenet121_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/densenet161/test_densenet161_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/densenet161/test_densenet161_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/densenet169/test_densenet169_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/densenet169/test_densenet169_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/densenet201/test_densenet201_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/densenet201/test_densenet201_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/dla34_in1k/test_dla34_in1k_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/dla34_in1k/test_dla34_in1k_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/ese_vovnet19b_dw_ra_in1k/test_ese_vovnet19b_dw_ra_in1k_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/ese_vovnet19b_dw_ra_in1k/test_ese_vovnet19b_dw_ra_in1k_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/googlenet/test_googlenet_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/googlenet/test_googlenet_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/inception_v4_tf_in1k/test_inception_v4_tf_in1k_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/inception_v4_tf_in1k/test_inception_v4_tf_in1k_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnet101/test_resnet101_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnet101/test_resnet101_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnet152/test_resnet152_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnet152/test_resnet152_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnet18/test_resnet18_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnet18/test_resnet18_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnet34/test_resnet34_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnet34/test_resnet34_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnet50/test_resnet50_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnet50/test_resnet50_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnext101_32x8d/test_resnext101_32x8d_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnext101_32x8d/test_resnext101_32x8d_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnext101_64x4d/test_resnext101_64x4d_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnext101_64x4d/test_resnext101_64x4d_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/resnext50_32x4d/test_resnext50_32x4d_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/resnext50_32x4d/test_resnext50_32x4d_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/retinanet_resnet50_fpn/test_retinanet_resnet50_fpn_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/retinanet_resnet50_fpn/test_retinanet_resnet50_fpn_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/retinanet_resnet50_fpn_v2/test_retinanet_resnet50_fpn_v2_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/retinanet_resnet50_fpn_v2/test_retinanet_resnet50_fpn_v2_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/ssd300_vgg16/test_ssd300_vgg16_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/ssd300_vgg16/test_ssd300_vgg16_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg11/test_vgg11_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg11/test_vgg11_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg11_bn/test_vgg11_bn_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg11_bn/test_vgg11_bn_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg13/test_vgg13_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg13/test_vgg13_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg13_bn/test_vgg13_bn_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg13_bn/test_vgg13_bn_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg16/test_vgg16_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg16/test_vgg16_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg16_bn/test_vgg16_bn_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg16_bn/test_vgg16_bn_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg19/test_vgg19_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg19/test_vgg19_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/vgg19_bn/test_vgg19_bn_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/vgg19_bn/test_vgg19_bn_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/wide_resnet101_2/test_wide_resnet101_2_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/wide_resnet101_2/test_wide_resnet101_2_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/autogen_op/wide_resnet50_2/test_wide_resnet50_2_aten_max_pool2d_with_indices_default.py
+++ b/tests/autogen_op/wide_resnet50_2/test_wide_resnet50_2_aten_max_pool2d_with_indices_default.py
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)
+        return torch.ops.aten.max_pool2d_with_indices.default(*args, **kwargs)[0]
 
 
 metrics = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def input_var_check_ttnn(request):
 
 @pytest.fixture(scope="session")
 def device():
+    # TODO(tt-metal#13746): Currently L1 small size needs to be manually determined
     device = ttnn.open_device(device_id=0, l1_small_size=1024)
     yield device
     ttnn.close_device(device)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ def input_var_check_ttnn(request):
 
 @pytest.fixture(scope="session")
 def device():
-    device = ttnn.open_device(device_id=0)
+    device = ttnn.open_device(device_id=0, l1_small_size=1024)
     yield device
     ttnn.close_device(device)
 

--- a/tests/lowering/pool/test_max_pool_2d.py
+++ b/tests/lowering/pool/test_max_pool_2d.py
@@ -1,7 +1,6 @@
 import torch
 import torch_ttnn
 import pytest
-import ttnn
 
 from tests.utils import assert_with_pcc
 
@@ -14,54 +13,96 @@ class MaxPool2dModule(torch.nn.Module):
         return torch.nn.functional.max_pool2d(*args, **kwargs)
 
 
-@pytest.mark.xfail(reason="We don't support returning indices from max_pool2d yet")
 @pytest.mark.parametrize(
-    "input_shapes, kernel_size, stride, padding, dilation",
+    "input_shapes, kernel_size, stride, padding, dilation, ceil_mode",
     (
-        ((1, 1024, 17, 17), (3, 3), 2, 0, 1),
-        ((1, 128, 112, 112), (2, 2), 2, 0, 1),
-        ((1, 192, 28, 28), (3, 3), 1, 1, 1),  # ceil_mode=True?
-        ((1, 512, 19, 19), (3, 3), 1, 1, 1),
+        ((1, 1024, 17, 17), (3, 3), 2, 0, 1, False),
+        ((1, 128, 112, 112), (2, 2), 2, 0, 1, False),
+        ((1, 512, 19, 19), (3, 3), 1, 1, 1, False),
+        pytest.param(
+            (1, 192, 28, 28),
+            (3, 3),
+            1,
+            1,
+            1,
+            False,
+            marks=pytest.mark.xfail(reason="non-pow-of-2 channel (tt-metal#13901)"),
+        ),
+        pytest.param(
+            (1, 256, 28, 28),
+            (3, 3),
+            1,
+            1,
+            1,
+            True,
+            marks=pytest.mark.xfail(reason="ceil_mode=True is not supported yet (tt-metal#14976)"),
+        ),
+        pytest.param(
+            (1, 64, 360, 640),
+            (3, 3),
+            2,
+            1,
+            1,
+            False,
+            marks=pytest.mark.xfail(reason="OOM (#385)"),
+        ),
+        pytest.param(
+            (1, 4, 14, 14),
+            (2, 2),
+            2,
+            1,
+            1,
+            False,
+            marks=pytest.mark.xfail(reason="channel size is not aligned to L1 page size (#419)"),
+        ),
+        pytest.param(
+            (1, 8, 14, 14),
+            (2, 2),
+            2,
+            1,
+            1,
+            False,
+            marks=pytest.mark.xfail(reason="unknown error (#419)"),
+        ),
     ),
 )
-def test_max_pool_2d_plain(device, input_shapes, kernel_size, stride, padding, dilation):
+def test_max_pool_2d_plain(device, input_shapes, kernel_size, stride, padding, dilation, ceil_mode):
     m = MaxPool2dModule()
     input_tensor = torch.rand(input_shapes, dtype=torch.bfloat16)
-    result_before = m.forward(input_tensor, kernel_size, stride, padding, dilation)
-    option = torch_ttnn.TorchTtnnOption(device=device)
+    result_before = m.forward(input_tensor, kernel_size, stride, padding, dilation, ceil_mode)
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    # ttnn operates on channels-last tensors
-    result_after = m.forward(input_tensor, kernel_size, stride, padding, dilation)
+    result_after = m.forward(input_tensor, kernel_size, stride, padding, dilation, ceil_mode)
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.max_pool2d) == 1
+    # Check the graph has be rewritten and aten ops are replaced
+    assert not any(node.target == torch.ops.aten.max_pool2d_with_indices.default for node in nodes)
     # Check inference result
     assert_with_pcc(result_before, result_after, pcc=0.99)
 
 
+@pytest.mark.xfail(reason="We don't support returning indices from max_pool2d yet")
 @pytest.mark.parametrize(
     "input_shapes, kernel_size",
     [((1, 3, 64, 64), (3, 3))],
 )
 def test_max_pool_2d_with_indices(device, input_shapes, kernel_size):
     m = MaxPool2dModule()
-    inputs = torch.rand(input_shapes, dtype=torch.bfloat16)
-    (pool_before, argmax_before) = m.forward(inputs, kernel_size, return_indices=True)
-    option = torch_ttnn.TorchTtnnOption(device=device)
+    input_tensor = torch.rand(input_shapes, dtype=torch.bfloat16)
+    (pool_before, argmax_before) = m.forward(input_tensor, kernel_size, return_indices=True)
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    # ttnn operates on channels-last tensors
-    input_tensor = torch.permute(inputs, (0, 2, 3, 1))
     (pool_after, argmax_after) = m.forward(input_tensor, kernel_size, return_indices=True)
-    pool_after = torch.permute(pool_after, (0, 3, 1, 2))
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.max_pool2d) == 1
+    # Check the graph has be rewritten and aten ops are replaced
+    assert not any(node.target == torch.ops.aten.max_pool2d_with_indices.default for node in nodes)
     # Check inference result
     assert_with_pcc(pool_before, pool_after, pcc=0.99)
     assert_with_pcc(argmax_before, argmax_after)

--- a/tests/lowering/pool/test_max_pool_2d.py
+++ b/tests/lowering/pool/test_max_pool_2d.py
@@ -1,0 +1,64 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+from tests.utils import assert_with_pcc
+
+
+class MaxPool2dModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *args, **kwargs):
+        return torch.nn.functional.max_pool2d(*args, **kwargs)
+
+
+@pytest.mark.xfail(reason="We don't support returning indices from max_pool2d yet")
+@pytest.mark.parametrize(
+    "input_shapes, kernel_size",
+    [((1, 3, 64, 64), (3, 3))],
+)
+def test_max_pool_2d_plain(device, input_shapes, kernel_size):
+    m = MaxPool2dModule()
+    inputs = torch.rand(input_shapes, dtype=torch.bfloat16)
+    result_before = m.forward(inputs, kernel_size)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    # ttnn operates on channels-last tensors
+    input_tensor = torch.permute(inputs, (0, 2, 3, 1))
+    result_after = m.forward(input_tensor, kernel_size)
+    result_after = torch.permute(result_after, (0, 3, 1, 2))
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.max_pool2d) == 1
+    # Check inference result
+    assert_with_pcc(result_before, result_after, pcc=0.99)
+
+
+@pytest.mark.parametrize(
+    "input_shapes, kernel_size",
+    [((1, 3, 64, 64), (3, 3))],
+)
+def test_max_pool_2d_with_indices(device, input_shapes, kernel_size):
+    m = MaxPool2dModule()
+    inputs = torch.rand(input_shapes, dtype=torch.bfloat16)
+    (pool_before, argmax_before) = m.forward(inputs, kernel_size, return_indices=True)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    # ttnn operates on channels-last tensors
+    input_tensor = torch.permute(inputs, (0, 2, 3, 1))
+    (pool_after, argmax_after) = m.forward(input_tensor, kernel_size, return_indices=True)
+    pool_after = torch.permute(pool_after, (0, 3, 1, 2))
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.max_pool2d) == 1
+    # Check inference result
+    assert_with_pcc(pool_before, pool_after, pcc=0.99)
+    assert_with_pcc(argmax_before, argmax_after)

--- a/tools/aten_test.tmpl
+++ b/tools/aten_test.tmpl
@@ -12,7 +12,7 @@ class AtenModule(torch.nn.Module):
         super().__init__()
 
     def forward(self, *args, **kwargs):
-        return torch.ops.{opname}(*args, **kwargs)
+        return torch.ops.{opname}(*args, **kwargs){extra_accessor}
 
 
 metrics = []

--- a/tools/generate_input_variation_test_from_models.py
+++ b/tools/generate_input_variation_test_from_models.py
@@ -27,12 +27,19 @@ class AtenOpTestExporter(InputVarPerOp):
             metrics_filename = opname
             model_name_ = model_name_.replace("/", "_")
             filename = f"test_{model_name_}_{opname_}.py"
+
+            extra_accessor = ""
+            # TODO(tt-metal#12099): ttnn.max_pool2d currently doesn't return indices so we only check the value for eval
+            if opname == "aten.max_pool2d_with_indices.default" and not model_name.endswith("-train"):
+                extra_accessor = "[0]"
+
             with open(template_path, "r") as f:
                 text = f.read()
             text = self.render_string(text, "opname", opname)
             text = self.render_string(text, "inputs_strings", str(inputs_strings))
             text = self.render_string(text, "metrics_dir", metrics_dir)
             text = self.render_string(text, "metrics_filename", metrics_filename)
+            text = self.render_string(text, "extra_accessor", extra_accessor)
             with open(basedir / filename, "w") as f:
                 f.write(text)
         os.system(f"pre-commit run --files {basedir}/* > /dev/null")

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -125,13 +125,23 @@ TTNN_DATAMOVE_OPS = [
     ttnn.split,
     ttnn.slice,
     ttnn.to_layout,
+    ttnn.sharded_to_interleaved,
 ]
 
-TTNN_TARGET_WRAPPERS = [target_wrappers.clone, target_wrappers.repeat]
+TTNN_TARGET_WRAPPERS = [
+    target_wrappers.clone,
+    target_wrappers.repeat,
+    target_wrappers.pack_to_tuple,
+]
 
 TTNN_NORM_OPS = [
     ttnn.group_norm,
     ttnn.layer_norm,
+]
+
+TTNN_POOL_OPS = [
+    ttnn.global_avg_pool2d,
+    ttnn.max_pool2d,
 ]
 
 TTNN_LAYOUT_CHANGE_OPS = set(
@@ -161,6 +171,7 @@ def is_tt_compute(node) -> bool:
         + TTNN_TARGET_WRAPPERS
         + TTNN_DATAMOVE_OPS
         + TTNN_NORM_OPS
+        + TTNN_POOL_OPS
         + [
             ttnn.embedding,
             ttnn.ones,
@@ -169,7 +180,6 @@ def is_tt_compute(node) -> bool:
             ttnn.zeros_like,
             ttnn.mean,
             ttnn.moreh_cumsum,
-            ttnn.global_avg_pool2d,
             ttnn.clip,
             ttnn.squeeze,
             ttnn.full,

--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -10,3 +10,9 @@ def clone(t):
 @torch.fx.wrap
 def repeat(t, sizes):
     return ttnn.repeat(t, ttnn.Shape(sizes))
+
+
+# Helper function to pack multiple values into a tuple on the graph
+@torch.fx.wrap
+def pack_to_tuple(*args):
+    return tuple(args)


### PR DESCRIPTION
### Ticket
#385

### Problem description
Convert `aten.max_pool2d_with_indices.default` to `ttnn.max_pool2d` for some cases. Unsupported cases and related issues are listed in ##385

### What's changed
- Add conversion from  `aten.max_pool2d_with_indices.default` to `ttnn.max_pool2d`
- Add unit tests
- Update `tools/generate_input_variation_test_from_models.py` and generated tests to only check return value and exclude indices due to [#12099](https://github.com/tenstorrent/tt-metal/issues/12099)

All model tests passed: https://github.com/tenstorrent/pytorch2.0_ttnn/actions/runs/11885828168
