### PR TITLE
Remove the blocklist for `aten.div.Tensor`

### DIFF
--- a/tests/lowering/eltwise/binary/test_div.py
+++ b/tests/lowering/eltwise/binary/test_div.py
@@ -22,11 +22,75 @@ class DivModule(torch.nn.Module):
         ((64, 32), (64, 1)),
         pytest.param(
             ((64, 1), (1, 64)),
-            marks=pytest.mark.xfail(reason="broadcasting issues (#64)"),
+            marks=pytest.mark.xfail(reason="Bidirectional broadcasting issue (#64)"),
         ),
         pytest.param(
             ((1, 23, 40, 1), (128,)),
-            marks=pytest.mark.xfail(reason="broadcasting issues (#64)"),
+            marks=pytest.mark.xfail(reason="Bidirectional broadcasting issue (#64)"),
+        ),
+        pytest.param(
+            ((), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 12, 9, 9), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 64, 9, 9), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 12, 25, 25), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 16, 9, 9), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 12, 7, 7), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 1280, 8, 8), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((10, 10), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((2, 2), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 16, 5, 5), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 16, 1, 6), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 128, 1568), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 64, 6272), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((1, 32, 25088), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((15, 15), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
+        ),
+        pytest.param(
+            ((17, 17), ()),
+            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
         ),
     ),
 )

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -153,17 +153,6 @@ aten_gt_Scalar_blocklist = [["Tensor<[]> self = ?", "number other = 0"]]
 # TODO: not pass yet
 
 ############################################################
-# EXTRA BLOCKLIST OF FLAN-T5
-############################################################
-# This div converted to reciprocal & mul, and reciprocal show this err msg:
-# TypeError: __call__(): incompatible function arguments. The following argument types are supported: ...
-aten_div_Tensor_blocklist += [["Tensor<[1, 1]> self = ?", "Tensor other = 16"]]
-
-# torch._dynamo.exc.BackendCompilerFailed: backend='ttnn_backend' raised:
-# Exception: unhashable type: non-singleton SymInt
-# TODO: not pass yet
-
-############################################################
 # EXTRA BLOCKLIST OF GLPN-KITTI
 ############################################################
 # index out of bound, see issue #420
