### PR TITLE
constant folding for `aten.ones.default` and remove guard blocklist

### DIFF
--- a/tests/lowering/creation/test_ones.py
+++ b/tests/lowering/creation/test_ones.py
@@ -28,7 +28,7 @@ def test_ones(device, input_shapes):
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops
-    nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.ones) == 1
+    nodes = [node.target for node in option._out_fx_graphs[0].nodes]
+    assert nodes.count(torch.ops.aten.ones.default) == 0
     # Check inference result
     assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/passes/constant_folding_pass.py
+++ b/torch_ttnn/passes/constant_folding_pass.py
@@ -21,6 +21,7 @@ class ConstantFoldingPass(PassBase):
             torch.ops.aten.sub.Tensor,
             torch.ops.aten.ceil.default,
             torch.ops.aten.clamp.default,
+            torch.ops.aten.ones.default,
         }
 
     def call(self, gm: torch.fx.GraphModule):

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -148,27 +148,6 @@ aten_split_Tensor_blocklist = [
     ["Tensor<[768]> self = ?", "int split_size = 256"],
     ["Tensor<[1, 7, 2304]> self = ?", "int split_size = 768", "int dim = 2"],
 ]
-aten_ones_default_blocklist = [
-    [
-        "List[int] size = [7, 7]",
-        "Optional[int] dtype = torch.bool",
-        "Optional[int] layout = torch.strided",
-        "Optional[Device] device = cpu",
-    ],
-    [
-        "List[int] size = [1, 1]",
-        "Optional[int] dtype = torch.int64",
-        "Optional[Device] device = cpu",
-        "Optional[bool] pin_memory = False",
-    ],
-    ["List[int] size = [1, 1]", "Optional[Device] device = cpu", "Optional[bool] pin_memory = False"],
-    [
-        "List[int] size = [1, 1, 1]",
-        "Optional[int] dtype = torch.float32",
-        "Optional[Device] device = cpu",
-        "Optional[bool] pin_memory = False",
-    ],
-]
 aten_where_self_blocklist = [
     ["Tensor<[1, 1, 7, 7]> condition = ?", "Tensor<[1, 12, 7, 7]> self = ?", "Tensor<[]> other = ?"],
     ["Tensor<[1, 1, 45, 45]> condition = ?", "Tensor<[1, 12, 45, 45]> self = ?", "Tensor<[]> other = ?"],
@@ -1418,7 +1397,6 @@ GUARD = {
     torch.ops.aten.native_layer_norm.default: partial(guard_aten, aten_native_layer_norm_default_blocklist),
     torch.ops.aten.exp.default: partial(guard_aten, aten_exp_default_blocklist),
     torch.ops.aten.split.Tensor: partial(guard_aten, aten_split_Tensor_blocklist),
-    torch.ops.aten.ones.default: partial(guard_aten, aten_ones_default_blocklist),
     torch.ops.aten.where.self: partial(guard_aten, aten_where_self_blocklist),
     torch.ops.aten.empty.memory_format: partial(guard_aten, aten_empty_memory_format_blocklist),
     torch.ops.aten.rsqrt.default: partial(guard_aten, aten_rsqrt_default_blocklist),
@@ -1449,7 +1427,6 @@ guard_ops = [
     "torch.ops.aten.exp.default",
     "torch.ops.aten.split.Tensor",
     "torch.ops.aten.t.default",
-    "torch.ops.aten.ones.default",
     "torch.ops.aten.where.self",
     "torch.ops.aten.empty.memory_format",
     "torch.ops.aten.log.default",


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/572

### Problem description
Some `aten.ones.default` op remains.
Most `aten.ones.default` op has constant input shape to create ones tensor, it could be constant folding.

### What's changed
1. Add constant folding for `aten.ones.default`
2. Remove guard block
