### PR TITLE
Try lowering `aten._scaled_dot_product_flash_attention`

### DIFF
--- a/tests/lowering/misc/test_scaled_dot_product_attention.py
+++ b/tests/lowering/misc/test_scaled_dot_product_attention.py
@@ -21,6 +21,7 @@ def fa_rand(*shape, dtype=torch.bfloat16):
     bernoulli = torch.bernoulli(torch.full(shape, 0.001, dtype=dtype))
     return normal_1 + normal_2 * bernoulli
 
+
 @pytest.mark.parametrize(
     "input_shape, is_causal",
     (
@@ -35,7 +36,6 @@ def fa_rand(*shape, dtype=torch.bfloat16):
         ((1, 16, 1370, 80), True),
         ((1, 12, 1, 64), True),
         ((1, 12, 4, 64), True),
-
         ((1, 16, 197, 64), False),
         ((1, 12, 197, 64), False),
         ((1, 16, 50, 64), False),
@@ -69,4 +69,4 @@ def test_sdpa(device, input_shape, is_causal):
     nodes = [node.target for node in option._out_fx_graphs[0].nodes]
     assert torch.ops.aten._scaled_dot_product_flash_attention.default not in nodes
     assert nodes.count(ttnn.transformer.scaled_dot_product_attention) == 1
-    assert_with_pcc(result_before, result_after, 0.994) # <- Same pcc as in ttnn tests
+    assert_with_pcc(result_before, result_after, 0.994)  # <- Same pcc as in ttnn tests

--- a/tests/lowering/misc/test_scaled_dot_product_attention.py
+++ b/tests/lowering/misc/test_scaled_dot_product_attention.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+import torch_ttnn
+import ttnn
+
+from tests.utils import assert_with_pcc
+
+
+class ScaledDotProductAttentionModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, *args, **kwargs):
+        return torch.nn.functional.scaled_dot_product_attention(*args, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "input_shape, is_causal",
+    (
+        ((1, 16, 197, 64), False),
+        ((1, 12, 197, 64), False),
+        ((1, 16, 50, 64), False),
+        ((1, 8, 4096, 40), False),
+        ((1, 8, 1024, 80), False),
+        ((1, 8, 256, 160), False),
+        ((1, 8, 64, 160), False),
+        ((1, 12, 50, 64), False),
+        ((1, 16, 1370, 80), False),
+        ((1, 12, 1, 64), False),
+        ((1, 12, 4, 64), True),
+    ),
+)
+def test_sdpa(device, input_shape, is_causal):
+    module = ScaledDotProductAttentionModule()
+    query = torch.rand(input_shape, dtype=torch.bfloat16)
+    key = torch.rand(input_shape, dtype=torch.bfloat16)
+    value = torch.rand(input_shape, dtype=torch.bfloat16)
+    result_before = module.forward(query, key, value, is_causal=is_causal)
+
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=False)
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    module = torch.compile(module, backend=torch_ttnn.backend, options=option)
+    result_after = module.forward(query, key, value, is_causal=is_causal)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = [node.target for node in option._out_fx_graphs[0].nodes]
+    assert torch.ops.aten._scaled_dot_product_flash_attention.default not in nodes
+    assert nodes.count(ttnn.transformer.scaled_dot_product_attention) == 1
+    assert_with_pcc(result_before, result_after)

--- a/tests/lowering/misc/test_scaled_dot_product_attention.py
+++ b/tests/lowering/misc/test_scaled_dot_product_attention.py
@@ -21,6 +21,18 @@ def rand_in_range(shape, a, b, dtype=torch.bfloat16):
 @pytest.mark.parametrize(
     "input_shape, is_causal",
     (
+        ((1, 16, 197, 64), True),
+        ((1, 12, 197, 64), True),
+        ((1, 16, 50, 64), True),
+        ((1, 8, 4096, 40), True),
+        ((1, 8, 1024, 80), True),
+        ((1, 8, 256, 160), True),
+        ((1, 8, 64, 160), True),
+        ((1, 12, 50, 64), True),
+        ((1, 16, 1370, 80), True),
+        ((1, 12, 1, 64), True),
+        ((1, 12, 4, 64), True),
+
         ((1, 16, 197, 64), False),
         ((1, 12, 197, 64), False),
         ((1, 16, 50, 64), False),
@@ -31,10 +43,11 @@ def rand_in_range(shape, a, b, dtype=torch.bfloat16):
         ((1, 12, 50, 64), False),
         ((1, 16, 1370, 80), False),
         ((1, 12, 1, 64), False),
-        ((1, 12, 4, 64), True),
+        ((1, 12, 4, 64), False),
     ),
 )
 def test_sdpa(device, input_shape, is_causal):
