### PR TITLE
Fix `ttnn.embedding` when the shape of `indices` is unknown

### DIFF
--- a/tests/lowering/embedding/test_embedding.py
+++ b/tests/lowering/embedding/test_embedding.py
@@ -48,6 +48,7 @@ def test_embedding(device, input_shapes):
     "batch_size, sentence_size, vocabulary_size, hidden_embedding_dim",
     [
         (8, 384, 250880, 1024),
+        (8, 384, 2048, 768),
     ],
 )
 def test_embedding_tile_layout(device, batch_size, sentence_size, vocabulary_size, hidden_embedding_dim):
@@ -73,6 +74,7 @@ def test_embedding_tile_layout(device, batch_size, sentence_size, vocabulary_siz
     "batch_size, sentence_size, vocabulary_size, hidden_embedding_dim",
     [
         (1, 8, 30528, 768),
+        (1, 8, 2048, 768),
     ],
 )
 def test_embedding_squeezebert(device, batch_size, sentence_size, vocabulary_size, hidden_embedding_dim):

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -236,7 +236,6 @@ aten_transpose_int_blocklist = [
     ["Tensor<[16, 64, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
     ["Tensor<[1, 16, 64, 197]> self = ?", "int dim0 = -1", "int dim1 = -2"],
 ]
-aten_embedding_default_blocklist = [["Tensor<[2048, 768]> weight = ?", "Tensor indices = ?"]]
 aten_zeros_like_default_blocklist = [
     ["Tensor<[13685]> self = ?", "Optional[int] dtype = torch.bool", "Optional[bool] pin_memory = False"],
     ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
@@ -493,7 +492,6 @@ GUARD = {
         guard_aten, aten__scaled_dot_product_flash_attention_default_blocklist
     ),
     torch.ops.aten.transpose.int: partial(guard_aten, aten_transpose_int_blocklist),
-    torch.ops.aten.embedding.default: partial(guard_aten, aten_embedding_default_blocklist),
     torch.ops.aten.zeros_like.default: partial(guard_aten, aten_zeros_like_default_blocklist),
     torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
     torch.ops.aten.mul.Tensor: partial(guard_aten, aten_mul_Tensor_blocklist),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -524,7 +524,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(ttnn.add, args=(beta_node, new_node))
 
             if node.target == torch.ops.aten.embedding.default:
-                tiled = args[1].meta["val"].size()[-1] % ttnn.TILE_SIZE == 0
+                tiled = args[1].meta.get("val")
+                tiled = False if tiled is None else tiled.size()[-1] % ttnn.TILE_SIZE == 0
                 layout = TtnnTileLayout() if tiled else TtnnRowMajorLayout()
                 tensor = g.call_function(ttnn.embedding, (args[1], args[0]), {"layout": layout})
                 return tensor if tiled else g.call_function(ttnn.to_layout, (tensor, TtnnTileLayout()))


### PR DESCRIPTION
### Ticket
Fix a particular case in #407

### Problem description
There is a failing generated test case for conversion to `ttnn.embedding`:
https://github.com/tenstorrent/pytorch2.0_ttnn/blob/8b7d5ce619a6b3d86900cbdbfc1c0d0e33a676c5/torch_ttnn/passes/lowering/to_tt_guard_autogen.py#L239

The argument `indices` does not have a known shape.  This triggered a runtime error.

### What's changed
Gracefully run the untiled algorithm when the shape of `indices` is unknown.