### PR TITLE
Refactor add data move pass

### DIFF
--- a/tests/pattern/test_data_move_reuse_pattern.py
+++ b/tests/pattern/test_data_move_reuse_pattern.py
@@ -1,0 +1,26 @@
+import torch
+import torch_ttnn
+import ttnn
+
+
+class PatternModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        add1 = torch.ops.aten.add.Tensor(input, 1.0)
+        mul1 = torch.ops.aten.mul.Tensor(input, 1.0)
+        add2 = torch.ops.aten.add.Tensor(add1, mul1)
+        return add2
+
+
+def test_data_move_reuse(device):
+    m = PatternModule()
+    input = torch.randn([4, 4]).to(torch.bfloat16)
+    result_before = m.forward(input)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input)
+    assert torch.allclose(result_before, result_after, rtol=0.1, atol=0.1)
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.from_torch) == 1

--- a/tests/pattern/test_data_move_reuse_pattern.py
+++ b/tests/pattern/test_data_move_reuse_pattern.py
@@ -14,6 +14,17 @@ class PatternModule(torch.nn.Module):
         return add2
 
 
+class PatternModuleEmb(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, weight):
+        emb1 = torch.nn.functional.embedding(input, weight)
+        emb2 = torch.nn.functional.embedding(input, weight)
+        add1 = torch.ops.aten.add.Tensor(emb1, emb2)
+        return add1
+
+
 def test_data_move_reuse(device):
     m = PatternModule()
     input = torch.randn([4, 4]).to(torch.bfloat16)
@@ -24,3 +35,16 @@ def test_data_move_reuse(device):
     assert torch.allclose(result_before, result_after, rtol=0.1, atol=0.1)
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.from_torch) == 1
+
+
+def test_data_move_reuse_emb(device):
+    m = PatternModuleEmb()
+    input = torch.tensor([[1, 2, 4, 5], [4, 3, 2, 9]])
+    weight = torch.rand([10, 4], dtype=torch.bfloat16)
+    result_before = m.forward(input, weight)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(input, weight)
+    assert torch.allclose(result_before, result_after, rtol=0.1, atol=0.1)
+    nodes = list(option._out_fx_graphs[0].nodes)
+    assert [node.target for node in nodes].count(ttnn.from_torch) == 2

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -426,9 +426,11 @@ class NodeInputAligner:
             if spec.dtype is not None:
                 kwargs["dtype"] = spec.dtype()
             aligning_nodes.append(g.call_function(ttnn.from_torch, (spec.input_node,), kwargs))
-            self._change_layout(spec, aligning_nodes)
+            if spec.layout != TtnnTileLayout:
+                self._change_layout(spec, aligning_nodes)
             # cannot implement by this, or perceiver_io will get this error
             # allocator.cpp:145: Out of Memory: Not enough space to allocate 6442450944 B DRAM buffer across 12 banks, where each bank needs to store 536870912 B
+            # see issue #552
             # kwargs = {}
             # if spec.device is not None and spec.device != "host":
             #     kwargs["device"] = spec.device()

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -318,26 +318,6 @@ class NodeInputAligner:
         layout: object
         dtype: object
 