+    torch.manual_seed(0)
     module = ScaledDotProductAttentionModule()
     # Values must be centered around 0 to avoid accuracy issues
     query = rand_in_range(input_shape, -10.0, 10.0, dtype=torch.bfloat16)
@@ -52,4 +65,4 @@ def test_sdpa(device, input_shape, is_causal):
     nodes = [node.target for node in option._out_fx_graphs[0].nodes]
     assert torch.ops.aten._scaled_dot_product_flash_attention.default not in nodes
     assert nodes.count(ttnn.transformer.scaled_dot_product_attention) == 1
-    assert_with_pcc(result_before, result_after, 0.99)
+    assert_with_pcc(result_before, result_after, 0.997)

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -71,20 +71,6 @@ class TorchTtnnOption:
         self._ttnn_fx_graphs = list()
 
 
-HighAccuracyComputeConfig = ttnn.WormholeComputeKernelConfig(
-    math_fidelity=ttnn.MathFidelity.HiFi4,
-    math_approx_mode=False,
-    fp32_dest_acc_en=False,
-    packer_l1_acc=False,
-)
-
-MidAccuracyComputeConfig = ttnn.WormholeComputeKernelConfig(
-    math_fidelity=ttnn.MathFidelity.HiFi2,
-    math_approx_mode=True,
-    fp32_dest_acc_en=False,
-    packer_l1_acc=False,
-)
-
 def register_ttnn_objects(option: TorchTtnnOption):
     """
     torch.fx builds a source object as a string, calls builtin compile(), and finally
@@ -100,8 +86,21 @@ def register_ttnn_objects(option: TorchTtnnOption):
     torch.fx.graph._register_custom_builtin("ttnn_int32", "", ttnn.int32)
     torch.fx.graph._register_custom_builtin("ttnn_bfloat16", "", ttnn.bfloat16)
 
-    torch.fx.graph._register_custom_builtin("HighAccuracyComputeConfig", "", HighAccuracyComputeConfig)
+    MidAccuracyComputeConfig = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
     torch.fx.graph._register_custom_builtin("MidAccuracyComputeConfig", "", MidAccuracyComputeConfig)
+
+    SPDAProgramConfig = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=option.device.compute_with_storage_grid_size(),
+        q_chunk_size=32,
+        k_chunk_size=32,
+        exp_approx_mode=False,
+    )
+    torch.fx.graph._register_custom_builtin("SPDAProgramConfig", "", SPDAProgramConfig)
 
     torch.fx.graph._register_custom_builtin(
         "ttnn_DRAM_MEMORY_CONFIG",

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -78,6 +78,13 @@ HighAccuracyComputeConfig = ttnn.WormholeComputeKernelConfig(
     packer_l1_acc=False,
 )
 
+MidAccuracyComputeConfig = ttnn.WormholeComputeKernelConfig(
+    math_fidelity=ttnn.MathFidelity.HiFi2,
+    math_approx_mode=True,
+    fp32_dest_acc_en=False,
+    packer_l1_acc=False,
+)
+
 def register_ttnn_objects(option: TorchTtnnOption):
     """
     torch.fx builds a source object as a string, calls builtin compile(), and finally
@@ -94,6 +101,7 @@ def register_ttnn_objects(option: TorchTtnnOption):
     torch.fx.graph._register_custom_builtin("ttnn_bfloat16", "", ttnn.bfloat16)
 
     torch.fx.graph._register_custom_builtin("HighAccuracyComputeConfig", "", HighAccuracyComputeConfig)
