### PR TITLE
Fuse mat mul with activation following it

### DIFF
--- a/tests/lowering/matmul/test_matmul.py
+++ b/tests/lowering/matmul/test_matmul.py
@@ -36,3 +36,4 @@ def test_matmul(device, input_shapes):
 
     # Check inference result
     assert_with_pcc(result_before, result_after, 0.99)
+    

--- a/tests/optimization/test_mm_fusion.py
+++ b/tests/optimization/test_mm_fusion.py
@@ -1,0 +1,110 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+from tests.utils import assert_with_pcc
+
+
+class MatmulModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, other, activation):
+        return activation(torch.matmul(input, other))
+        
+@pytest.mark.parametrize(
+    ("input_shapes", "activation"),
+    [
+     ([(64, 64), (64, 64)], torch.nn.functional.relu),
+     ([(64, 64), (64, 64)], torch.nn.functional.gelu),
+     ([(64, 64), (64, 64)], torch.nn.functional.silu),
+     
+     # Inside ttnn/cpp/ttnn/operations/matmul/matmul.cpp, function bound_matmul only supports the thre activations above
+     pytest.param([(64, 64), (64, 64)], torch.nn.functional.sigmoid, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.sqrt, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.exp, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.reciprocal, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.log, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.nn.functional.tanh, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.log2, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.log10, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.sin, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.cos, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.abs, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.sign, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.square, marks=pytest.mark.xfail()),
+     pytest.param([(64, 64), (64, 64)], torch.nn.functional.softplus, marks=pytest.mark.xfail()),
+    ]
+)
+def test_matmul(device, input_shapes, activation):
+    m = MatmulModule()
+    inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+    torch_result = m.forward(*inputs, activation)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    ttnn_result = m.forward(*inputs, activation)
+    option._out_fx_graphs[0].print_tabular()
+    
+    # Check the graph has be rewritten and contains ttnn mat mul and total of 7 ops
+    # (2 input args, 2 from_torch, 1 mat mul, 1 to_torch, 1 output arg)
+    nodes = list(option._out_fx_graphs[0].nodes)
+    target = [node.target for node in nodes]
+    assert target.count(ttnn.matmul) == 1 and len(target) == 7
+    
+    # Check inference result
+    assert_with_pcc(torch_result, ttnn_result, 0.98)
+
+
+class BmmModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, other, activation):
+        return activation(torch.bmm(input, other))
+
+@pytest.mark.parametrize(
+    ("input_shapes", "activation"),
+    [
+     ([(3, 64, 64), (3, 64, 64)], torch.nn.functional.relu),
+     ([(3, 64, 64), (3, 64, 64)], torch.nn.functional.gelu),
+     ([(3, 64, 64), (3, 64, 64)], torch.nn.functional.silu),
+
+     # Inside ttnn/cpp/ttnn/operations/matmul/matmul.cpp, function bound_matmul only supports the thre activations above
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.nn.functional.sigmoid, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.sqrt, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.exp, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.reciprocal, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.log, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.nn.functional.tanh, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.log2, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.log10, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.sin, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.cos, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.abs, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.sign, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.square, marks=pytest.mark.xfail()),
+     pytest.param([(3, 64, 64), (3, 64, 64)], torch.nn.functional.softplus, marks=pytest.mark.xfail()),
+    ]
+)
+def test_bmm(device, input_shapes, activation):
+    m = BmmModule()
+    inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+    torch_result = m.forward(*inputs, activation)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    ttnn_result = m.forward(*inputs, activation)
+    option._out_fx_graphs[0].print_tabular()
+    
+    # Check the graph has be rewritten and contains ttnn mat mul and total of 7 ops
+    # (2 input args, 2 from_torch, 1 mat mul, 1 to_torch, 1 output arg)
+    nodes = list(option._out_fx_graphs[0].nodes)
+    target = [node.target for node in nodes]
+    assert target.count(ttnn.matmul) == 1 and len(target) == 7
+    
+    # Check inference result
+    assert_with_pcc(torch_result, ttnn_result, 0.98)

--- a/tests/optimization/test_mm_fusion.py
+++ b/tests/optimization/test_mm_fusion.py
@@ -20,7 +20,7 @@ class MatmulModule(torch.nn.Module):
      ([(64, 64), (64, 64)], torch.nn.functional.gelu),
      ([(64, 64), (64, 64)], torch.nn.functional.silu),
      
