### PR TITLE
Convert `aten.hardsigmoid` to `ttnn.hardsigmoid`

### DIFF
--- a/tests/lowering/eltwise/unary/test_hardsigmoid.py
+++ b/tests/lowering/eltwise/unary/test_hardsigmoid.py
@@ -1,0 +1,58 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+from tests.utils import assert_with_pcc
+
+
+class HardSigmoidModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return torch.nn.functional.hardsigmoid(x)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    (
+        (1, 72, 1, 1),
+        (1, 120, 1, 1),
+        (1, 480, 1, 1),
+        (1, 672, 1, 1),
+        (1, 256, 1, 1),
+        (1, 512, 1, 1),
+        (1, 768, 1, 1),
+        (1, 1024, 1, 1),
+        (1, 960, 1, 1),
+        (1, 16, 1, 1),
+        (1, 96, 1, 1),
+        (1, 240, 1, 1),
+        (1, 144, 1, 1),
+        (1, 288, 1, 1),
+        (1, 576, 1, 1),
+        (2, 3, 4, 5),
+        (7, 7, 7),
+        (420, 69),
+        pytest.param((1337,), marks=pytest.mark.xfail(reason="1D cases solved in #198, waiting for review")),
+    ),
+)
+def test_hardsigmoid(device, input_shape):
+    m = HardSigmoidModule()
+    input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(input_tensor)
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
+
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input_tensor)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and not contain aten ops
+    targets = (*(node.target for node in option._out_fx_graphs[0].nodes),)
+    assert torch.ops.aten.hardsigmoid.default not in targets
+    assert targets.count(ttnn.hardsigmoid) == 1
+
+    # Check inference result
+    assert_with_pcc(result_before, result_after)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -44,6 +44,7 @@ TTNN_POINTWISE_UNARY_OPS = [
     ttnn.expm1,
     ttnn.floor,
     ttnn.gelu,
+    ttnn.hardsigmoid,
     ttnn.hardtanh,
     ttnn.isinf,
     ttnn.isnan,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -220,6 +220,9 @@ class ReplaceMoreTt(torch.fx.Transformer):
         if target == torch.ops.aten.gelu.default:
             return self.call_function_prop_meta(ttnn.gelu, args, kwargs)
 
+        if target == torch.ops.aten.hardsigmoid.default:
+            return self.call_function_prop_meta(ttnn.hardsigmoid, args, kwargs)
+
         if target == torch.ops.aten.hardtanh.default:
             new_kwargs = map_args_to_kwargs(args, ((1, "min_val"), (2, "max_val")), default_none=True)
             new_args = (args[0],)


### PR DESCRIPTION
### Ticket
- Resolves #480

### Problem description
Compile `aten.hardsigmoid` to `ttnn.sigmoid`:
https://pytorch.org/docs/stable/generated/torch.nn.Sigmoid.html

### What's changed
- [x] Implement the conversion
- [x] Pass auto-generated op test cases
- [x] Pass testing models
- [x] Write op test cases
