### PR TITLE
Implement `torch.ops.aten.sum.default` lowering to `ttnn.sum`

### DIFF
--- a/tests/lowering/misc/test_if.py
+++ b/tests/lowering/misc/test_if.py
@@ -37,7 +37,7 @@ def test_if(device, input_shape):
     # Check the graph has be rewritten and contain ttnn ops
     nodes_0 = list(option._out_fx_graphs[0].nodes)
     target_0 = [node.target for node in nodes_0]
-    assert target_0.count(torch.ops.aten.sum.default) == 1
+    assert target_0.count(ttnn.sum) == 1
     # This `gt` is not converted yet because its shape does not fit tiled layout
     assert target_0.count(torch.ops.aten.gt.Scalar) == 1
     nodes_1 = list(option._out_fx_graphs[1].nodes)

--- a/tests/lowering/misc/test_sum.py
+++ b/tests/lowering/misc/test_sum.py
@@ -1,0 +1,41 @@
+import torch
+import torch_ttnn
+import pytest
+
+from tests.utils import assert_with_pcc
+
+
+class SumModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, tensor):
+        return torch.ops.aten.sum.default(tensor)
+
+
+@pytest.mark.parametrize(
+    "input_shapes",
+    [
+        (1, 20, 30),
+        (1, 20),
+        (1, 1),
+        (1,),
+    ],
+)
+def test_sum(device, input_shapes):
+    m = SumModule()
+    inputs = torch.rand(input_shapes, dtype=torch.bfloat16)
+    result_before = m.forward(inputs)
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=False)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+
+    result_after = m.forward(inputs)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = [node.target for node in option._out_fx_graphs[0].nodes]
+    assert nodes.count(torch.ops.aten.sum.default) == 0
+
+    assert_with_pcc(result_before, result_after, pcc=0.99)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -175,6 +175,7 @@ def is_tt_compute(node) -> bool:
             ttnn.as_tensor,
             ttnn.expand,
             ttnn.moreh_cumsum,
+            ttnn.sum,
         ]
     )
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`torch.ops.aten.sum.default` should be lowering to `ttnn.sum` if possible.

### What's changed
`torch.ops.aten.sum.default` can be replaced by `ttnn.sum` and a `torch.ops.aten.squeeze.default`.

Because `torch.ops.aten.sum.default` will sum out to rank 0 result, an auxiliary `torch.ops.aten.squeeze.default` op is required to reach original result tensor.

- test
```
pytest -s tests/lowering/misc/test_sum.py
```
