### PR TITLE
Remove `aten.zeros_like` autogen blocklist and guards unsupported cases

### DIFF
--- a/tests/lowering/creation/test_zeros_like.py
+++ b/tests/lowering/creation/test_zeros_like.py
@@ -1,7 +1,6 @@
 import torch
 import torch_ttnn
 import pytest
-import ttnn
 
 
 class ZerosLikeModule(torch.nn.Module):
@@ -13,22 +12,34 @@ class ZerosLikeModule(torch.nn.Module):
 
 
 @pytest.mark.parametrize(
-    "input_shapes",
-    [[(4, 4)]],
+    "input_shape",
+    [
+        (4, 4),
+        (7, 7),
+        (1, 1),
+        (17, 17),
+        (1, 920),
+        (100, 1, 256),
+        pytest.param(
+            (13685,), marks=pytest.mark.xfail(reason="Doesn't support 1D output tensor in tile layout (#280)")
+        ),
+    ],
 )
-def test_zeros_like(device, input_shapes):
+def test_zeros_like(device, input_shape):
     m = ZerosLikeModule()
-    inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
-    result_before = m.forward(*inputs)
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    result_before = m.forward(torch_input)
     option = torch_ttnn.TorchTtnnOption(device=device)
     option.gen_graphviz = True
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    result_after = m.forward(*inputs)
+    result_after = m.forward(torch_input)
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.zeros_like) == 1
+    # Check the graph has be rewritten and aten ops are replaced
+    assert not any(node.target == torch.ops.aten.zeros_like.default for node in nodes)
     # Check inference result
     assert torch.allclose(result_before, result_after)
+    assert result_before.shape == result_after.shape

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -311,7 +311,6 @@ class NodeInputAligner:
         if node.target in [
             ttnn.split,
             ttnn.embedding,
-            ttnn.zeros_like,
             target_wrappers.repeat,
             target_wrappers.roll,
             target_wrappers.stack,

--- a/torch_ttnn/passes/lowering/to_tt_guard.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard.py
@@ -200,16 +200,6 @@ aten_maximum_default_blocklist += [["Tensor<[1, 16, 59, 59]> self = ?", "Tensor 
 #                [ 0.00000,  0.00000,  ...,  0.00000,  0.00000]]]], shape=Shape([1, 23, 40[64], 1[32]]), dtype=DataType::BFLOAT16, layout=Layout::TILE), 1; kwargs: dtype=torch.float32
 aten_cumsum_default_blocklist = [["Tensor<[1, 23, 40]> self = ?", "int dim = 1", "Optional[int] dtype = torch.float32"]]
 
-# RuntimeError: TT_FATAL @ binary_device_operation.cpp:68: input_tensor_a.get_layout() == Layout::TILE
-# info:
-# Input to eltwise binary must be tilized
-# zero_like([1, 920]) & subtract([1[32], 920[928]]) => mul
-aten_zeros_like_default_blocklist += [
-    ["Tensor<[1, 920]> self = ?", "Optional[int] dtype = torch.bfloat16", "Optional[bool] pin_memory = False"],
-    ["Tensor<[100, 1, 256]> self = ?", "Optional[bool] pin_memory = False"],
-]
-
-
 ############################################################
 # EXTRA BLOCKLIST OF ssd300_vgg16
 ############################################################

--- a/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
+++ b/torch_ttnn/passes/lowering/to_tt_guard_autogen.py
@@ -81,12 +81,6 @@ aten__scaled_dot_product_flash_attention_default_blocklist = [
         "bool is_causal = True",
     ],
 ]
-aten_zeros_like_default_blocklist = [
-    ["Tensor<[13685]> self = ?", "Optional[int] dtype = torch.bool", "Optional[bool] pin_memory = False"],
-    ["Tensor<[7, 7]> self = ?", "Optional[int] dtype = torch.bfloat16"],
-    ["Tensor<[1, 1]> self = ?", "Optional[bool] pin_memory = False"],
-    ["Tensor<[17, 17]> self = ?", "Optional[bool] pin_memory = False"],
-]
 aten_div_Tensor_blocklist = [
     ["Tensor<[]> self = ?", "Tensor<[]> other = ?"],
     ["Tensor<[1, 23, 40, 1]> self = ?", "Tensor<[128]> other = ?"],
@@ -731,7 +725,6 @@ GUARD = {
     torch.ops.aten._scaled_dot_product_flash_attention.default: partial(
         guard_aten, aten__scaled_dot_product_flash_attention_default_blocklist
     ),
-    torch.ops.aten.zeros_like.default: partial(guard_aten, aten_zeros_like_default_blocklist),
     torch.ops.aten.div.Tensor: partial(guard_aten, aten_div_Tensor_blocklist),
     torch.ops.aten.native_layer_norm.default: partial(guard_aten, aten_native_layer_norm_default_blocklist),
     torch.ops.aten.exp.default: partial(guard_aten, aten_exp_default_blocklist),
@@ -757,7 +750,6 @@ guard_ops = [
     "torch.ops.aten._scaled_dot_product_flash_attention.default",
     "torch.ops.aten.transpose.int",
     "torch.ops.aten.embedding.default",
-    "torch.ops.aten.zeros_like.default",
     "torch.ops.aten.div.Tensor",
     "torch.ops.aten.mul.Tensor",
     "torch.ops.aten.native_layer_norm.default",


### PR DESCRIPTION
### Ticket
#630, #280

### Problem description
Remove `aten.zeros_like` autogen blocklist. The 1-D output shape is fallback currently because tile layout tensor is always 2D currently (#280)

### What's changed
- Remove `aten_zeros_like` autogen blocklist
- Guard 1-D output shape cases in `to_tt_pass.py`
- Add more test cases
