### PR TITLE
Fix docs OP report

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -261,8 +261,6 @@ jobs:
           python3 tools/generate_input_variation_test_from_models.py --merge=True
           echo "Remove these files because it's heavy for running"
           rm -f tests/autogen_op/Stable_Diffusion_V2/test_Stable_Diffusion_V2_aten_convolution_default.py
-          rm -f tests/autogen_op/ALL/test_ALL_aten_convolution_default.py
-          rm -f tests/autogen_op/ALL/test_ALL_aten_convolution_backward_default.py
           if [ "${{ github.event.inputs.commit_report }}" == "All" ]; then
             git add --all
           elif [ "${{ github.event.inputs.commit_report }}" == "Tests" ]; then

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -201,6 +201,8 @@ def call_to_torch_with_meta(g, src_node):
     call_func = g.call_function(ttnn.to_torch, (src_node,))
     if src_node.meta is not None:
         call_func.meta = src_node.meta
+    if "original_input_variations" in call_func.meta:
+        call_func.meta["original_input_variations"] = None
     return call_func
 
 
@@ -220,6 +222,8 @@ def try_call_aten__to_copy_with_meta(g, to_torch_node):
             {"dtype": dtype},
         )
         call_func.meta = to_torch_node.meta
+        if "original_input_variations" in call_func.meta:
+            call_func.meta["original_input_variations"] = None
         return call_func
     else:
         return None


### PR DESCRIPTION
### Ticket
N/A

### Problem description

There's an example element in `metrics/xxx/compiled-schema_list.pickle`
```
{'opname': 'ttnn.add', 
 'original_inputs': {'opname': 'aten.add.Tensor', 'inputs': ['Tensor<[2, 3]> self = ?', 'Tensor<[2, 3]> other = ?']}}
```
And the `collect_metrics.py` will parse it to check whether original aten op is converted to ttnn op

And the code of [`add_data_move_pass.py`](https://github.com/tenstorrent/pytorch2.0_ttnn/blob/a26823e8ab290f5142a2d9417f1cd8b32375e7d7/torch_ttnn/passes/lowering/add_data_move_pass.py#L222)
```
def try_call_aten__to_copy_with_meta(g, to_torch_node):
    # try_add_data_move_in will change dtype to bfloat16
    # so the to_torch's output dtype will be bfloat16, which is incorrect
    # luckly, the meta remain the origin correct dtype
    # so add aten._to_copy(dtype) to correct the dtype
    # TODO: If to_torch can specify dtype, then can merge to_copy on it

    # if user only output, then no need to add
    if hasattr(to_torch_node, "meta") and "val" in to_torch_node.meta and hasattr(to_torch_node.meta["val"], "dtype"):
        dtype = to_torch_node.meta["val"].dtype
        call_func = g.call_function(
            torch.ops.aten._to_copy.default,
            (to_torch_node,),
            {"dtype": dtype},
        )
        call_func.meta = to_torch_node.meta
        return call_func
    else:
        return None
```
will
1. try to generate an `aten._to_copy` node
2. assign the `original_input_variations` from src node to this `aten.to_copy` node with member `meta`

So there will cause this new generated `aten._to_copy` node with the wrong original node info, for example, BERT will have this
```
{'opname': 'aten._to_copy.default', 
 'original_inputs': {'opname': 'aten.unsqueeze.default', 'inputs': ['Tensor<[1, 1, 256]> self = ?', 'int dim = 2']}}
```
(The `aten._to_copy` get the meta from `ttnn.to_torch`, and `ttnn.to_torch` also get the meta from its src node: `aten.reshape`, which converted from `aten.unsqueeze`)

The new generated `aten._to_copy` should not have any original node info because it is the new extra generated node, so in this PR, deassign `original_input_variations` to it

### What's changed
 - Remove `original_input_varations` of `ttnn.to_torch` and `aten._to_copy` because it is the new generated node, not belong to any original input

After this fix, the weired OP status [mentioned in there](https://docs.google.com/presentation/d/1JcY9nivdEZ2mSOwRpTg-bS_veszPGna_OZ_L3kKmpXw/edit#slide=id.g3144bfeba14_0_42) is all gone

 - not remove `tests/autogen_op/ALL/test_ALL_aten_convolution_default.py` because it needs to be tested