### PR TITLE
Fix `aten.split.Tensor` lowering

### DIFF
--- a/tests/pattern/test_detr.py
+++ b/tests/pattern/test_detr.py
@@ -1,0 +1,25 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+
+class PatternModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, arg56_1, addend):
+        split = torch.ops.aten.split.Tensor(arg56_1, 256)
+        getitem_2 = split[0]
+        return torch.ops.aten.add.Tensor(getitem_2, addend)
+
+
+def test_detr_pattern(device):
+    m = PatternModule()
+    arg56_1 = torch.randn([768, 256]).to(torch.bfloat16)
+    addend = torch.randn([256, 256]).to(torch.bfloat16)
+    result_before = m.forward(arg56_1, addend)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(arg56_1, addend)
+    assert torch.allclose(result_before, result_after, rtol=0.1, atol=0.1)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -12,6 +12,7 @@ from torch_ttnn.utils import (
 from dataclasses import dataclass
 from enum import Enum
 from typing import Union, Type, Literal
+from operator import getitem
 
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 from . import target_wrappers
@@ -304,13 +305,17 @@ class NodeInputAligner:
         if node.target in TTNN_LAYOUT_CHANGE_OPS and (input_site_type == self.InputSiteType.ARGS and input_site == 0):
             spec.layout = TtnnRowMajorLayout
             spec.device = "host"
-        if node.target in [ttnn.embedding, ttnn.zeros_like, target_wrappers.repeat, target_wrappers.roll]:
+        if node.target in [ttnn.split, ttnn.embedding, ttnn.zeros_like, target_wrappers.repeat, target_wrappers.roll]:
             # TODO: Only uint32 needs to to_layout on host
             spec.layout = TtnnRowMajorLayout
             spec.device = TtnnDevice
         return spec
 
     def _reset_to_default_layout(self, input_node, spec):
+        # split(list of tensor with row major layout) => getitem(row major layout)
+        # convert back to tile layout
+        if input_node.target == getitem and input_node.args[0].target == ttnn.split:
+            spec.layout = TtnnTileLayout
         # legalize to the default layout and device
         if input_node.target in TTNN_LAYOUT_CHANGE_OPS.union(
             set(

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -111,11 +111,6 @@ aten_native_layer_norm_default_blocklist = [
     ],
 ]
 aten_exp_default_blocklist = [["Tensor<[0, 1]> self = ?"], ["Tensor<[]> self = ?"]]
-aten_split_Tensor_blocklist = [
-    ["Tensor<[768, 256]> self = ?", "int split_size = 256"],
-    ["Tensor<[768]> self = ?", "int split_size = 256"],
-    ["Tensor<[1, 7, 2304]> self = ?", "int split_size = 768", "int dim = 2"],
-]
 aten_where_self_blocklist = [
     ["Tensor<[1, 1, 7, 7]> condition = ?", "Tensor<[1, 12, 7, 7]> self = ?", "Tensor<[]> other = ?"],
     ["Tensor<[1, 1, 45, 45]> condition = ?", "Tensor<[1, 12, 45, 45]> self = ?", "Tensor<[]> other = ?"],
@@ -1102,7 +1097,6 @@ GUARD = {
     torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
     torch.ops.aten.native_layer_norm.default: partial(guard_aten, aten_native_layer_norm_default_blocklist),
     torch.ops.aten.exp.default: partial(guard_aten, aten_exp_default_blocklist),
-    torch.ops.aten.split.Tensor: partial(guard_aten, aten_split_Tensor_blocklist),
     torch.ops.aten.where.self: partial(guard_aten, aten_where_self_blocklist),
     torch.ops.aten.empty.memory_format: partial(guard_aten, aten_empty_memory_format_blocklist),
     torch.ops.aten.rsqrt.default: partial(guard_aten, aten_rsqrt_default_blocklist),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -811,18 +811,25 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
             if node.target == torch.ops.aten.split.Tensor:
                 # convert input tensopr to ROW MAJOR layout for split
                 to_layout = g.call_function(ttnn.to_layout, (args[0],), {"layout": TtnnRowMajorLayout()})
+                if len(args[0].meta["val"].size()) == 1:
+                    # For example, the input shape original is [768]
+                    # But due to issue #390 it become [1, 768] and cause failed
+                    # remove this part once #390 is solved
+                    return None
 
                 # convert relative split dim to absolute
-                if args[2] >= 0:
-                    split_dim = args[0]
+                dim = args[2] if len(args) > 2 else 0
+                if dim >= 0:
+                    split_dim = dim
                 else:
-                    split_dim = len(args[0].meta["val"].size()) + args[2]
+                    split_dim = len(args[0].meta["val"].size()) + dim
 
                 # convert from PyTorch size of chunk to ttnn number of chunks
                 if isinstance(args[1], int):
                     num_chunks = math.floor(args[0].meta["val"].size()[split_dim] / args[1])
                 else:
-                    raise RuntimeError(f"ttnn.split only supports chunks of same size.")
+                    # ttnn.split only supports chunks of same size.
+                    return None
 
                 new_args = (to_layout, num_chunks, split_dim)
                 return g.call_function(ttnn.split, args=new_args)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -809,8 +809,6 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(ttnn.reshape, (args[0], args[1]), {})
 
             if node.target == torch.ops.aten.split.Tensor:
-                # convert input tensopr to ROW MAJOR layout for split
-                to_layout = g.call_function(ttnn.to_layout, (args[0],), {"layout": TtnnRowMajorLayout()})
                 if len(args[0].meta["val"].size()) == 1:
                     # For example, the input shape original is [768]
                     # But due to issue #390 it become [1, 768] and cause failed
@@ -831,7 +829,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                     # ttnn.split only supports chunks of same size.
                     return None
 
-                new_args = (to_layout, num_chunks, split_dim)
+                new_args = (args[0], num_chunks, split_dim)
                 return g.call_function(ttnn.split, args=new_args)
 
             if node.target == torch.ops.aten._to_copy.default:


### PR DESCRIPTION
### Ticket
#595 

### Problem description
Fix lowering of split and identify this issue

https://github.com/tenstorrent/pytorch2.0_ttnn/blob/61de9b9f12ef7645ef2c729a988a38f188c98305/torch_ttnn/passes/lowering/to_tt_pass.py#L778-L782

### What's changed
 - Fix split lowering
 - Remove aten_split_Tensor_blocklist
