### PR TITLE
Temporarily disable failing tests

### DIFF
--- a/tests/lowering/creation/test_masked_fill.py
+++ b/tests/lowering/creation/test_masked_fill.py
@@ -85,6 +85,6 @@ class MaskedFillModule(torch.nn.Module):
         # pytest.param((1, 1, 1, s10 + 1), (1, 1, 1, s10 + 1), -3.4028234663852886e+38, marks=pytest.mark.xfail(reason="Input variation shape")),
     ],
 )
-@pytest.mark.skip(reason="TODO")
+@pytest.mark.skip(reason="Temporarily disabled due to #458")
 def test_masked_fill(device, input_shape, mask_shape, fill_value):
     _test_masked_fill_common(device, MaskedFillModule(), input_shape, mask_shape, fill_value)

--- a/tests/lowering/creation/test_masked_fill.py
+++ b/tests/lowering/creation/test_masked_fill.py
@@ -85,5 +85,6 @@ class MaskedFillModule(torch.nn.Module):
         # pytest.param((1, 1, 1, s10 + 1), (1, 1, 1, s10 + 1), -3.4028234663852886e+38, marks=pytest.mark.xfail(reason="Input variation shape")),
     ],
 )
+@pytest.mark.skip(reason="TODO")
 def test_masked_fill(device, input_shape, mask_shape, fill_value):
     _test_masked_fill_common(device, MaskedFillModule(), input_shape, mask_shape, fill_value)

--- a/tests/lowering/pool/test_avg_pool_2d.py
+++ b/tests/lowering/pool/test_avg_pool_2d.py
@@ -18,6 +18,7 @@ class AdaptiveAvgPool2dModule(torch.nn.Module):
     "input_shapes",
     [(1, 2048, 7, 7)],
 )
+@pytest.mark.skip(reason="TODO")
 def test_adaptive_avg_pool_2d(device, input_shapes):
     m = AdaptiveAvgPool2dModule()
     inputs = torch.rand(input_shapes, dtype=torch.bfloat16)

--- a/tests/lowering/pool/test_avg_pool_2d.py
+++ b/tests/lowering/pool/test_avg_pool_2d.py
@@ -18,7 +18,7 @@ class AdaptiveAvgPool2dModule(torch.nn.Module):
     "input_shapes",
     [(1, 2048, 7, 7)],
 )
-@pytest.mark.skip(reason="TODO")
+@pytest.mark.skip(reason="Temporarily disabled due to #458")
 def test_adaptive_avg_pool_2d(device, input_shapes):
     m = AdaptiveAvgPool2dModule()
     inputs = torch.rand(input_shapes, dtype=torch.bfloat16)


### PR DESCRIPTION
### Ticket
#458

### Problem description
Temporarily disable failing tests `test_adaptive_avg_pool_2d` and `test_masked_fill`

### What's changed
- Skip tests of `test_adaptive_avg_pool_2d` and `test_masked_fill`
