### PR TITLE
Update Contributing.md

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -9,7 +9,7 @@ In practice, we heavily rely on CI and the Model Test Suite to uphold these prin
 
 # What is Model's Lifecycle in the test suite?
 Every model in the test suite goes through the following stages: <br>
-`Traced` -> `Compiled` -> `E2E on device` -> `Performant`
+`Traced` -> `Compiled` -> `E2E TT-NN` -> `E2E on Device` -> `Performant`
 
 ### Traced
 In this stage, a properly added model runs on the CPU to collect operation traces, which guide further development for both the compiler and TT-NN.
@@ -19,8 +19,12 @@ Examples: [Model trace](https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main
 At this stage, the compiler has successfully transformed PyTorch ATen operations into TT-NN operations, allowing the model to complete its run. 
 Not all operations may be converted, and fallbacks can still be used if TT-NN or the compiler does not fully handle specific inputs.
 
+### E2E TT-NN
+This status requires that model is fully running with TT-NN calls and no ATen calls remain in the graph.
+Model accuracy must be above 98%.
+
 ### E2E on Device
-This status requires that no fallbacks remain; every ATen call is fully replaced by a TT-NN call on the device.
+There must be no fallbacks to host.
 
 ### Performant
 The performance target is not yet established. We will revisit this section once more than 50% of test models run E2E on the device.


### PR DESCRIPTION
### Ticket
none

### What's changed
⭐️ We are making some changes to the Model Suite status reports to better reflect the current state.

We introduce a new step "E2E TT-NN"
We currently do not track wether each TT-NN operation runs on device. 
We are aware that there are cases that fallback to host. 
We think it is important to distinguish between this new state and E2E on Device. 

Model journey in the test suite changes from
Traced -> Compiled -> E2E on Device -> Performant
to
Traced -> Compiled -> E2E TT-NN -> E2E on Device -> Performant

We add accuracy requirement to the "E2E TT-NN" status
Yesterday we spotted that among 22 models running e2e with TT-NN, only 8 have a satisfactory PCC when compared to the Torch run.
For a model to transition behind Compiled status its accuracy must be above 98%.