### PR TITLE
Use `ttnn.transpose` for aten transpose ops

### DIFF
--- a/tests/lowering/tensor_manipulation/test_aten_t.py
+++ b/tests/lowering/tensor_manipulation/test_aten_t.py
@@ -34,6 +34,7 @@ def _t(device, input_shapes):
 @pytest.mark.parametrize(
     "input_shapes",
     [
+        [(5,)],
         [(1, 32)],
         [(1, 3)],
         [(12, 3)],
@@ -44,19 +45,6 @@ def _t(device, input_shapes):
     ],
 )
 def test_aten_t(device, input_shapes):
-    nodes = _t(device, input_shapes)
-    # Check the graph has be rewritten and aten ops are replaced
-    assert not any(node.target == torch.ops.aten.t.default for node in nodes)
-
-
-@pytest.mark.parametrize(
-    "input_shapes",
-    [
-        [5],
-        [(5)],
-    ],
-)
-def test_aten_t_less_2d(device, input_shapes):
     nodes = _t(device, input_shapes)
     # Check the graph has be rewritten and aten ops are replaced
     assert not any(node.target == torch.ops.aten.t.default for node in nodes)

--- a/tests/lowering/tensor_manipulation/test_aten_t.py
+++ b/tests/lowering/tensor_manipulation/test_aten_t.py
@@ -39,8 +39,8 @@ def _t(device, input_shapes):
         [(12, 3)],
         [(1, 21843)],
         [(768, 21843)],
-        pytest.param((2, 1), marks=pytest.mark.xfail(reason="inner-most dim can't be 1 (#377)")),
-        pytest.param((512, 1), marks=pytest.mark.xfail(reason="inner-most dim can't be 1 (#377)")),
+        [(2, 1)],
+        [(512, 1)],
     ],
 )
 def test_aten_t(device, input_shapes):

--- a/tests/lowering/tensor_manipulation/test_transpose.py
+++ b/tests/lowering/tensor_manipulation/test_transpose.py
@@ -16,15 +16,12 @@ class TransposeModule(torch.nn.Module):
 @pytest.mark.parametrize(
     "input_shape, dim0, dim1",
     [
-        # Constraint: Last dim of input should be even.
-        # If not, this runtime error will be thrown:
-        # RuntimeError: TT_FATAL @ ../tt_metal/impl/buffers/buffer.cpp:41: page_size % sizeof(uint32_t) == 0
         ((5, 3, 2), 0, 2),
         ((5, 3, 1), 0, 2),
         ((5, 3, 1), 1, 2),
         ((5, 3, 1), 0, 1),
         ((1, 3), 0, 1),
-        pytest.param((3, 1), 1, 0, marks=pytest.mark.xfail(reason="inner-most dim can't be 1 (#377)")),
+        ((3, 1), 1, 0),
     ],
 )
 def test_transpose(device, input_shape, dim0, dim1):

--- a/tests/lowering/tensor_manipulation/test_transpose.py
+++ b/tests/lowering/tensor_manipulation/test_transpose.py
@@ -16,6 +16,7 @@ class TransposeModule(torch.nn.Module):
 @pytest.mark.parametrize(
     "input_shape, dim0, dim1",
     [
+        ((32,), 0, 0),
         ((5, 3, 2), 0, 2),
         ((5, 3, 1), 0, 2),
         ((5, 3, 1), 1, 2),

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -118,14 +118,15 @@ TTNN_MATRIX_MULPIPLICATION_OPS = [
 ]
 
 TTNN_DATAMOVE_OPS = [
-    ttnn.reshape,
+    ttnn.concat,
     ttnn.pad,
     ttnn.permute,
-    ttnn.concat,
-    ttnn.split,
-    ttnn.slice,
-    ttnn.to_layout,
+    ttnn.reshape,
     ttnn.sharded_to_interleaved,
+    ttnn.slice,
+    ttnn.split,
+    ttnn.to_layout,
+    ttnn.transpose,
 ]
 
 TTNN_TARGET_WRAPPERS = [

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -707,12 +707,12 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(ttnn.reshape, args=(args[0], output_size))
 
             if node.target in [torch.ops.aten.transpose.int, torch.ops.aten.t.default]:
+                rank = len(node.meta["val"].size())
+                if rank < 2:
+                    # Less 2D transpose is no-op
+                    return args[0]
                 if node.target == torch.ops.aten.t.default:
-                    rank = len(node.meta["val"].size())
-                    assert rank >= 0 and rank <= 2, "Input tensor can only be 0D, 1D or 2D"
-                    if rank < 2:
-                        # Less 2D transpose is no-op
-                        return args[0]
+                    assert rank == 2, "Input tensor should only be 2D here"
                     dim0 = 0
                     dim1 = 1
                 else:

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -707,9 +707,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(ttnn.reshape, args=(args[0], output_size))
 
             if node.target in [torch.ops.aten.transpose.int, torch.ops.aten.t.default]:
-                output_size = node.meta["val"].size()
-                rank = len(output_size)
                 if node.target == torch.ops.aten.t.default:
+                    rank = len(node.meta["val"].size())
                     assert rank >= 0 and rank <= 2, "Input tensor can only be 0D, 1D or 2D"
                     if rank < 2:
                         # Less 2D transpose is no-op
@@ -719,21 +718,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 else:
                     dim0 = args[1]
                     dim1 = args[2]
-                permutation = list(range(rank))
-                permutation[dim0], permutation[dim1] = (
-                    permutation[dim1],
-                    permutation[dim0],
-                )
-                # TODO(#377): ttnn.permute fails when swapping inner-most dim = 1 for 2D
-                if rank == 2 and output_size[0] == 1:
-                    return None
-                new_nodes = list()
-                new_nodes.append(g.call_function(ttnn.permute, args=(args[0], permutation)))
-                new_nodes[-1].meta["val"] = node.meta["val"]
-                # strange workaround when dim 0 is 1 for rank 3
-                # TODO(bdrazic): remove workaround when permute issue is fixed https://github.com/tenstorrent/tt-metal/issues/11191
-                new_nodes = workaround_permute_3d_first_out_dim_is_one(g, new_nodes, rank, output_size)
-                return new_nodes[-1]
+                return g.call_function(ttnn.transpose, args=(args[0], dim0, dim1))
 
             if node.target == torch.ops.aten.permute.default:
                 new_nodes = list()


### PR DESCRIPTION
### Ticket
#439

### Problem description
`ttnn.transpose` has been improved to support all use cases of `aten.t.default` and `aten.tranpose.int`. Use it instead of `ttnn.permute`

### What's changed
- Convert `aten.t.default` and `aten.tranpose.int` into `ttnn.tranpose`
- Enable all tests