@@ -209,13 +198,6 @@ aten_maximum_default_blocklist += [["Tensor<[1, 16, 59, 59]> self = ?", "Tensor 
 #               ...,
 #                [ 0.00000,  0.00000,  ...,  0.00000,  0.00000]]]], shape=Shape([1, 23, 40[64], 1[32]]), dtype=DataType::BFLOAT16, layout=Layout::TILE), 1; kwargs: dtype=torch.float32
 aten_cumsum_default_blocklist = [["Tensor<[1, 23, 40]> self = ?", "int dim = 1", "Optional[int] dtype = torch.float32"]]
-
-# TypeError: __call__(): incompatible function arguments. The following argument types are supported:
-#     1. (self: ttnn._ttnn.operations.unary.reciprocal_t, input_tensor: ttnn._ttnn.tensor.Tensor, *, memory_config: Optional[ttnn._ttnn.tensor.MemoryConfig] = None, output_tensor: Optional[ttnn._ttnn.tensor.Tensor] = None, queue_id: int = 0) -> ttnn._ttnn.tensor.Tensor
-#     2. (self: ttnn._ttnn.operations.unary.reciprocal_t, input_tensor: ttnn::operations::complex::ComplexTensor, *, memory_config: ttnn._ttnn.tensor.MemoryConfig) -> ttnn::operations::complex::ComplexTensor
-#
-# Invoked with: <ttnn._ttnn.operations.unary.reciprocal_t object at 0x7f08ea7a0e30>, 128
-aten_div_Tensor_blocklist += [["Tensor<[128]> self = ?", "Tensor other = 128"]]
 
 # RuntimeError: TT_FATAL @ binary_device_operation.cpp:68: input_tensor_a.get_layout() == Layout::TILE
 # info:

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -137,25 +137,10 @@ aten_zeros_like_default_blocklist = [
 ]
 aten_div_Tensor_blocklist = [
     ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
-    ["Tensor<[1, 12, 9, 9]> self = ?", "Tensor other = 8.0"],
-    ["Tensor<[1, 64, 9, 9]> self = ?", "Tensor other = 8.0"],
     ["Tensor<[1, 23, 40, 1]> self = ?", "Tensor<[128]> other = ?"],
-    ["Tensor<[1, 12, 25, 25]> self = ?", "Tensor other = 8.0"],
-    ["Tensor<[1, 16, 9, 9]> self = ?", "Tensor other = 11.313708498984761"],
-    ["Tensor<[1, 16, 9, 9]> self = ?", "Tensor other = 8.0"],
     ["Tensor<[1, 12, 7, 7]> self = ?", "Tensor<[]> other = ?"],
-    ["Tensor<[1, 1280, 8, 8]> self = ?", "Tensor other = 1"],
-    ["Tensor<[10, 10]> self = ?", "Tensor other = 8"],
-    ["Tensor<[2, 2]> self = ?", "Tensor other = 16"],
     ["Tensor<[1, 16, 5, 5]> self = ?", "Tensor<[]> other = ?"],
     ["Tensor<[1, 16, 1, 6]> self = ?", "Tensor<[]> other = ?"],
-    ["Tensor<[1, 128, 1568]> self = ?", "Tensor other = 3"],
-    ["Tensor<[1, 64, 6272]> self = ?", "Tensor other = 3"],
-    ["Tensor<[1, 32, 25088]> self = ?", "Tensor other = 3"],
-    ["Tensor<[15, 15]> self = ?", "Tensor other = 8"],
-    ["Tensor<[15, 15]> self = ?", "Tensor other = 2.772588722239781"],
-    ["Tensor<[17, 17]> self = ?", "Tensor other = 16"],
-    ["Tensor<[17, 17]> self = ?", "Tensor other = 2.0794415416798357"],
 ]
 aten_mul_Tensor_blocklist = [
     ["Tensor<[]> self = ?", "Tensor<[3234, 1]> other = ?"],

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -601,8 +601,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(ttnn.log, (softmax_node,), kwargs)
 
             if node.target == torch.ops.aten.div.Tensor:
-                if isinstance(args[1], float):
-                    return g.call_function(ttnn.mul, (args[0], 1 / args[1]), {})
+                if isinstance(args[1], (float, int)):
+                    return g.call_function(ttnn.mul, (args[0], 1.0 / args[1]), {})
 
                 if get_shape(args[0]) == get_shape(args[1]):
                     return g.call_function(ttnn.div, args, {})

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -601,10 +601,14 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(ttnn.log, (softmax_node,), kwargs)
 
             if node.target == torch.ops.aten.div.Tensor:
-                if not isinstance(args[1], (float, int)) and (get_shape(args[0]) != get_shape(args[1])):
-                    recip = g.call_function(ttnn.reciprocal, (args[1],), {})
-                    return g.call_function(ttnn.mul, (args[0], recip), {})
-                return g.call_function(ttnn.div, args, {})
+                if isinstance(args[1], float):
+                    return g.call_function(ttnn.mul, (args[0], 1 / args[1]), {})
+
+                if get_shape(args[0]) == get_shape(args[1]):
+                    return g.call_function(ttnn.div, args, {})
+
+                recip = g.call_function(ttnn.reciprocal, (args[1],), {})
+                return g.call_function(ttnn.mul, (args[0], recip), {})
 
             if node.target == torch.ops.aten.expand.default:
                 if not (hasattr(args[0], "meta") and "val" in args[0].meta and hasattr(args[0].meta["val"], "size")):


### PR DESCRIPTION
### Ticket
- Resolves #479 
- Relates to tenstorrent/tt-metal#15630

### Problem description
Remove the blocklist for `aten.div.Tensor` and make sure these cases pass

### What's changed
- [x] Further optimize `tensor / const` to `tensor * (1 / const)`
- [x] Remove block list entries that should work since #507
- [ ] Resolve `tensor / scalar` where the scalar is unknown
