### PR TITLE
Get correct tensor shape of `get_attr` op

### DIFF
--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -457,7 +457,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return g.call_function(target_wrappers.pack_to_tuple, (output,))
 
             def lower_binary_eltwise(fn, args):
-                shapes = get_shape(args[0]), get_shape(args[1])
+                shapes = get_shape(gm, args[0]), get_shape(gm, args[1])
 
                 if (isinstance(args[0], torch.fx.node.Node) and shapes[0] == torch.Size()) or (
                     isinstance(args[1], torch.fx.node.Node) and shapes[1] == torch.Size()
@@ -596,7 +596,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 if isinstance(args[1], (float, int)):
                     return g.call_function(ttnn.mul, (args[0], 1.0 / args[1]), {})
 
-                if get_shape(args[0]) == get_shape(args[1]):
+                if get_shape(gm, args[0]) == get_shape(gm, args[1]):
                     return g.call_function(ttnn.div, args, {})
 
                 recip = g.call_function(ttnn.reciprocal, (args[1],), {})

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -10,6 +10,16 @@ def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 
 def get_shape(gm: torch.fx.GraphModule, node_or_shape):
+    """
+    Get the shape of a node or shape itself.
+
+    Args:
+        gm (torch.fx.GraphModule): The GraphModule containing the node.
+        node_or_shape: The node or shape to get the shape of. Can be an int, float, torch.Size, list, tuple, or torch.fx.node.Node.
+
+    Returns:
+        torch.Size or None: The shape of the node or shape itself, or None if it cannot be determined.
+    """
     if isinstance(node_or_shape, (int, float)):
         return torch.Size()
     if isinstance(node_or_shape, (torch.Size, list, tuple)):
@@ -20,7 +30,10 @@ def get_shape(gm: torch.fx.GraphModule, node_or_shape):
 
         if node_or_shape.op == "get_attr":
             val = getattr(gm, node_or_shape.target)
-            return val.size()
+            if isinstance(val, torch.Tensor):
+                return val.size()
+            if isinstance(val, (int, float)):
+                return torch.Size()
 
     return None
 

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -9,7 +9,7 @@ def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     return gm
 
 
-def get_shape(node_or_shape):
+def get_shape(gm: torch.fx.GraphModule, node_or_shape):
     if isinstance(node_or_shape, (int, float)):
         return torch.Size()
     if isinstance(node_or_shape, (torch.Size, list, tuple)):
@@ -17,6 +17,11 @@ def get_shape(node_or_shape):
     if isinstance(node_or_shape, torch.fx.node.Node):
         if (val := node_or_shape.meta.get("val", None)) is not None:
             return val.size()
+
+        if node_or_shape.op == "get_attr":
+            val = getattr(gm, node_or_shape.target)
+            return val.size()
+
     return None
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/610

### Problem description
`get_shape` function could not properly deal with `get_attr` op

### What's changed
Get correct tensor shape of `get_attr` op.
