### PR TITLE
Fix push-autogen-op-tests job failed and input variation report the wrong status

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -221,13 +221,14 @@ jobs:
           elif [ "${{ github.event.inputs.commit_report }}" == "Docs" ]; then
             git add README.md
             git add docs/
-          elif [ "${{ github.event.inputs.commit_report }}" == "None" ]; then
+          else
             echo "No files will be committed"
             exit 0
           fi
 
-          if git diff-index --quiet HEAD; then
+          if git diff --cached --quiet; then
             echo "No changes to commit"
+            exit 0
           else
             git commit -m '[auto][on-merge-queue] Update metrics report in README.md'
             git push
@@ -265,12 +266,13 @@ jobs:
             git add --all
           elif [ "${{ github.event.inputs.commit_report }}" == "Tests" ]; then
             git add tests/
-          elif [ "${{ github.event.inputs.commit_report }}" == "None" ]; then
+          else
             echo "No files will be committed"
             exit 0
           fi
-          if git diff-index --quiet HEAD; then
+          if git diff --cached --quiet; then
             echo "No changes to commit"
+            exit 0
           else
             git commit -m '[auto][on-merge-queue] Update input variations tests'
             git push

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -216,7 +216,7 @@ def is_tt(node):
 def call_to_torch_with_meta(g, src_node):
     call_func = g.call_function(ttnn.to_torch, (src_node,))
     if src_node.meta is not None:
-        call_func.meta = src_node.meta
+        call_func.meta = src_node.meta.copy()
     if "original_input_variations" in call_func.meta:
         call_func.meta["original_input_variations"] = None
     return call_func
@@ -239,7 +239,7 @@ def try_call_aten__to_copy_with_meta(g, to_torch_node, target_users_ops):
             (to_torch_node,),
             {"dtype": dtype},
         )
-        call_func.meta = to_torch_node.meta
+        call_func.meta = to_torch_node.meta.copy()
         if "original_input_variations" in call_func.meta:
             call_func.meta["original_input_variations"] = None
         return call_func


### PR DESCRIPTION
### Ticket
N/A

### Problem description
 - In `push-autogen-op-tests`, nothing to commit but run `git push` cause it failed
 - `call_func.meta = src_node.meta` assign the reference so the later `call_func.meta["original_input_variations"] = None` also infect `src_node.meta`, and then it cause input variation report the wrong status

### What's changed
 - Fix `push-autogen-op-tests` job failed if workflow set `Docs`
 - Fix input variation report the wrong status