### PR TITLE
Decompose `aten.full_like` into `aten.full`

### DIFF
--- a/tests/lowering/creation/test_full_like.py
+++ b/tests/lowering/creation/test_full_like.py
@@ -24,13 +24,12 @@ class FullLikeModule(torch.nn.Module):
 def test_full_like(device, input_shape):
     m = FullLikeModule()
     fill_value = 1.23
-    tensor = torch.zeros(input_shape)
-    result_before = m.forward(tensor, fill_value).to(torch.bfloat16)
-    option = torch_ttnn.TorchTtnnOption(device=device)
-    option.gen_graphviz = True
+    tensor = torch.zeros(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(tensor, fill_value)
+    option = torch_ttnn.TorchTtnnOption(device=device, gen_graphviz=True)
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    result_after = m.forward(tensor, fill_value).to(torch.bfloat16)
+    result_after = m.forward(tensor, fill_value)
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops

--- a/tests/lowering/creation/test_full_like.py
+++ b/tests/lowering/creation/test_full_like.py
@@ -1,0 +1,41 @@
+import torch
+import torch_ttnn
+import pytest
+
+
+class FullLikeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, tensor, fill_value):
+        return torch.full_like(tensor, fill_value)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (64, 128),
+        (15, 15),
+        (1, 1),
+        (2, 2),
+        (17, 17),
+    ],
+)
+def test_full_like(device, input_shape):
+    m = FullLikeModule()
+    fill_value = 1.23
+    tensor = torch.zeros(input_shape)
+    result_before = m.forward(tensor, fill_value).to(torch.bfloat16)
+    option = torch_ttnn.TorchTtnnOption(device=device)
+    option.gen_graphviz = True
+    # The compilation is lazy, so we need to run forward once to trigger the compilation
+    m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    result_after = m.forward(tensor, fill_value).to(torch.bfloat16)
+    option._out_fx_graphs[0].print_tabular()
+
+    # Check the graph has be rewritten and contain ttnn ops
+    nodes = list(option._out_fx_graphs[0].nodes)
+    # Check the graph has be rewritten and aten ops are replaced
+    assert not any(node.target == torch.ops.aten.full_like.default for node in nodes)
+    # Check inference result
+    assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -94,6 +94,14 @@ aten_full_default_blocklist = [
         "Optional[bool] pin_memory = False",
     ],
 ]
+# TODO(#615): Dynamic shape is not supported yet
+aten_full_like_default_blocklist = [
+    [
+        "Tensor<[s0 + 1, s0 + 1]> self = ?",
+        "number fill_value = 31",
+        "Optional[bool] pin_memory = False",
+    ],
+]
 aten__scaled_dot_product_flash_attention_default_blocklist = [
     ["Tensor<[1, 16, 197, 64]> query = ?", "Tensor<[1, 16, 197, 64]> key = ?", "Tensor<[1, 16, 197, 64]> value = ?"],
     ["Tensor<[1, 12, 197, 64]> query = ?", "Tensor<[1, 12, 197, 64]> key = ?", "Tensor<[1, 12, 197, 64]> value = ?"],
@@ -1395,6 +1403,7 @@ GUARD = {
     torch.ops.aten.maximum.default: partial(guard_aten, aten_maximum_default_blocklist),
     torch.ops.aten._log_softmax.default: partial(guard_aten, aten__log_softmax_default_blocklist),
     torch.ops.aten.full.default: partial(guard_aten, aten_full_default_blocklist),
+    torch.ops.aten.full_like.default: partial(guard_aten, aten_full_like_default_blocklist),
     torch.ops.aten._scaled_dot_product_flash_attention.default: partial(
         guard_aten, aten__scaled_dot_product_flash_attention_default_blocklist
     ),
@@ -1422,6 +1431,7 @@ guard_ops = [
     "torch.ops.aten.maximum.default",
     "torch.ops.aten._log_softmax.default",
     "torch.ops.aten.full.default",
+    "torch.ops.aten.full_like.default",
     "torch.ops.aten.rsub.Scalar",
     "torch.ops.aten._scaled_dot_product_flash_attention.default",
     "torch.ops.aten.transpose.int",


### PR DESCRIPTION
### Ticket
#589

### Problem description
Decompose `aten.full_like` into `aten.full`. There is one remaining dynamic shape case is not supported yet and guarded

### What's changed
- Decompose `aten.full_like` into `aten.full`
- Add tests