-     # Inside ttnn/cpp/ttnn/operations/matmul/matmul.cpp, function bound_matmul only supports the thre activations above
+     # (Issue #15745) Inside ttnn/cpp/ttnn/operations/matmul/matmul.cpp, function bound_matmul only supports the three activations above
      pytest.param([(64, 64), (64, 64)], torch.nn.functional.sigmoid, marks=pytest.mark.xfail()),
      pytest.param([(64, 64), (64, 64)], torch.sqrt, marks=pytest.mark.xfail()),
      pytest.param([(64, 64), (64, 64)], torch.exp, marks=pytest.mark.xfail()),
@@ -72,7 +72,7 @@ class BmmModule(torch.nn.Module):
      ([(3, 64, 64), (3, 64, 64)], torch.nn.functional.gelu),
      ([(3, 64, 64), (3, 64, 64)], torch.nn.functional.silu),
 
-     # Inside ttnn/cpp/ttnn/operations/matmul/matmul.cpp, function bound_matmul only supports the thre activations above
+     # (Issue #15745) Inside ttnn/cpp/ttnn/operations/matmul/matmul.cpp, function bound_matmul only supports the three activations above
      pytest.param([(3, 64, 64), (3, 64, 64)], torch.nn.functional.sigmoid, marks=pytest.mark.xfail()),
      pytest.param([(3, 64, 64), (3, 64, 64)], torch.sqrt, marks=pytest.mark.xfail()),
      pytest.param([(3, 64, 64), (3, 64, 64)], torch.exp, marks=pytest.mark.xfail()),

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -111,6 +111,7 @@ def aten_backend(
     from torch.fx.passes.infra.pass_manager import PassManager
     from torch.fx.passes.dialect.common.cse_pass import CSEPass
     from torch_ttnn.passes.constant_folding_pass import ConstantFoldingPass
+    from torch_ttnn.passes.mm_fusion_pass import MMFusionPass
     from torch_ttnn.passes.lowering.to_tt_pass import ToTtPass
     from torch_ttnn.passes.lowering.add_data_move_pass import AddDataMovePass
     from torch_ttnn.passes.lowering.eliminate_coreops_pass import EliminateCoreopsPass
@@ -120,6 +121,7 @@ def aten_backend(
 
     passes = [
         ConstantFoldingPass(),
+        MMFusionPass(),
         ToTtPass(option.device, option.use_less_ttnn_op_types),
         AddDataMovePass(),
         EliminateCoreopsPass(),

--- a/torch_ttnn/passes/mm_fusion_pass.py
+++ b/torch_ttnn/passes/mm_fusion_pass.py
@@ -1,0 +1,61 @@
+import torch
+import ttnn
+from torch._subclasses.fake_tensor import unset_fake_temporarily
+from torch.fx.passes.infra.pass_base import PassBase, PassResult
+
+
+class MMFusionPass(PassBase):
+    def __init__(self):
+        super().__init__()
+        self.mm_ops = {
+            torch.ops.aten.mm.default,
+            torch.ops.aten.bmm.default,
+            # torch.ops.aten.addmm.default,
+            # torch.ops.aten.linear.default,
+            # torch.ops.aten.baddbmm.default,
+        }
+
+        self.activation_ops_map = {
+            torch.ops.aten.relu.default : 'relu',
+            torch.ops.aten.gelu.default : 'gelu',
+            torch.ops.aten.silu.default : 'silu',
+            torch.ops.aten.sigmoid.default : 'sigmoid',
+            torch.ops.aten.sqrt.default : 'sqrt',
+            torch.ops.aten.exp.default : 'exp',
+            torch.ops.aten.reciprocal.default : 'recip',
+            torch.ops.aten.log.default : 'log',
+            torch.ops.aten.tanh.default : 'tanh',
+            torch.ops.aten.log2.default : 'log2',
+            torch.ops.aten.log10.default : 'log10',
+            torch.ops.aten.sin.default : 'sin',
+            torch.ops.aten.cos.default : 'cos',
+            torch.ops.aten.abs.default : 'abs',
+            torch.ops.aten.sign.default : 'sign',
+            torch.ops.aten.pow.Tensor_Scalar : 'square',
+            torch.ops.aten.softplus.default : 'softplus',
+        }
+        
+    def call(self, gm: torch.fx.GraphModule):
+        g = gm.graph
+        #with unset_fake_temporarily():
+        for node in gm.graph.nodes:
+            # Find nodes that are mat mul and don't already have an activation fuinction fused to them
+            if node.op == "call_function" and node.target in self.mm_ops and 'activation' not in node.kwargs:
+                users = [user for user in node.users.keys()]
+                # If only user of mat mul is an activation, we can fuse activation into mat mul
+                if len(users) == 1 and users[0].op == "call_function" and users[0].target in self.activation_ops_map:
+                    activation = users[0].target
+                    if activation == torch.ops.aten.pow.Tensor_Scalar and users[0].args[1] != 2:
+                        # pow in general is not supported for fusion, but if exponent is 2 we can fuse as square op
+                        continue
+                    with g.inserting_after(node):
+                        # create ttnn mat mul with fused activation function
+                        new_kwargs = node.kwargs.copy()
+                        new_kwargs["activation"] = self.activation_ops_map[users[0].target]
+                        new_node = g.call_function(ttnn.matmul, node.args, new_kwargs)
+                    # delete torch mat mul and activation nodes that were replaced by ttnn mat mul with fused activation
+                    users[0].replace_all_uses_with(new_node)
+                    g.erase_node(users[0])                        
+                    g.erase_node(node)
+
+        return PassResult(gm, True)

--- a/torch_ttnn/passes/mm_fusion_pass.py
+++ b/torch_ttnn/passes/mm_fusion_pass.py
@@ -10,34 +10,31 @@ class MMFusionPass(PassBase):
         self.mm_ops = {
             torch.ops.aten.mm.default,
             torch.ops.aten.bmm.default,
-            # torch.ops.aten.addmm.default,
-            # torch.ops.aten.linear.default,
-            # torch.ops.aten.baddbmm.default,
         }
 
         self.activation_ops_map = {
             torch.ops.aten.relu.default : 'relu',
             torch.ops.aten.gelu.default : 'gelu',
             torch.ops.aten.silu.default : 'silu',
-            torch.ops.aten.sigmoid.default : 'sigmoid',
-            torch.ops.aten.sqrt.default : 'sqrt',
-            torch.ops.aten.exp.default : 'exp',
-            torch.ops.aten.reciprocal.default : 'recip',
-            torch.ops.aten.log.default : 'log',
-            torch.ops.aten.tanh.default : 'tanh',
-            torch.ops.aten.log2.default : 'log2',
-            torch.ops.aten.log10.default : 'log10',
-            torch.ops.aten.sin.default : 'sin',
-            torch.ops.aten.cos.default : 'cos',
-            torch.ops.aten.abs.default : 'abs',
-            torch.ops.aten.sign.default : 'sign',
-            torch.ops.aten.pow.Tensor_Scalar : 'square',
-            torch.ops.aten.softplus.default : 'softplus',
+            # (Issue #15745) Inside ttnn/cpp/ttnn/operations/matmul/matmul.cpp, function bound_matmul only supports the three activations above
+            # torch.ops.aten.sigmoid.default : 'sigmoid',
+            # torch.ops.aten.sqrt.default : 'sqrt',
+            # torch.ops.aten.exp.default : 'exp',
+            # torch.ops.aten.reciprocal.default : 'recip',
+            # torch.ops.aten.log.default : 'log',
+            # torch.ops.aten.tanh.default : 'tanh',
+            # torch.ops.aten.log2.default : 'log2',
+            # torch.ops.aten.log10.default : 'log10',
+            # torch.ops.aten.sin.default : 'sin',
+            # torch.ops.aten.cos.default : 'cos',
+            # torch.ops.aten.abs.default : 'abs',
+            # torch.ops.aten.sign.default : 'sign',
+            # torch.ops.aten.pow.Tensor_Scalar : 'square',
+            # torch.ops.aten.softplus.default : 'softplus',
         }
         
     def call(self, gm: torch.fx.GraphModule):
         g = gm.graph
-        #with unset_fake_temporarily():
         for node in gm.graph.nodes:
             # Find nodes that are mat mul and don't already have an activation fuinction fused to them
             if node.op == "call_function" and node.target in self.mm_ops and 'activation' not in node.kwargs:


### PR DESCRIPTION
### Problem description
`torch.ops.aten.mm.default` and `torch.ops.aten.bmm.default` are lowered to `ttnn.mm`, which has option to execute an activation function together with the multiplication. The three supported functions are `torch.nn.functional.relu`, `torch.nn.functional.gelu`, and `torch.nn.functional.silu`. Executing activation together with multiplication is faster, so mat mul and activation function should be fused.
     
### What's changed
`MMFusionPass` added to perform the fusion of mat mul and activation function that follows it.
Added `tests/optimization/test_mm_fusion.py` to test fusion.
