### PR TITLE
Sweep the ❌ models(no train)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,8 @@ def compile_and_run(device, reset_torch_dynamo, request):
 
             end = time.perf_counter() * 1000
             comp_runtime_metrics = {"success": True, "run_time": round(end - start, 2)}
-            option._out_fx_graphs[0].print_tabular()
+            if len(option._out_fx_graphs) > 0:
+                option._out_fx_graphs[0].print_tabular()
             if model_name not in ["speecht5-tts"]:
                 accuracy = calculate_accuracy(outputs, outputs_after)
                 if accuracy:

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -36,7 +36,6 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.compilation_xfail
 def test_detr(record_property, mode):
     model_name = "DETR"
     record_property("model_name", model_name)

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -21,7 +21,6 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.parametrize("model_name", ["distilbert-base-uncased"])
-@pytest.mark.compilation_xfail
 def test_distilbert(record_property, model_name, mode):
     record_property("model_name", model_name)
     record_property("mode", mode)

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -26,7 +26,6 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.compilation_xfail
 def test_dpr(record_property, mode):
     model_name = "DPR"
     record_property("model_name", model_name)

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -25,7 +25,6 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.compilation_xfail
 def test_gpt2(record_property, mode):
     model_name = "GPT-2"
     record_property("model_name", model_name)

--- a/tests/models/hand_landmark/test_hand_landmark.py
+++ b/tests/models/hand_landmark/test_hand_landmark.py
@@ -39,7 +39,6 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.usefixtures("manage_dependencies")
-@pytest.mark.compilation_xfail
 def test_hand_landmark(record_property, mode):
     model_name = "Hand Landmark"
     record_property("model_name", model_name)

--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -23,7 +23,6 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.compilation_xfail
 def test_mlpmixer(record_property, mode):
     model_name = "MLPMixer"
     record_property("model_name", model_name)

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -21,7 +21,6 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.compilation_xfail
 def test_roberta(record_property, mode):
     model_name = "RoBERTa"
     record_property("model_name", model_name)

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -37,7 +37,6 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-@pytest.mark.compilation_xfail
 def test_segformer(record_property, mode):
     model_name = "SegFormer"
     record_property("model_name", model_name)

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -49,7 +49,6 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-@pytest.mark.compilation_xfail
 def test_yolov3(record_property, mode):
     model_name = "YOLOv3"
     record_property("model_name", model_name)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -234,9 +234,15 @@ def try_call_aten__to_copy_with_meta(g, to_torch_node, target_users_ops):
 
     if hasattr(to_torch_node, "meta") and "val" in to_torch_node.meta and hasattr(to_torch_node.meta["val"], "dtype"):
         dtype = to_torch_node.meta["val"].dtype
-        # if user only output and output type is float-like, then no need to add
         if dtype in [torch.float32, torch.float64, torch.bfloat16]:
-            return None
+            # segformer: Index put requires the source and destination dtypes match, got Float for the destination and BFloat16 for the source.
+            # _unsafe_index_put_default = torch.ops.aten._unsafe_index_put.default(new_zeros_default, [None, None, unsqueeze_11, _to_copy_22], ttnn_to_torch, True)
+            # (Pdb) new_zeros_default.dtype
+            # torch.float32
+            # (Pdb) ttnn_to_torch.dtype
+            # torch.bfloat16 => should have to_copy to be torch.float32
+            if torch.ops.aten._unsafe_index_put.default not in target_users_ops:
+                return None
         call_func = g.call_function(
             torch.ops.aten._to_copy.default,
             (to_torch_node,),

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -226,7 +226,7 @@ aten_mul_Tensor_blocklist += [["Tensor<[1, 1]> self = ?", "Tensor other = 50258"
 
 aten_select_int_blocklist = [["Tensor<[1, 45]> self = ?", "int dim = 1", "int index = -1"]]
 
-# ERROR tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[eval] -
+# ERROR tests/models/gpt_neo/test_gpt_neo.py::test_gpt_neo[eval], see issue #503
 # RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
 # TODO: not pass yet
 
@@ -254,8 +254,8 @@ aten_gt_Scalar_blocklist = [["Tensor<[]> self = ?", "number other = 0"]]
 # TypeError: __call__(): incompatible function arguments. The following argument types are supported: ...
 aten_div_Tensor_blocklist += [["Tensor<[1, 1]> self = ?", "Tensor other = 16"]]
 
-#             torch._dynamo.exc.BackendCompilerFailed: backend='ttnn_backend' raised:
-#             Exception: unhashable type: non-singleton SymInt
+# torch._dynamo.exc.BackendCompilerFailed: backend='ttnn_backend' raised:
+# Exception: unhashable type: non-singleton SymInt
 # TODO: not pass yet
 
 ############################################################
@@ -321,6 +321,103 @@ aten_zeros_like_default_blocklist += [
     ["Tensor<[100, 1, 256]> self = ?", "Optional[bool] pin_memory = False"],
 ]
 
+
+############################################################
+# EXTRA BLOCKLIST OF ssd300_vgg16
+############################################################
+# IndexError: index 480 is out of bounds for dimension 0 with size 480, see issue #420
+# add => multiply => subtract => unsqueeze
+aten_add_Tensor_blocklist += [["Tensor<[300]> self = ?", "Tensor other = 0.5"]]
+aten_mul_Tensor_blocklist += [["Tensor<[300]> self = ?", "Tensor other = 1.6"]]
+aten_sub_Tensor_blocklist += [["Tensor<[300]> self = ?", "Tensor other = 0.5"]]
+aten_unsqueeze_default_blocklist += [["Tensor<[300]> self = ?", "int dim = 1"]]
+# RuntimeError: expected scalar type BFloat16 but found Float
+# convolution_default_5 weight dtype is float32, this is
+# because RuntimeError: "nms_kernel" not implemented for 'BFloat16' so cannot model.to(torch.bfloat16)
+# TODO: not pass yet
+
+############################################################
+# EXTRA BLOCKLIST OF ssdlite320_mobilenet_v3_large
+############################################################
+# IndexError: IndexError: index 640 is out of bounds for dimension 1 with size 640, see issue #420
+# add => multiply => subtract => unsqueeze
+aten_add_Tensor_blocklist += [["Tensor<[320]> self = ?", "Tensor other = 0.5"]]
+aten_mul_Tensor_blocklist += [
+    ["Tensor<[320]> self = ?", "Tensor other = 1.5"],
+    ["Tensor<[320]> self = ?", "Tensor other = 2.0"],
+]
+aten_sub_Tensor_blocklist += [["Tensor<[320]> self = ?", "Tensor other = 0.5"]]
+aten_unsqueeze_default_blocklist += [["Tensor<[320]> self = ?", "int dim = 1"]]
+# tt_metal/common/math.hpp:16: b > 0
+# Divide by 0 error
+aten_convolution_default_blocklist += [
+    [
+        "Tensor<[1, 128, 5, 5]> input = ?",
+        "Tensor<[128, 1, 3, 3]> weight = ?",
+        "Optional[Tensor] bias = ?",
+        "List[int] stride = [2, 2]",
+        "List[int] padding = [1, 1]",
+        "List[int] dilation = [1, 1]",
+        "bool transposed = False",
+        "List[int] output_padding = [0, 0]",
+        "int groups = 128",
+    ]
+]
+
+# RuntimeError: expected scalar type BFloat16 but found Float
+# convolution_default_66 weight dtype is float32, this is
+# because RuntimeError: "nms_kernel" not implemented for 'BFloat16' so cannot model.to(torch.bfloat16)
+# TODO: not pass yet
+
+############################################################
+# EXTRA BLOCKLIST OF MobileNetSSD
+############################################################
+# IndexError: index 320 is out of bounds for dimension 0 with size 320, see issue #420
+# add => multiply => subtract => unsqueeze
+aten_add_Tensor_blocklist += [["Tensor<[320]> self = ?", "Tensor other = 0.5"]]
+aten_mul_Tensor_blocklist += [["Tensor<[320]> self = ?", "Tensor other = 1.0"]]
+aten_sub_Tensor_blocklist += [["Tensor<[320]> self = ?", "Tensor other = 0.5"]]
+aten_unsqueeze_default_blocklist += [["Tensor<[320]> self = ?", "int dim = 1"]]
+# RuntimeError: expected scalar type BFloat16 but found Float
+# convolution_default_66 weight dtype is float32, this is
+# because RuntimeError: "nms_kernel" not implemented for 'BFloat16' so cannot model.to(torch.bfloat16)
+# TODO: not pass yet
+
+############################################################
+# EXTRA BLOCKLIST OF retinanet_resnet50_fpn
+############################################################
+# IndexError: index 480 is out of bounds for dimension 0 with size 480, see issue #420
+aten_add_Tensor_blocklist += [["Tensor<[800]> self = ?", "Tensor other = 0.5"]]
+aten_mul_Tensor_blocklist += [["Tensor<[800]> self = ?", "Tensor other = 0.6"]]
+aten_sub_Tensor_blocklist += [["Tensor<[800]> self = ?", "Tensor other = 0.5"]]
+aten_unsqueeze_default_blocklist += [["Tensor<[800]> self = ?", "int dim = 1"]]
+# RuntimeError: expected scalar type BFloat16 but found Float
+# convolution_default weight dtype is float32, this is
+# because RuntimeError: "nms_kernel" not implemented for 'BFloat16' so cannot model.to(torch.bfloat16)
+# TODO: not pass yet
+
+
+############################################################
+# EXTRA BLOCKLIST OF retinanet_resnet50_fpn_v2
+############################################################
+# RuntimeError: expected scalar type BFloat16 but found Float
+# convolution_default weight dtype is float32, this is
+# because RuntimeError: "nms_kernel" not implemented for 'BFloat16' so cannot model.to(torch.bfloat16)
+# TODO: not pass yet
+
+############################################################
+# EXTRA BLOCKLIST OF RoBERTa
+############################################################
+# RuntimeError: TT_FATAL @ xxx/embedding.cpp:32: input_tensor_arg.get_layout() == ttnn::ROW_MAJOR_LAYOUT
+# info:
+# Indices tensor must be in row major layout.
+# ttnn_embedding = ttnn_decorators_ttnn_embedding(ttnn_from_torch_2, ttnn_to_device_3, layout = ttnn_ROW_MAJOR_LAYOUT)
+# (Pdb) ttnn_from_torch_2.layout
+# <Layout.TILE: 1>
+aten_embedding_default_blocklist = [
+    ["Tensor<[250002, 768]> weight = ?", "Tensor<[1, 10]> indices = ?", "int padding_idx = 1"]
+]
+
 ############################################################
 
 GUARD[torch.ops.aten.add.Tensor] = partial(guard_aten, aten_add_Tensor_blocklist)
@@ -330,6 +427,7 @@ GUARD[torch.ops.aten.select.int] = partial(guard_aten, aten_select_int_blocklist
 GUARD[torch.ops.aten.gt.Scalar] = partial(guard_aten, aten_gt_Scalar_blocklist)
 GUARD[torch.ops.aten.unsqueeze.default] = partial(guard_aten, aten_unsqueeze_default_blocklist)
 GUARD[torch.ops.aten.cumsum.default] = partial(guard_aten, aten_cumsum_default_blocklist)
+GUARD[torch.ops.aten.embedding.default] = partial(guard_aten, aten_embedding_default_blocklist)
 
 
 def can_lowering_to_ttnn(node):

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -891,8 +891,9 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 tensors = args[0]
                 if len(tensors) == 1:
                     return tensors[0]
-
-                dim = args[1]
+                dim = 0
+                if len(args) > 1:
+                    dim = args[1]
                 rank = len(node.meta["val"].size())
                 dim = (dim + rank) % rank
                 layout = TtnnTileLayout() if rank == 4 else TtnnRowMajorLayout()


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Sweep the ❌ models and try to let it 🚧, now remains these 15 ❌ models that is hard to 🚧 by blocklist

| model | issue |
|---|---|
| GPTNeo | result nan #503 |
| codegen | SymInt #524 |
| FLAN-T5 | SymInt #524 |
| GLPN-KITTI | shape differ #390 |
| OPT | SymInt #524 |
| t5-small | SymInt #524 |
| t5-base | SymInt #524 |
| t5-large | SymInt #524 |
| MobileNetSSD | nms_kernel needs float #525 |
| ssd300_vgg16 | nms_kernel needs float #525 |
| ssdlite320_mobilenet_v3_large | nms_kernel needs float #525 |
| retinanet_resnet50_fpn | nms_kernel needs float #525 |
| retinanet_resnet50_fpn_v2 | nms_kernel needs float #525 |
| Whisper | SymInt #524 |
| Stable Diffusion V2 | test time too long, postpone |

### What's changed
 - Remove some `@pytest.mark.compilation_xfail`
 - Add blocklist to try to let model 🚧
