### PR TITLE
Lowering transpose 

### DIFF
--- a/tests/lowering/tensor_manipulation/test_transpose.py
+++ b/tests/lowering/tensor_manipulation/test_transpose.py
@@ -23,6 +23,13 @@ class TransposeModule(torch.nn.Module):
         ((5, 3, 1), 0, 1),
         ((1, 3), 0, 1),
         ((3, 1), 1, 0),
+        ((1, 197, 1, 3, 1024), 0, -2),
+        pytest.param(
+            (1, 197, 1, 3, 1024),
+            1,
+            -2,
+            marks=pytest.mark.xfail(reason="transpose rank > 4 issues (#585)"),
+        ),
     ],
 )
 def test_transpose(device, input_shape, dim0, dim1):

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -113,22 +113,6 @@ aten__scaled_dot_product_flash_attention_default_blocklist = [
         "bool is_causal = True",
     ],
 ]
-aten_transpose_int_blocklist = [
-    ["Tensor<[1, 197, 1, 3, 1024]> self = ?", "int dim0 = 0", "int dim1 = -2"],
-    ["Tensor<[12, 197, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
-    ["Tensor<[12, 64, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
-    ["Tensor<[1, 12, 64, 197]> self = ?", "int dim0 = -1", "int dim1 = -2"],
-    ["Tensor<[1, 197, 1, 3, 768]> self = ?", "int dim0 = 0", "int dim1 = -2"],
-    ["Tensor<[1, 768, 49]> self = ?", "int dim0 = 1", "int dim1 = 2"],
-    ["Tensor<[16, 7, 7]> self = ?", "int dim0 = 1", "int dim1 = 2"],
-    ["Tensor<[16, 64, 7]> self = ?", "int dim0 = 1", "int dim1 = 2"],
-    ["Tensor<[1, 50, 1, 3, 1024]> self = ?", "int dim0 = 0", "int dim1 = -2"],
-    ["Tensor<[1, 50, 1, 3, 768]> self = ?", "int dim0 = 0", "int dim1 = -2"],
-    ["Tensor<[1, 1370, 1, 3, 1280]> self = ?", "int dim0 = 0", "int dim1 = -2"],
-    ["Tensor<[16, 197, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
-    ["Tensor<[16, 64, 197]> self = ?", "int dim0 = 1", "int dim1 = 2"],
-    ["Tensor<[1, 16, 64, 197]> self = ?", "int dim0 = -1", "int dim1 = -2"],
-]
 aten_zeros_like_default_blocklist = [
     ["Tensor<[13685]> self = ?", "Optional[int] dtype = torch.bool", "Optional[bool] pin_memory = False"],
     ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
@@ -1504,7 +1488,6 @@ GUARD = {
     torch.ops.aten._scaled_dot_product_flash_attention.default: partial(
         guard_aten, aten__scaled_dot_product_flash_attention_default_blocklist
     ),
-    torch.ops.aten.transpose.int: partial(guard_aten, aten_transpose_int_blocklist),
     torch.ops.aten.zeros_like.default: partial(guard_aten, aten_zeros_like_default_blocklist),
     torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
     torch.ops.aten.mul.Tensor: partial(guard_aten, aten_mul_Tensor_blocklist),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -720,33 +720,35 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 if rank <= 4:
                     return g.call_function(ttnn.transpose, args=(args[0], dim0, dim1))
 
-                # Try to reshape,
+                # Try to reshape. Find the new shape here
                 #   eg. the original shape [A, B, C, D, E] shape[dim0] = A, shape[dim1] = D
                 #   reshape to [A, (B*C), D, E]
-                originalShape = list(args[0].meta["val"].size())
-                newShape = []
-                newDim0, newDim1 = 0, 1
-                if len(originalShape[:dim0]) > 0:
-                    newShape.append(np.prod(originalShape[:dim0]))
-                    newDim0 += 1
-                    newDim1 += 1
+                original_shape = list(args[0].meta["val"].size())
+                dim0, dim1 = (dim0, dim1) if dim0 < dim1 else (dim1, dim0)
 
-                newShape.append(originalShape[dim0])
+                new_dim0, new_dim1 = 0, 1
+                new_shape = []
+                if len(original_shape[:dim0]) > 0:
+                    new_shape.append(np.prod(original_shape[:dim0]))
+                    new_dim0 += 1
+                    new_dim1 += 1
 
-                if len(originalShape[dim0 + 1 : dim1]) > 0:
-                    newShape.append(np.prod(originalShape[dim0 + 1 : dim1]))
-                    newDim1 += 1
+                new_shape.append(original_shape[dim0])
 
-                newShape.append(originalShape[dim1])
+                if len(original_shape[dim0 + 1 : dim1]) > 0:
+                    new_shape.append(np.prod(original_shape[dim0 + 1 : dim1]))
+                    new_dim1 += 1
+
+                new_shape.append(original_shape[dim1])
 
                 if dim1 + 1 < rank:
-                    newShape.append(np.prod(originalShape[dim1 + 1 :]))
+                    new_shape.append(np.prod(original_shape[dim1 + 1 :]))
 
                 # if the rank of reshaped result still <= 4, then do
                 #    reshape->transpose->reshape
-                if len(newShape) <= 4:
-                    reshaped = g.call_function(ttnn.reshape, args=(args[0], list(newShape)))
-                    transposed = g.call_function(ttnn.transpose, args=(reshaped, newDim0, newDim1))
+                if len(new_shape) <= 4:
+                    reshaped = g.call_function(ttnn.reshape, args=(args[0], list(new_shape)))
+                    transposed = g.call_function(ttnn.transpose, args=(reshaped, new_dim0, new_dim1))
                     output_shape = list(node.meta["val"].size())
                     return g.call_function(ttnn.reshape, args=(transposed, list(output_shape)))
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/543

### Problem description
1. `aten.transpose.int` operation not lowering to TTNN
2. tensor with rank > 4 could not support by `ttnn.transpose`

### What's changed
1. Remove `aten.transpose.int` op guarding block list
2. Try do `ttnn.reshape->ttnn.transpose->ttnn.reshape` to do transpose tensor of rank > 4