+    torch.fx.graph._register_custom_builtin("MidAccuracyComputeConfig", "", MidAccuracyComputeConfig)
 
     torch.fx.graph._register_custom_builtin(
         "ttnn_DRAM_MEMORY_CONFIG",

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -83,26 +83,8 @@ def register_ttnn_objects(option: TorchTtnnOption):
     get_add_custom_object_in_graph("ttnn_ROW_MAJOR_LAYOUT", ttnn.ROW_MAJOR_LAYOUT)
     get_add_custom_object_in_graph("ttnn_TILE_LAYOUT", ttnn.TILE_LAYOUT)
 
-    torch.fx.graph._register_custom_builtin("ttnn_uint32", "", ttnn.uint32)
-    torch.fx.graph._register_custom_builtin("ttnn_int32", "", ttnn.int32)
-    torch.fx.graph._register_custom_builtin("ttnn_bfloat16", "", ttnn.bfloat16)
-
-    MidAccuracyComputeConfig = ttnn.WormholeComputeKernelConfig(
-        math_fidelity=ttnn.MathFidelity.HiFi2,
-        math_approx_mode=True,
-        fp32_dest_acc_en=False,
-        packer_l1_acc=False,
-    )
-    torch.fx.graph._register_custom_builtin("MidAccuracyComputeConfig", "", MidAccuracyComputeConfig)
-
-    SPDAProgramConfig = ttnn.SDPAProgramConfig(
-        compute_with_storage_grid_size=option.device.compute_with_storage_grid_size(),
-        q_chunk_size=32,
-        k_chunk_size=32,
-        exp_approx_mode=False,
-    )
-    torch.fx.graph._register_custom_builtin("SPDAProgramConfig", "", SPDAProgramConfig)
     get_add_custom_object_in_graph("ttnn_uint32", ttnn.uint32)
+    get_add_custom_object_in_graph("ttnn_int32", ttnn.int32)
     get_add_custom_object_in_graph("ttnn_bfloat16", ttnn.bfloat16)
 
     torch.fx.graph._register_custom_builtin(

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -71,6 +71,13 @@ class TorchTtnnOption:
         self._ttnn_fx_graphs = list()
 
 
+HighAccuracyComputeConfig = ttnn.WormholeComputeKernelConfig(
+    math_fidelity=ttnn.MathFidelity.HiFi4,
+    math_approx_mode=False,
+    fp32_dest_acc_en=False,
+    packer_l1_acc=False,
+)
+
 def register_ttnn_objects(option: TorchTtnnOption):
     """
     torch.fx builds a source object as a string, calls builtin compile(), and finally
@@ -85,6 +92,8 @@ def register_ttnn_objects(option: TorchTtnnOption):
     torch.fx.graph._register_custom_builtin("ttnn_uint32", "", ttnn.uint32)
     torch.fx.graph._register_custom_builtin("ttnn_int32", "", ttnn.int32)
     torch.fx.graph._register_custom_builtin("ttnn_bfloat16", "", ttnn.bfloat16)
+
+    torch.fx.graph._register_custom_builtin("HighAccuracyComputeConfig", "", HighAccuracyComputeConfig)
 
     torch.fx.graph._register_custom_builtin(
         "ttnn_DRAM_MEMORY_CONFIG",

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -15,6 +15,7 @@ import tools.export_code as export_code
 import torch_ttnn.metrics as metrics
 from torch_ttnn import mem_utils
 import copy
+from torch_ttnn.utils import get_add_custom_object_in_graph
 
 torch._dynamo.config.suppress_errors = False
 torch._dynamo.config.verbose = True
@@ -77,10 +78,10 @@ def register_ttnn_objects(option: TorchTtnnOption):
     calls builtin exec() with a dictionary of globals that contains the strings (keys)
     that will be replaced by the ttnn objects (values) during evaluation.
     """
-    torch.fx.graph._register_custom_builtin("ttnn_Specified_Device", "", option.device)
+    get_add_custom_object_in_graph("ttnn_Specified_Device", option.device)
 
-    torch.fx.graph._register_custom_builtin("ttnn_ROW_MAJOR_LAYOUT", "", ttnn.ROW_MAJOR_LAYOUT)
-    torch.fx.graph._register_custom_builtin("ttnn_TILE_LAYOUT", "", ttnn.TILE_LAYOUT)
+    get_add_custom_object_in_graph("ttnn_ROW_MAJOR_LAYOUT", ttnn.ROW_MAJOR_LAYOUT)
+    get_add_custom_object_in_graph("ttnn_TILE_LAYOUT", ttnn.TILE_LAYOUT)
 
     torch.fx.graph._register_custom_builtin("ttnn_uint32", "", ttnn.uint32)
     torch.fx.graph._register_custom_builtin("ttnn_int32", "", ttnn.int32)
@@ -101,6 +102,8 @@ def register_ttnn_objects(option: TorchTtnnOption):
         exp_approx_mode=False,
     )
     torch.fx.graph._register_custom_builtin("SPDAProgramConfig", "", SPDAProgramConfig)
+    get_add_custom_object_in_graph("ttnn_uint32", ttnn.uint32)
+    get_add_custom_object_in_graph("ttnn_bfloat16", ttnn.bfloat16)
 
     torch.fx.graph._register_custom_builtin(
         "ttnn_DRAM_MEMORY_CONFIG",

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -87,16 +87,8 @@ def register_ttnn_objects(option: TorchTtnnOption):
     get_add_custom_object_in_graph("ttnn_int32", ttnn.int32)
     get_add_custom_object_in_graph("ttnn_bfloat16", ttnn.bfloat16)
 
-    torch.fx.graph._register_custom_builtin(
-        "ttnn_DRAM_MEMORY_CONFIG",
-        "",
-        ttnn.DRAM_MEMORY_CONFIG,
-    )
-    torch.fx.graph._register_custom_builtin(
-        "ttnn_L1_MEMORY_CONFIG",
-        "",
-        ttnn.L1_MEMORY_CONFIG,
-    )
+    get_add_custom_object_in_graph("ttnn_DRAM_MEMORY_CONFIG", ttnn.DRAM_MEMORY_CONFIG)
+    get_add_custom_object_in_graph("ttnn_L1_MEMORY_CONFIG", ttnn.L1_MEMORY_CONFIG)
 
 
 # The backend for torch.compile that converts a graph to use ttnn.

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -223,6 +223,7 @@ def is_tt_compute(node) -> bool:
             ttnn.argmax,
             ttnn.fill,
             ttnn.empty,
+            ttnn.transformer.scaled_dot_product_attention,
         ]
     )
 

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -293,43 +293,6 @@ class NodeInputAligner:
         layout: Union[None, Type[TtnnTileLayout], Type[TtnnRowMajorLayout]]
         dtype: Union[None, Type[TtnnBfloat16], Type[TtnnUint32]]
 
