### PR TITLE
Enable `torch.ops.aten.slice_scatter.default`  lowering

### DIFF
--- a/tests/lowering/tensor_manipulation/test_slice_scatter.py
+++ b/tests/lowering/tensor_manipulation/test_slice_scatter.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+import ttnn
+import torch_ttnn
+
+
+class SliceScatterModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input_tensor, src_tensor, dim, start, end):
+        out_relu = torch.relu(src_tensor)
+        return torch.slice_scatter(input_tensor, out_relu, dim, start, end)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, start, end",
+    [
+        ((1, 128, 28, 28), 1, 3, 20),
+    ],
+)
+def test_slice_scatter(device, input_shape, dim, start, end):
+    m = SliceScatterModule()
+    input_tensor = torch.rand(input_shape, dtype=torch.bfloat16)
+    src_tensor_shape = list(input_shape)
+    src_tensor_shape[dim] = end - start
+    src_tensor = torch.rand(src_tensor_shape, dtype=torch.bfloat16)
+
+    result_before = m.forward(input_tensor, src_tensor, dim, start, end)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input_tensor, src_tensor, dim, start, end)
+    print(option._out_fx_graphs[0])
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(torch.ops.aten.slice_scatter.default) == 0
+    # Check inference result
+    assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1060,7 +1060,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
                 # slice_scatter could be concat([pre_slice_tensor, src_tensor, post_slice_tensor])
                 rank = len(tensor_shape)
-                end = min(tensor_shape[dim], end) if end >= 0 else (end + tensor_shape[dim])
+                end = end if end >= 0 else (end + tensor_shape[dim])
+                end = 0 if end < 0 else min(tensor_shape[dim], end)
                 [step] = step or [1]
 
                 if step != 1 or dim >= rank:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/485

### Problem description
`torch.ops.aten.slice_scatter.default`  remains not lowering to TTNN.

### What's changed
`torch.ops.aten.slice_scatter.default(input, src, dim, start, end)` could be lowered into `ttnn.slice` + `ttnn.concat`
or
just return `src` tensor, if size of `src` tensor == size of `input` tensor

The only 2 models, **ghostnet_100.in1k** and **ghostnetv2_100.in1k** which has `torch.ops.aten.slice_scatter.default` op are the case of just return `src` tensor


Test
```bash
pytest -s tests/lowering/tensor_manipulation/test_slice_scatter.py
```
