### PR TITLE
Relax max_pool2d constraints for non-pow-of-2 channels

### DIFF
--- a/tests/lowering/pool/test_max_pool_2d.py
+++ b/tests/lowering/pool/test_max_pool_2d.py
@@ -19,14 +19,15 @@ class MaxPool2dModule(torch.nn.Module):
         ((1, 1024, 17, 17), (3, 3), 2, 0, 1, False),
         ((1, 128, 112, 112), (2, 2), 2, 0, 1, False),
         ((1, 512, 19, 19), (3, 3), 1, 1, 1, False),
+        ((1, 192, 28, 28), (3, 3), 1, 1, 1, False),
         pytest.param(
-            (1, 192, 28, 28),
+            (1, 320, 28, 28),
             (3, 3),
             1,
             1,
             1,
             False,
-            marks=pytest.mark.xfail(reason="non-pow-of-2 channel (tt-metal#13901)"),
+            marks=pytest.mark.xfail(reason="wide channel not divisible by TILE_SIZE * 8 (tt-metal#13901)"),
         ),
         pytest.param(
             (1, 256, 28, 28),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -959,8 +959,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                     ceil_mode
                     # TODO(#385): OOM
                     or volume > 16 * 1024 * 1024
-                    # TODO(tt-metal#13901): Non-pow-of-2 channel isn't supported yet
-                    or (in_c & (in_c - 1)) != 0
+                    # TODO(tt-metal#13901): Wide input channels can only be multiple of 8 tiles
+                    or (in_c > (ttnn.TILE_SIZE * 8) and in_c % (ttnn.TILE_SIZE * 8) != 0)
                     # TODO(#419): Currently fails with in_c < 16
                     or in_c < 16
                     # TODO(tt-metal#12099): Currently it doesn't return indices. Convert if only the value is used


### PR DESCRIPTION
### Ticket
#430, https://github.com/tenstorrent/tt-metal/issues/13901

### Problem description
With the recent change https://github.com/tenstorrent/tt-metal/commit/8dee2c21618a386a121663632241a871f06a1765, we can relax the constraint of non-pow-of-2 channels of `max_pool2d` to "be divisible by TILE_SIZE * 8 when > TILE_SIE * 8"

### What's changed
- Relax the constraint of non-pow-of-2 channels of `max_pool2d`
- Update test cases