-    def _align_for_special_layout(self, node, spec, input_site, input_site_type: InputSiteType):
-        if is_target_a_user_of_curr_node(node, ttnn.embedding) and (
-            input_site_type == self.InputSiteType.ARGS and input_site == 0
-        ):
-            spec.dtype = TtnnUint32
-        # TODO(#372): #322 will enable tile layout for more layout change ops
-        if node.target in TTNN_LAYOUT_CHANGE_OPS and (input_site_type == self.InputSiteType.ARGS and input_site == 0):
-            spec.layout = TtnnRowMajorLayout
-            spec.device = "host"
-        if node.target in [
-            ttnn.split,
-            ttnn.embedding,
-            target_wrappers.repeat,
-            target_wrappers.roll,
-            target_wrappers.stack,
-        ]:
-            # TODO: Only uint32 needs to to_layout on host
-            spec.layout = TtnnRowMajorLayout
-            spec.device = TtnnDevice
-        if node.target == target_wrappers.conv2d and input_site == 1:
-            # TODO(#417, tt-metal#15893): weight currently needs to be on host and can't be moved to device first
-            spec.layout = TtnnRowMajorLayout
-            spec.device = "host"
-        if (
-            node.target == ttnn.reshape
-            and hasattr(spec.input_node, "meta")
-            and "val" in spec.input_node.meta
-            and hasattr(spec.input_node.meta["val"], "dtype")
-            and spec.input_node.meta["val"].dtype in [torch.int32, torch.int64]
-        ):
-            spec.dtype = TtnnUint32
-        # Slice works only on device with any layout right now
-        if node.target == ttnn.slice and input_site_type == self.InputSiteType.ARGS and input_site == 0:
-            spec.layout = None
-            spec.device = TtnnDevice
-        return spec
-
     def _reset_to_default_layout(self, input_node, spec):
         # split(list of tensor with row major layout) => getitem(row major layout)
         # convert back to tile layout

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -10,13 +10,6 @@ from functools import partial
 
 
 aten__log_softmax_default_blocklist = [["Tensor<[19, 256008]> self = ?", "int dim = 1", "bool half_to_float = False"]]
