### PR TITLE
Fix `aten.select.int` lowering issue and remove additional `aten._to_copy` op creation

### DIFF
--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -229,7 +229,7 @@ def try_call_aten__to_copy_with_meta(g, to_torch_node, target_users_ops):
     if hasattr(to_torch_node, "meta") and "val" in to_torch_node.meta and hasattr(to_torch_node.meta["val"], "dtype"):
         dtype = to_torch_node.meta["val"].dtype
         # if user only output and output type is float-like, then no need to add
-        if target_users_ops.count("output") and dtype in [torch.float32, torch.float64, torch.bfloat16]:
+        if dtype in [torch.float32, torch.float64, torch.bfloat16]:
             return None
         call_func = g.call_function(
             torch.ops.aten._to_copy.default,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -861,7 +861,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
                 if input_size.numel() != output_size.numel():
                     slice_start, slice_end = [0] * len(input_size), list(input_size)
-                    slice_start[dim], slice_end[dim] = start, start + 1
+                    slice_start[dim] = (start + input_size[dim]) % input_size[dim]
+                    slice_end[dim] = slice_start[dim] + 1
 
                     slice_tensor = g.call_function(ttnn.slice, (tensor, [*slice_start], [*slice_end]))
                 else:


### PR DESCRIPTION
### Ticket
N/A

### Problem description
1. Lowering `aten.select.int` should consider the negative index
2. float type `to_torch` no need to insert additional `aten._to_copy`

### What's changed
1. Lowering `aten.select.int` op will legalize negative index then set to TTNN op.
2. If dtype of  `to_torch` op in is **torch.float32**, **torch.float64**, **torch.bfloat16**, then skip `aten._to_copy` creation.