### PR TITLE
Fix lowering of aten._adaptive_avg_pool2d.default

### DIFF
--- a/tests/pattern/test_vgg_pattern.py
+++ b/tests/pattern/test_vgg_pattern.py
@@ -1,0 +1,27 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class PatternModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, output_size):
+        return torch.ops.aten._adaptive_avg_pool2d.default(input, output_size)
+
+
+def test_vgg_adaptive_avg_pool2d(device):
+    m = PatternModule()
+    input = torch.randn([1, 512, 7, 7]).to(torch.bfloat16)
+    output_size = [7, 7]
+    result_before = m.forward(input, output_size)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, output_size)
+    assert result_before.shape == result_after.shape
+    assert torch.allclose(result_before, result_after, rtol=0.1, atol=0.1)
+    assert not any(
+        node.target == torch.ops.aten._adaptive_avg_pool2d.default for node in option._out_fx_graphs[0].nodes
+    )

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -146,7 +146,6 @@ TTNN_NORM_OPS = [
 ]
 
 TTNN_POOL_OPS = [
-    ttnn.global_avg_pool2d,
     ttnn.max_pool2d,
 ]
 

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -12,19 +12,6 @@ aten_view_default_blocklist = [
 ]
 
 ############################################################
-# EXTRA BLOCKLIST OF vgg*
-############################################################
-# see issue #362
-# vgg11
-# aten::_adaptive_avg_pool2d => aten::view
-# if aten avgpool lowering to ttnn avgpool,
-# then its output shape become torch.Size([1, 1, 1, 7]) and cause aten::view error
-# RuntimeError: shape '[1, 25088]' is invalid for input of size 7
-# vgg11/vgg11_bn/vgg13/vgg13_bn/vgg16/vgg16_bn/vgg19/vgg19_bn all have this input var
-aten__adaptive_avg_pool2d_default_blocklist = [["Tensor<[1, 512, 7, 7]> self = ?", "List[int] output_size = [7, 7]"]]
-
-
-############################################################
 # EXTRA BLOCKLIST OF retinanet_resnet50_fpn*
 ############################################################
 
@@ -357,7 +344,6 @@ aten_embedding_default_blocklist = [
 ############################################################
 
 GUARD[torch.ops.aten.add.Tensor] = partial(guard_aten, aten_add_Tensor_blocklist)
-GUARD[torch.ops.aten._adaptive_avg_pool2d.default] = partial(guard_aten, aten__adaptive_avg_pool2d_default_blocklist)
 GUARD[torch.ops.aten.view.default] = partial(guard_aten, aten_view_default_blocklist)
 GUARD[torch.ops.aten.select.int] = partial(guard_aten, aten_select_int_blocklist)
 GUARD[torch.ops.aten.gt.Scalar] = partial(guard_aten, aten_gt_Scalar_blocklist)


### PR DESCRIPTION
### Ticket
#475 

### Problem description
Current lowering of `aten._adaptive_avg_pool2d.default` is wrong, and `ttnn.avg_pool2d` is not finished according to https://github.com/tenstorrent/tt-metal/issues/12151, so disable its lowering

Additionally, some special input varation let `aten._adaptive_avg_pool2d.default` do nothing, add the code to detect it and bypass it

### What's changed
 - Disable lowering of `aten._adaptive_avg_pool2d.default`
 - Check special input variation pattern of aten._adaptive_avg_pool2d.default
 - Remove blocklist of `aten._adaptive_avg_pool2d.default`
