### PR TITLE
Fix some `aten.add/mul` not lowered

### DIFF
--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -457,9 +457,12 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(target_wrappers.pack_to_tuple, (output,))
 
             def lower_binary_eltwise(fn, args):
+                if any(isinstance(x, (int, float)) for x in args):
+                    return g.call_function(fn, args)
+
                 shapes = get_shape(args[0]), get_shape(args[1])
 
-                if any(s is None for s in shapes):
+                if any(not s for s in shapes):
                     return None
 
                 if max(map(len, shapes)) > 4 and shapes[0][-3:-2] != shapes[1][-3:-2]:

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -459,6 +459,12 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
             def lower_binary_eltwise(fn, args):
                 shapes = get_shape(args[0]), get_shape(args[1])
 
+                if (isinstance(args[0], torch.fx.node.Node) and shapes[0] == torch.Size()) or (
+                    isinstance(args[1], torch.fx.node.Node) and shapes[1] == torch.Size()
+                ):
+                    # ttnn.from_torch not yet support scalar tensor, see issue 442
+                    return None
+
                 if any(s is None for s in shapes):
                     return None
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -457,12 +457,9 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(target_wrappers.pack_to_tuple, (output,))
 
             def lower_binary_eltwise(fn, args):
-                if any(isinstance(x, (int, float)) for x in args):
-                    return g.call_function(fn, args)
-
                 shapes = get_shape(args[0]), get_shape(args[1])
 
-                if any(not s for s in shapes):
+                if any(s is None for s in shapes):
                     return None
 
                 if max(map(len, shapes)) > 4 and shapes[0][-3:-2] != shapes[1][-3:-2]:

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -459,7 +459,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
             def lower_binary_eltwise(fn, args):
                 shapes = get_shape(args[0]), get_shape(args[1])
 
-                if any(not s for s in shapes):
+                if any(s is None for s in shapes):
                     return None
 
                 if max(map(len, shapes)) > 4 and shapes[0][-3:-2] != shapes[1][-3:-2]:

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -12,12 +12,11 @@ def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 def get_shape(node_or_shape):
     if isinstance(node_or_shape, (int, float)):
         return torch.Size([])
+    if isinstance(node_or_shape, (torch.Size, list, tuple)):
+        return node_or_shape
     if isinstance(node_or_shape, torch.fx.node.Node):
         if (val := node_or_shape.meta.get("val", None)) is not None:
             return val.size()
-    elif isinstance(node_or_shape, torch.Size) or isinstance(node_or_shape, list):
-        return node_or_shape
-
     return None
 
 

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -10,6 +10,8 @@ def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 
 def get_shape(node_or_shape):
+    if isinstance(node_or_shape, (int, float)):
+        return torch.Size([])
     if isinstance(node_or_shape, torch.fx.node.Node):
         if (val := node_or_shape.meta.get("val", None)) is not None:
             return val.size()

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -11,7 +11,7 @@ def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 def get_shape(node_or_shape):
     if isinstance(node_or_shape, (int, float)):
-        return torch.Size([])
+        return torch.Size()
     if isinstance(node_or_shape, (torch.Size, list, tuple)):
         return node_or_shape
     if isinstance(node_or_shape, torch.fx.node.Node):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Some ✅ modes become 🚧 
 - BERT
 - SqueezeBERT
 - Perceiver IO
 - albert/albert-base-v2-classification
 - twmkn9/albert-base-v2-squad2

And the reason is `aten.add/mul` become not lowered

I think the root cause is because `get_shape(node)` not handle the scalar case

### What's changed
 - Let `get_shape(node)` handle the arg is scalar case, and above model is back to ✅
