### PR TITLE
Fix reshape value error too large

### DIFF
--- a/tests/pattern/test_beit_pattern.py
+++ b/tests/pattern/test_beit_pattern.py
@@ -23,3 +23,4 @@ def test_beit_pattern(device):
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
     result_after = m.forward(arg1_1, arg223_1)
     assert torch.allclose(result_before, result_after, rtol=0.1, atol=0.1)
+    assert not any(node.target == torch.ops.aten.view.default for node in option._out_fx_graphs[0].nodes)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -323,6 +323,14 @@ class NodeInputAligner:
             # TODO(#417, tt-metal#15893): weight currently needs to be on host and can't be moved to device first
             spec.layout = TtnnRowMajorLayout
             spec.device = "host"
+        if (
+            node.target == ttnn.reshape
+            and hasattr(spec.input_node, "meta")
+            and "val" in spec.input_node.meta
+            and hasattr(spec.input_node.meta["val"], "dtype")
+            and spec.input_node.meta["val"].dtype in [torch.int32, torch.int64]
+        ):
+            spec.dtype = TtnnUint32
         return spec
 
     def _reset_to_default_layout(self, input_node, spec):

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -2,16 +2,6 @@ from functools import partial
 from .to_tt_guard_autogen import *
 
 ############################################################
-# EXTRA BLOCKLIST OF microsoft/beit-*-patch16-224
-############################################################
-# error value let 731 become 732 and cause index error (shape is [732, 12])
-# see issue #420
-
-aten_view_default_blocklist = [
-    ["Tensor<[197, 197]> self = ?", "List[int] size = [-1]"],
-]
-
-############################################################
 # EXTRA BLOCKLIST OF retinanet_resnet50_fpn*
 ############################################################
 
@@ -292,7 +282,6 @@ aten_unsqueeze_default_blocklist += [["Tensor<[800]> self = ?", "int dim = 1"]]
 ############################################################
 
 GUARD[torch.ops.aten.add.Tensor] = partial(guard_aten, aten_add_Tensor_blocklist)
-GUARD[torch.ops.aten.view.default] = partial(guard_aten, aten_view_default_blocklist)
 GUARD[torch.ops.aten.select.int] = partial(guard_aten, aten_select_int_blocklist)
 GUARD[torch.ops.aten.gt.Scalar] = partial(guard_aten, aten_gt_Scalar_blocklist)
 GUARD[torch.ops.aten.unsqueeze.default] = partial(guard_aten, aten_unsqueeze_default_blocklist)


### PR DESCRIPTION
### Ticket
#420 

### Problem description
 - from_torch not as bfloat16 if val type is int and its user is reshape

### What's changed
 - from_torch not as bfloat16 if val type is int and its user is reshape

I'll merge #532 first then this PR