### PR TITLE
Update TT-NN to 0.53.0-rc48

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tabulate==0.9.0
 networkx==3.1
 graphviz
 matplotlib==3.7.1
-https://github.com/tenstorrent/tt-metal/releases/download/v0.53.0-rc47/metal_libs-0.53.0rc47+wormhole.b0-cp38-cp38-linux_x86_64.whl
+https://github.com/tenstorrent/tt-metal/releases/download/v0.53.0-rc48/metal_libs-0.53.0rc48+wormhole.b0-cp38-cp38-linux_x86_64.whl


### PR DESCRIPTION
This PR updates TT-NN wheel to the latest pre-release version.