### PR TITLE
Lowering `aten.argmax.default` to TTNN

### DIFF
--- a/tests/lowering/misc/test_argmax.py
+++ b/tests/lowering/misc/test_argmax.py
@@ -1,0 +1,40 @@
+import torch
+import torch_ttnn
+import pytest
+import ttnn
+
+from tests.utils import assert_with_pcc
+
+
+class ArgmaxModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim):
+        return torch.argmax(input, dim=dim)
+
+
+@pytest.mark.xfail(reason="argmax issues (#605)")
+@pytest.mark.parametrize(
+    "input_shapes, dim",
+    [
+        ((1, 32), None),
+    ],
+)
+def test_select(device, input_shapes, dim):
+    m = ArgmaxModule()
+    inputs = torch.rand(input_shapes, dtype=torch.bfloat16)
+    result_before = m.forward(inputs, dim)
+
+    option = torch_ttnn.TorchTtnnOption(device=device)
+
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+
+    result_after = m.forward(inputs, dim)
+    print(option._out_fx_graphs[0])
+
+    # Check the graph has be rewritten and contain ttnn ops
+
+    # Check inference result
+    assert_with_pcc(result_before, result_after, pcc=0.99)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -151,6 +151,7 @@ TTNN_LAYOUT_CHANGE_OPS = set(
     [
         ttnn.reshape,
         ttnn.slice,
+        ttnn.argmax,
     ]
 )
 
@@ -191,6 +192,7 @@ def is_tt_compute(node) -> bool:
             ttnn.moreh_cumsum,
             ttnn.sum,
             ttnn.typecast,
+            ttnn.argmax,
         ]
     )
 

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -1386,6 +1386,12 @@ aten_convolution_default_blocklist = [
     ],
 ]
 
+aten_argmax_default_blocklist = [
+    ["Tensor<[2, 7]> self = ?", "Optional[int] dim = -1"],
+    ["Tensor<[1, 7]> self = ?", "Optional[int] dim = -1"],
+    ["Tensor<[1, 51865]> self = ?", "Optional[int] dim = -1"],
+]
+
 
 def get_inputs(node):
     node_inputs = metrics.collect_input_variation_from_node(node)
@@ -1427,6 +1433,7 @@ GUARD = {
     torch.ops.aten.new_empty_strided.default: partial(guard_aten, aten_new_empty_strided_default_blocklist),
     torch.ops.aten.mm.default: partial(guard_aten, aten_mm_default_blocklist),
     torch.ops.aten.convolution.default: partial(guard_aten, aten_convolution_default_blocklist),
+    torch.ops.aten.argmax.default: partial(guard_aten, aten_argmax_default_blocklist),
 }
 
 guard_ops = [

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1147,6 +1147,16 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
                 return g.call_function(ttnn.concat, (tensors_to_concat, dim))
 
+            if node.target == torch.ops.aten.argmax.default:
+                tensor, *dim = args
+                rank = len(tensor.meta["val"].size())
+                tt_kwargs = {}
+                if dim:
+                    dim = (dim[0] + rank) % rank
+                    tt_kwargs["dim"] = dim
+
+                return g.call_function(ttnn.argmax, args=(tensor,), kwargs=tt_kwargs)
+
             # PEP 8 suggests this explicit statement
             return None
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/571

### Problem description

`aten.argmax.default` not lowering to `ttnn.argmax`

### What's changed
1. Add lowering aten.argmax.default to ttnn.argmax
2. Add test_argmax.py