-aten_div_Tensor_blocklist = [
-    ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
-    ["Tensor<[1, 23, 40, 1]> self = ?", "Tensor<[128]> other = ?"],
-    ["Tensor<[1, 12, 7, 7]> self = ?", "Tensor<[]> other = ?"],
-    ["Tensor<[1, 16, 5, 5]> self = ?", "Tensor<[]> other = ?"],
-    ["Tensor<[1, 16, 1, 6]> self = ?", "Tensor<[]> other = ?"],
-]
 aten_native_layer_norm_default_blocklist = [
     [
         "Tensor<[1, 9, 4096]> input = ?",
@@ -328,7 +321,6 @@ def guard_aten(blocklist, node):
 
 GUARD = {
     torch.ops.aten._log_softmax.default: partial(guard_aten, aten__log_softmax_default_blocklist),
-    torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
     torch.ops.aten.native_layer_norm.default: partial(guard_aten, aten_native_layer_norm_default_blocklist),
     torch.ops.aten.convolution.default: partial(guard_aten, aten_convolution_default_blocklist),
     torch.ops.aten.argmax.default: partial(guard_aten, aten_argmax_default_blocklist),

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -10,25 +10,6 @@ from functools import partial
 
 
 aten__log_softmax_default_blocklist = [["Tensor<[19, 256008]> self = ?", "int dim = 1", "bool half_to_float = False"]]
-aten__scaled_dot_product_flash_attention_default_blocklist = [
-    ["Tensor<[1, 16, 197, 64]> query = ?", "Tensor<[1, 16, 197, 64]> key = ?", "Tensor<[1, 16, 197, 64]> value = ?"],
-    ["Tensor<[1, 12, 197, 64]> query = ?", "Tensor<[1, 12, 197, 64]> key = ?", "Tensor<[1, 12, 197, 64]> value = ?"],
-    ["Tensor<[1, 16, 50, 64]> query = ?", "Tensor<[1, 16, 50, 64]> key = ?", "Tensor<[1, 16, 50, 64]> value = ?"],
-    ["Tensor<[1, 8, 4096, 40]> query = ?", "Tensor<[1, 8, 4096, 40]> key = ?", "Tensor<[1, 8, 4096, 40]> value = ?"],
-    ["Tensor<[1, 8, 1024, 80]> query = ?", "Tensor<[1, 8, 9, 80]> key = ?", "Tensor<[1, 8, 9, 80]> value = ?"],
-    ["Tensor<[1, 8, 256, 160]> query = ?", "Tensor<[1, 8, 256, 160]> key = ?", "Tensor<[1, 8, 256, 160]> value = ?"],
-    ["Tensor<[1, 8, 64, 160]> query = ?", "Tensor<[1, 8, 64, 160]> key = ?", "Tensor<[1, 8, 64, 160]> value = ?"],
-    ["Tensor<[1, 12, 50, 64]> query = ?", "Tensor<[1, 12, 50, 64]> key = ?", "Tensor<[1, 12, 50, 64]> value = ?"],
-    ["Tensor<[1, 16, 1370, 80]> query = ?", "Tensor<[1, 16, 1370, 80]> key = ?", "Tensor<[1, 16, 1370, 80]> value = ?"],
-    ["Tensor<[1, 12, 1, 64]> query = ?", "Tensor<[1, 12, 1, 64]> key = ?", "Tensor<[1, 12, 1, 64]> value = ?"],
-    [
-        "Tensor<[1, 12, 4, 64]> query = ?",
-        "Tensor<[1, 12, 4, 64]> key = ?",
-        "Tensor<[1, 12, 4, 64]> value = ?",
-        "float dropout_p = 0.0",
-        "bool is_causal = True",
-    ],
-]
 aten_div_Tensor_blocklist = [
     ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
     ["Tensor<[1, 23, 40, 1]> self = ?", "Tensor<[128]> other = ?"],
@@ -347,9 +328,6 @@ def guard_aten(blocklist, node):
 
 GUARD = {
     torch.ops.aten._log_softmax.default: partial(guard_aten, aten__log_softmax_default_blocklist),
-    torch.ops.aten._scaled_dot_product_flash_attention.default: partial(
-        guard_aten, aten__scaled_dot_product_flash_attention_default_blocklist
-    ),
     torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
     torch.ops.aten.native_layer_norm.default: partial(guard_aten, aten_native_layer_norm_default_blocklist),
     torch.ops.aten.convolution.default: partial(guard_aten, aten_convolution_default_blocklist),

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -29,6 +29,13 @@ aten__scaled_dot_product_flash_attention_default_blocklist = [
         "bool is_causal = True",
     ],
 ]
+aten_div_Tensor_blocklist = [
+    ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 23, 40, 1]> self = ?", "Tensor<[128]> other = ?"],
+    ["Tensor<[1, 12, 7, 7]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 16, 5, 5]> self = ?", "Tensor<[]> other = ?"],
+    ["Tensor<[1, 16, 1, 6]> self = ?", "Tensor<[]> other = ?"],
+]
 aten_native_layer_norm_default_blocklist = [
     [
         "Tensor<[1, 9, 4096]> input = ?",
@@ -343,6 +350,7 @@ GUARD = {
     torch.ops.aten._scaled_dot_product_flash_attention.default: partial(
         guard_aten, aten__scaled_dot_product_flash_attention_default_blocklist
     ),
+    torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
     torch.ops.aten.native_layer_norm.default: partial(guard_aten, aten_native_layer_norm_default_blocklist),
     torch.ops.aten.convolution.default: partial(guard_aten, aten_convolution_default_blocklist),
     torch.ops.aten.argmax.default: partial(guard_aten, aten_argmax_default_blocklist),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1386,7 +1386,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                 def select(dropout_p=0.0, is_causal=False):
                     # TODO(jdh8): Add support for training mode
                     if dropout_p > 0.0 or not is_getitem_0_only_user(node):
-                        return g.call_function(node.target, args, kwargs)
+                        return None
 
                     # Pad last dimension of Q, K, V to tile size
                     q, k, v = args[:3]

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1413,13 +1413,6 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                         )
                     else:
                         raise RuntimeError(f"Unsupported device for {device.arch()} compute kernel config")
-                    compute_kernel_config = get_emplace_custom_object_in_graph(
-                        ttnn.WormholeComputeKernelConfig,
-                        math_fidelity=ttnn.MathFidelity.HiFi2,
-                        math_approx_mode=True,
-                        fp32_dest_acc_en=False,
-                        packer_l1_acc=False,
-                    )
                     program_config = get_emplace_custom_object_in_graph(
                         ttnn.SDPAProgramConfig,
                         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1388,7 +1388,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                     return q, k, v, d
 
                 def select(dropout_p=0.0, is_causal=False):
-                    # TODO(jdh8): Add suuport for training mode
+                    # TODO(jdh8): Add support for training mode
                     if dropout_p > 0.0:
                         return g.call_function(node.target, args, kwargs)
 
@@ -1407,7 +1407,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                         fp32_dest_acc_en=False,
                         packer_l1_acc=False,
                     )
-                    progra_config = get_emplace_custom_object_in_graph(
+                    program_config = get_emplace_custom_object_in_graph(
                         ttnn.SDPAProgramConfig,
                         compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
                         q_chunk_size=32,
@@ -1421,7 +1421,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                             "is_causal": is_causal,
                             "scale": kwargs.get("scale", None),
                             "compute_kernel_config": compute_kernel_config,
-                            "program_config": progra_config,
+                            "program_config": program_config,
                         },
                     )
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1385,7 +1385,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
 
                 def select(dropout_p=0.0, is_causal=False):
                     # TODO(jdh8): Add support for training mode
-                    if dropout_p > 0.0:
+                    if dropout_p > 0.0 or not is_getitem_0_only_user(node):
                         return g.call_function(node.target, args, kwargs)
 
                     # Pad last dimension of Q, K, V to tile size
@@ -1442,7 +1442,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
 
                     # torch.ops.aten._scaled_dot_product_flash_attention.default return a tuple of values and inserts a
                     # getitem(ret, 0) after it. ttnn.transformer.scaled_dot_product_attention only returns one value.
-                    if (val := res_node.meta.get("val", None)) is not None and is_getitem_0_only_user(node):
+                    if (val := res_node.meta.get("val", None)) is not None:
                         res_node.meta["val"] = val[0]
 
                     return res_node

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -17,6 +17,7 @@ from torch_ttnn.utils import (
     TtnnRowMajorLayout,
     TtnnTileLayout,
     TtnnHighAccuracyComputeConfig,
+    TtnnMidAccuracyComputeConfig,
     get_shape,
     get_dtype,
     get_arg,
@@ -1361,7 +1362,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                         kwargs={
                             "is_causal": is_causal,
                             "scale": kwargs.get("scale", None),
-                            "compute_kernel_config": TtnnHighAccuracyComputeConfig(),
+                            "compute_kernel_config": TtnnMidAccuracyComputeConfig() if is_causal else TtnnHighAccuracyComputeConfig(),
                         }
                     )
                     # torch.ops.aten._scaled_dot_product_flash_attention.default return a tuple of values and inserts a 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -427,8 +427,8 @@ class GraphWrapper:
             pad = []
             input_shape = args[0].meta["val"].shape
             for dim in range(len(args[1])):
-                pad.append(-args[2][dim])
-                pad.append(args[1][dim] - input_shape[dim])
+                pad.append(args[2][dim])
+                pad.append(args[1][dim] - args[2][dim] - input_shape[dim])
             return torch.nn.functional.pad(self._get_val(args[0]), tuple(pad), value=args[3])
         return self._get_val(node)
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1392,7 +1392,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
 
                 def select(dropout_p=0.0, is_causal=False):
                     # TODO(jdh8): Add support for training mode
-                    if dropout_p > 0.0 or ttnn.device.is_grayskull(device):
+                    if dropout_p > 0.0:
                         return g.call_function(node.target, args, kwargs)
 
                     # Pad last dimension of Q, K, V to tile size

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -189,6 +189,7 @@ class ReplaceMoreTt(torch.fx.Transformer):
                 call_func.node.meta["original_input_variations"] = metrics.collect_input_variation(
                     self.old_target, self.old_args, self.old_kwargs
                 )
+
         return call_func
 
     def call_function(self, target, args, kwargs):
@@ -442,8 +443,6 @@ class GraphWrapper:
             return val
         return obj.meta["val"]
 
-    def inserting_after(self, node):
-        return self.g.inserting_after(node)
 
 def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_types: bool) -> torch.fx.GraphModule:
     nodes = list(gm.graph.nodes)

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -135,3 +135,7 @@ class TtnnL1MemoryConfig:
 class TtnnHighAccuracyComputeConfig:
     def __repr__(self):
         return f"HighAccuracyComputeConfig"
+
+class TtnnMidAccuracyComputeConfig:
+    def __repr__(self):
+        return f"MidAccuracyComputeConfig"

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -133,8 +133,11 @@ class TtnnL1MemoryConfig:
     def __repr__(self):
         return f"ttnn_L1_MEMORY_CONFIG"
 
+
 # repr_str -> (object_wrapper, object)
 __custom_objects_registry = {}
+
+
 # Note: key MUST be unique!
 def get_add_custom_object_in_graph(key: str, obj):
     if key in __custom_objects_registry:
@@ -148,13 +151,14 @@ def get_add_custom_object_in_graph(key: str, obj):
     __custom_objects_registry[key] = (WrapperObj(), obj)
     return __custom_objects_registry[key][0]
 
+
 def get_emplace_custom_object_in_graph(object_type, *args, **kwargs):
     def sanitize(s):
         # Replace non-alphanumeric characters with underscores
-        s = re.sub(r'[^0-9a-zA-Z_]', '_', str(s))
+        s = re.sub(r"[^0-9a-zA-Z_]", "_", str(s))
         # Remove consecutive underscores
-        s = re.sub(r'_+', '_', s)
-        return s.strip('_')
+        s = re.sub(r"_+", "_", s)
+        return s.strip("_")
 
     # This representation of an object MUST be unique
     def build_repr():
@@ -164,6 +168,7 @@ def get_emplace_custom_object_in_graph(object_type, *args, **kwargs):
         for k, v in kwargs.items():
             repr_str += f"_{sanitize(k)}_{sanitize(v)}"
         return repr_str
+
     key = build_repr()
 
     if key in __custom_objects_registry:

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -171,14 +171,4 @@ def get_emplace_custom_object_in_graph(object_type, *args, **kwargs):
 
     key = build_repr()
 
-    if key in __custom_objects_registry:
-        return __custom_objects_registry[key][0]
-
-    class WrapperObj:
-        def __repr__(self):
-            return key
-
-    obj = object_type(*args, **kwargs)
-    torch.fx.graph._register_custom_builtin(key, "", obj)
-    __custom_objects_registry[key] = (WrapperObj(), obj)
-    return __custom_objects_registry[key][0]
+    return get_add_custom_object_in_graph(key, object_type(*args, **kwargs))

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import torch
+import re
 
 
 def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
@@ -132,10 +133,47 @@ class TtnnL1MemoryConfig:
     def __repr__(self):
         return f"ttnn_L1_MEMORY_CONFIG"
 
-class TtnnMidAccuracyComputeConfig:
-    def __repr__(self):
-        return f"MidAccuracyComputeConfig"
+# repr_str -> (object_wrapper, object)
+__custom_objects_registry = {}
+# Note: key MUST be unique!
+def get_add_custom_object_in_graph(key: str, obj):
+    if key in __custom_objects_registry:
+        return __custom_objects_registry[key][0]
 
-class TtnnSPDAProgramConfig:
-    def __repr__(self):
-        return f"SPDAProgramConfig"
+    class WrapperObj:
+        def __repr__(self):
+            return key
+
+    torch.fx.graph._register_custom_builtin(key, "", obj)
+    __custom_objects_registry[key] = (WrapperObj(), obj)
+    return __custom_objects_registry[key][0]
+
+def get_emplace_custom_object_in_graph(object_type, *args, **kwargs):
+    def sanitize(s):
+        # Replace non-alphanumeric characters with underscores
+        s = re.sub(r'[^0-9a-zA-Z_]', '_', str(s))
+        # Remove consecutive underscores
+        s = re.sub(r'_+', '_', s)
+        return s.strip('_')
+
+    # This representation of an object MUST be unique
+    def build_repr():
+        repr_str = f"{object_type.__name__}"
+        for arg in args:
+            repr_str += f"_{sanitize(arg)}"
+        for k, v in kwargs.items():
+            repr_str += f"_{sanitize(k)}_{sanitize(v)}"
+        return repr_str
+    key = build_repr()
+
+    if key in __custom_objects_registry:
+        return __custom_objects_registry[key][0]
+
+    class WrapperObj:
+        def __repr__(self):
+            return key
+
+    obj = object_type(*args, **kwargs)
+    torch.fx.graph._register_custom_builtin(key, "", obj)
+    __custom_objects_registry[key] = (WrapperObj(), obj)
+    return __custom_objects_registry[key][0]

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -131,3 +131,7 @@ class TtnnDramMemoryConfig:
 class TtnnL1MemoryConfig:
     def __repr__(self):
         return f"ttnn_L1_MEMORY_CONFIG"
+
+class TtnnHighAccuracyComputeConfig:
+    def __repr__(self):
+        return f"HighAccuracyComputeConfig"

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -132,10 +132,10 @@ class TtnnL1MemoryConfig:
     def __repr__(self):
         return f"ttnn_L1_MEMORY_CONFIG"
 
-class TtnnHighAccuracyComputeConfig:
-    def __repr__(self):
-        return f"HighAccuracyComputeConfig"
-
 class TtnnMidAccuracyComputeConfig:
     def __repr__(self):
         return f"MidAccuracyComputeConfig"
+
+class TtnnSPDAProgramConfig:
+    def __repr__(self):
+        return f"SPDAProgramConfig"


### PR DESCRIPTION
### Ticket
- Resolves #541

### Problem description
Convert `aten._scaled_dot_product_flash_attention` to a series of ops.  Future goal might be implementing it as a composite kernel op instead.

The source op is functionally equivalent to its high-level counterpart:
https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html

### What's changed

- Remove fallback for torch.ops.aten._scaled_dot_product_flash_attention.default. 
- since ttnn.transformer.scaled_dot_product_attention requires last dimension padded to tile_size, I added padding nodes before and slicing after if needed. 
- Remove getitem(out, 0) node after ttnn.transformer.scaled_dot_product_attention and fix metadata, since it returns only 1 value (unlike torch self attention)
- add unittest for sdpa
- Add get_add_custom_object_in_graph and get_emplace_custom_object_in_graph function to simplify adding custom objects in fx graph