-    class AlignSpecInTtnn:
-        def __init__(self, input_node, device, layout, dtype):
-            self.input_node = input_node
-            self.device = device
-            self.layout = layout
-            self.dtype = dtype
-
-        def __eq__(self, other):
-            if not isinstance(other, self.__class__):
-                return False
-            return (
-                self.input_node == other.input_node
-                and self.device == other.device
-                and self.layout == other.layout
-                and self.dtype == other.dtype
-            )
-
-        def __hash__(self):
-            return hash((self.input_node, self.device, self.layout, self.dtype))
-
     def _align_for_special_layout(self, node, spec, input_site, input_site_type: InputSiteType):
         if is_target_a_user_of_curr_node(node, ttnn.embedding) and (
             input_site_type == self.InputSiteType.ARGS and input_site == 0

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -10,6 +10,7 @@ from torch_ttnn.utils import (
 )
 from dataclasses import dataclass
 from enum import Enum
+from typing import Union, Type, Literal
 
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 from . import target_wrappers
@@ -302,21 +303,21 @@ class NodeInputAligner:
     @dataclass(unsafe_hash=True)
     class AlignSpecFromTorch:
         input_node: torch.fx.node.Node
-        device: ttnn.Device
-        layout: object
-        dtype: object
+        device: Union[None, Type[TtnnDevice], Literal["host"]]
+        layout: Union[None, Type[TtnnTileLayout], Type[TtnnRowMajorLayout]]
+        dtype: Union[None, Type[TtnnBfloat16], Type[TtnnUint32]]
 
     @dataclass(unsafe_hash=True)
     class AlignSpecToTorch:
         input_node: torch.fx.node.Node
-        dtype: object
+        dtype: Union[None, Type[TtnnBfloat16], Type[TtnnUint32], Literal["by_node_meta"]]
 
     @dataclass(unsafe_hash=True)
     class AlignSpecInTtnn:
         input_node: torch.fx.node.Node
-        device: ttnn.Device
-        layout: object
-        dtype: object
+        device: Union[None, Type[TtnnDevice], Literal["host"]]
+        layout: Union[None, Type[TtnnTileLayout], Type[TtnnRowMajorLayout]]
+        dtype: Union[None, Type[TtnnBfloat16], Type[TtnnUint32]]
 
     def _align_for_special_layout(self, node, spec, input_site, input_site_type: InputSiteType):
         if is_target_a_user_of_curr_node(node, ttnn.embedding) and (

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -391,18 +391,57 @@ class NodeInputAligner:
             return spec
         return None
 
+    def _change_layout(self, spec, aligning_nodes):
+        g = self.graph
+        need_from_device = False
+        need_to_layout = False
+        need_to_device = False
+        if spec.device == "host":
+            need_from_device = True
+        elif spec.device is not None:
+            need_from_device = True
+            need_to_device = True
+        if spec.layout is not None:
+            need_to_layout = True
+
+        if need_from_device:
+            aligning_nodes.append(
+                g.call_function(ttnn.from_device, (aligning_nodes[-1] if aligning_nodes else spec.input_node,))
+            )
+        if need_to_layout:
+            aligning_nodes.append(
+                g.call_function(
+                    ttnn.to_layout, (aligning_nodes[-1] if aligning_nodes else spec.input_node, spec.layout())
+                )
+            )
+        if need_to_device:
+            aligning_nodes.append(
+                g.call_function(
+                    ttnn.to_device,
+                    (aligning_nodes[-1] if aligning_nodes else spec.input_node,),
+                    {"device": spec.device()},
+                )
+            )
+
     def _create_aligned_node(self, spec):
         aligning_nodes = []
         g = self.graph
         if isinstance(spec, self.AlignSpecFromTorch):
-            kwargs = {}
-            if spec.device is not None and spec.device != "host":
-                kwargs["device"] = spec.device()
-            if spec.layout is not None:
-                kwargs["layout"] = spec.layout()
+            kwargs = {"layout": TtnnTileLayout(), "device": TtnnDevice()}
             if spec.dtype is not None:
                 kwargs["dtype"] = spec.dtype()
             aligning_nodes.append(g.call_function(ttnn.from_torch, (spec.input_node,), kwargs))
+            self._change_layout(spec, aligning_nodes)
+            # cannot implement by this, or perceiver_io will get this error
+            # allocator.cpp:145: Out of Memory: Not enough space to allocate 6442450944 B DRAM buffer across 12 banks, where each bank needs to store 536870912 B
+            # kwargs = {}
+            # if spec.device is not None and spec.device != "host":
+            #     kwargs["device"] = spec.device()
+            # if spec.layout is not None:
+            #     kwargs["layout"] = spec.layout()
+            # if spec.dtype is not None:
+            #     kwargs["dtype"] = spec.dtype()
+            # aligning_nodes.append(g.call_function(ttnn.from_torch, (spec.input_node,), kwargs))
         elif isinstance(spec, self.AlignSpecToTorch):
             target_users_ops = [user.target for user in spec.input_node.users.keys()]
             aligning_nodes.append(call_to_torch_with_meta(g, spec.input_node))
@@ -411,33 +450,7 @@ class NodeInputAligner:
                 if copy_node:
                     aligning_nodes.append(copy_node)
         elif isinstance(spec, self.AlignSpecInTtnn):
-            need_from_device = False
-            need_to_layout = False
-            need_to_device = False
-            if spec.device == "host":
-                need_from_device = True
-            elif spec.device is not None:
-                need_from_device = True
-                need_to_device = True
-            if spec.layout is not None:
-                need_to_layout = True
-
-            if need_from_device:
-                aligning_nodes.append(g.call_function(ttnn.from_device, (spec.input_node,)))
-            if need_to_layout:
-                aligning_nodes.append(
-                    g.call_function(
-                        ttnn.to_layout, (aligning_nodes[-1] if aligning_nodes else spec.input_node, spec.layout())
-                    )
-                )
-            if need_to_device:
-                aligning_nodes.append(
-                    g.call_function(
-                        ttnn.to_device,
-                        (aligning_nodes[-1] if aligning_nodes else spec.input_node,),
-                        {"device": spec.device()},
-                    )
-                )
+            self._change_layout(spec, aligning_nodes)
         return aligning_nodes[-1]
 
     def _connect_aligned_node(self, node, aligned_node, input_site, input_site_type):

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -329,19 +329,6 @@ aten_unsqueeze_default_blocklist += [["Tensor<[800]> self = ?", "int dim = 1"]]
 # TODO: not pass yet
 
 ############################################################
-# EXTRA BLOCKLIST OF RoBERTa
-############################################################
-# RuntimeError: TT_FATAL @ xxx/embedding.cpp:32: input_tensor_arg.get_layout() == ttnn::ROW_MAJOR_LAYOUT
-# info:
-# Indices tensor must be in row major layout.
-# ttnn_embedding = ttnn_decorators_ttnn_embedding(ttnn_from_torch_2, ttnn_to_device_3, layout = ttnn_ROW_MAJOR_LAYOUT)
-# (Pdb) ttnn_from_torch_2.layout
-# <Layout.TILE: 1>
-aten_embedding_default_blocklist = [
-    ["Tensor<[250002, 768]> weight = ?", "Tensor<[1, 10]> indices = ?", "int padding_idx = 1"]
-]
-
-############################################################
 
 GUARD[torch.ops.aten.add.Tensor] = partial(guard_aten, aten_add_Tensor_blocklist)
 GUARD[torch.ops.aten.view.default] = partial(guard_aten, aten_view_default_blocklist)
@@ -349,7 +336,6 @@ GUARD[torch.ops.aten.select.int] = partial(guard_aten, aten_select_int_blocklist
 GUARD[torch.ops.aten.gt.Scalar] = partial(guard_aten, aten_gt_Scalar_blocklist)
 GUARD[torch.ops.aten.unsqueeze.default] = partial(guard_aten, aten_unsqueeze_default_blocklist)
 GUARD[torch.ops.aten.cumsum.default] = partial(guard_aten, aten_cumsum_default_blocklist)
-GUARD[torch.ops.aten.embedding.default] = partial(guard_aten, aten_embedding_default_blocklist)
 
 
 def can_lowering_to_ttnn(node):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Although this pass named `add_data_move`, but put things in perspective, if each node can ensure its input correct, then it also ensure the input is added the appropriate data movement node

So in there introduce `NodeInputAligner` class, which help node's input  **`align`** to the correct posture

In torch_ttnn compiler, the main task of `NodeInputAligner` to deal with has these scope

1. torch to ttnn: key action is `from_torch`
2. ttnn to torch: key action is `to_torch`

worth noting, some ttnn node may needs different layout & device, so also have this scope

3. ttnn to ttnn: key action is `to_layout` and (`from_device` or `to_device`)

for example, if reshape input is `tile_layout`,then the input needs be aligned using `_align_for_special_layout`
```
input_node => to_layout(row_major_layout) => reshape
```
Additionally, since the layout changes to row_major_layout after the reshape operation—different from the default layout—the next node must reset to the default using `_reset_to_default_layout`
```
input_node => to_layout(row_major_layout) => reshape => to_layout(tile_layout)
```
### What's changed
 - Introduce `NodeInputAligner` class to align the node's input as the correct posture
   - Give `AlignSpec*` class for prepare the aligner information and let it be the key of created_aligned_node for reuse
   - Implemented core functions:
     - `_get_align_spec`: Retrieves alignment specifications
     - `_create_aligned_node`: Creates nodes for alignment
     - `_connect_aligned_node`: Connects aligned nodes
   - Added support functions:
     - `_align_for_special_layout`: Handles special layout requirements
     - `_reset_to_default_layout`: Resets to the default layout when necessary