### PR TITLE
Fix aten.mean lowering when keep_dim=False

### DIFF
--- a/tests/pattern/test_beit_train_pattern.py
+++ b/tests/pattern/test_beit_train_pattern.py
@@ -1,0 +1,26 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+# Found this bug on beit is aten.mean result shape is [1, 1000] but ttnn.mean result become [1, 1, 1000]
+# Fixed it on the lowering of aten.mean
+class PatternModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, dim):
+        return torch.ops.aten.mean.dim(x, dim)
+
+
+def test_beit_train_pattern(device):
+    m = PatternModule()
+    x = torch.randn([1, 2, 3]).to(torch.bfloat16)
+    dim = [1]
+    result_before = m.forward(x, dim)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(x, dim)
+    assert result_before.shape == result_after.shape
+    assert torch.allclose(result_before, result_after, rtol=0.1, atol=0.1)

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -215,25 +215,9 @@ aten_masked_fill_scalar_blocklist += [
 aten_mul_Tensor_blocklist += [["Tensor<[1, 1]> self = ?", "Tensor other = 50258"]]
 
 ############################################################
-# EXTRA BLOCKLIST OF microsoft/beit-*-patch16-224-train
-############################################################
-# see issue #364
-# microsoft/beit-base-patch16-224
-# self = FastOperation(python_fully_qualified_name='ttnn.permute', ...)
-# function_args = (ttnn.Tensor(<buffer is not allocated>,
-# shape=Shape([1, 1[32], 1000[1024]]), dtype=DataType::BFLOAT16, layout=Layout::TILE), (1, 0))
-# function_kwargs = {}
-# RuntimeError: TT_FATAL @ .../permute.cpp:170: input_rank == dims.size()
-# don't know why block aten.mean can avoid this error
-aten_mean_dim_blocklist = [["Tensor<[1, 196, 768]> self = ?", "Optional[List[int]] dim = [1]"]]
-# microsoft/beit-large-patch16-224: same issue
-aten_mean_dim_blocklist += [["Tensor<[1, 196, 1024]> self = ?", "Optional[List[int]] dim = [1]"]]
-
-############################################################
 
 GUARD[torch.ops.aten.add.Tensor] = partial(guard_aten, aten_add_Tensor_blocklist)
 GUARD[torch.ops.aten._adaptive_avg_pool2d.default] = partial(guard_aten, aten__adaptive_avg_pool2d_default_blocklist)
-GUARD[torch.ops.aten.mean.dim] = partial(guard_aten, aten_mean_dim_blocklist)
 GUARD[torch.ops.aten.view.default] = partial(guard_aten, aten_view_default_blocklist)
 
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -341,10 +341,21 @@ class ReplaceMoreTt(torch.fx.Transformer):
         # Reduction
         ############################################################
         if target == torch.ops.aten.mean.dim:
+            new_args = []
+            new_args.append(args[0])
             # change dim parameter to tuple
-            new_args = list(args)
-            new_args[1] = tuple(args[1]) if len(args[1]) > 1 else args[1][0]
-            return self.call_function_prop_meta(ttnn.mean, tuple(new_args), kwargs)
+            new_args.append(tuple(args[1]) if len(args[1]) > 1 else args[1][0])
+            keep_dim = False
+            if len(args) > 2:
+                keep_dim = args[2]
+            elif "keepdim" in kwargs:
+                keep_dim = kwargs["keepdim"]
+            if keep_dim:
+                return self.call_function_prop_meta(ttnn.mean, tuple(new_args), {})
+            # ttnn.mean does not support keep_dim==False, need reshape to remove dim
+            mean_shape = list(fx_traceback.get_current_meta()["val"].shape)
+            mean = self.call_function_prop_meta(ttnn.mean, tuple(new_args), {})
+            return self.call_function_prop_meta(ttnn.reshape, (mean, mean_shape))
 
         if target == torch.ops.aten.min.default:
             return self.call_function_prop_meta(ttnn.min, args, kwargs)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
ttnn.mean does not support keep_dim=False but aten.mean does. Append reshape to workaround

### What's changed
 - Fix aten.mean lowering when keep_dim=False
 - Remove all `aten_mean_dim_blocklist`
 - Add `test_beit_train_pattern.py` because I found this bug from beit

I'll merge #422 first then this PR