### PR TITLE
Relax unsqueeze

### DIFF
--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -214,11 +214,24 @@ aten_masked_fill_scalar_blocklist += [
 
 aten_mul_Tensor_blocklist += [["Tensor<[1, 1]> self = ?", "Tensor other = 50258"]]
 
+
+############################################################
+# EXTRA BLOCKLIST OF GPTNeo
+############################################################
+# RuntimeError: TT_FATAL @ xxx/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp:110:
+# modified_ends[idx] >= modified_begins[idx]
+
+aten_select_int_blocklist = [["Tensor<[1, 45]> self = ?", "int dim = 1", "int index = -1"]]
+
+# ERROR tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[eval] -
+# RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
+
 ############################################################
 
 GUARD[torch.ops.aten.add.Tensor] = partial(guard_aten, aten_add_Tensor_blocklist)
 GUARD[torch.ops.aten._adaptive_avg_pool2d.default] = partial(guard_aten, aten__adaptive_avg_pool2d_default_blocklist)
 GUARD[torch.ops.aten.view.default] = partial(guard_aten, aten_view_default_blocklist)
+GUARD[torch.ops.aten.select.int] = partial(guard_aten, aten_select_int_blocklist)
 
 
 def can_lowering_to_ttnn(node):


### PR DESCRIPTION
### Ticket
#386 

### Problem description
I was going to support unsqueeze guided by [here](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/386#issuecomment-2479097908), but I found latest tt-metal already support all input variation except zero element num, so I just relax the unsqueeze lowering constraint and it's now fully lowered in llama 

### What's changed
 - Relax lowering constraint of unsqueeze
 - Add guard of GPTNeo
