### PR TITLE
Convert aten convolution 1d cases to `ttnn.Conv1d`

### DIFF
--- a/tests/lowering/conv/test_conv.py
+++ b/tests/lowering/conv/test_conv.py
@@ -49,7 +49,7 @@ class ConvolutionModule(torch.nn.Module):
             (1, 1),
             1,
             False,
-            marks=pytest.mark.xfail(reason="Low PCC (#TODO)"),
+            marks=pytest.mark.xfail(reason="Low PCC (tt-metal#16262)"),
         ),
         ((1, 16, 28, 28), (16, 4, 3, 3), (1, 1), (1, 1), (1, 1), 4, False),
         ((1, 32, 7, 7), (32, 32, 2, 2), (2, 2), (0, 0), (1, 1), 1, False),

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -138,7 +138,7 @@ TTNN_TARGET_WRAPPERS = [
     target_wrappers.repeat,
     target_wrappers.pack_to_tuple,
     target_wrappers.move_to_host,
-    target_wrappers.conv2d,
+    target_wrappers.conv,
     target_wrappers.roll,
     target_wrappers.stack,
 ]
@@ -318,7 +318,7 @@ class NodeInputAligner:
             # TODO: Only uint32 needs to to_layout on host
             spec.layout = TtnnRowMajorLayout
             spec.device = TtnnDevice
-        if node.target == target_wrappers.conv2d and input_site == 1:
+        if node.target == target_wrappers.conv and input_site == 1:
             # TODO(#417, tt-metal#15893): weight currently needs to be on host and can't be moved to device first
             spec.layout = TtnnRowMajorLayout
             spec.device = "host"

--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -25,7 +25,7 @@ def move_to_host(device_tensor, layout):
 
 
 @torch.fx.wrap
-def conv2d(
+def conv(
     input_tensor,
     weight_tensor,
     bias_tensor,

--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -43,6 +43,7 @@ def conv2d(
     output_padding=None,
 ):
     if len(in_spatial_shape) == 1:
+        # TODO(tt-metal#16258): conv1d API doesn't support transposed yet
         assert not transposed, "conv1d doesn't support transposed yet"
         return ttnn.Conv1d(
             input_tensor=input_tensor,

--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -43,6 +43,9 @@ def conv2d(
     transposed,
     output_padding=None,
 ):
+    if len(weight_tensor.shape) < 4:
+        weight_tensor = ttnn.reshape(weight_tensor, list(weight_tensor.shape) + [1])
+
     if transposed:
         output_tensor = ttnn.conv_transpose2d(
             input_tensor=input_tensor,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -94,19 +94,19 @@ def is_getitem_0_only_user(node):
     )
 
 
-def insert_nchw_to_nhwc(g, input_tensor, input_shape):
-    return g.call_function(ttnn.permute, (input_tensor, (0, 2, 1) if len(input_shape) < 4 else (0, 2, 3, 1)))
+# Convert (n, c, x, ...) to (n, x, ..., c)
+def insert_ncx_to_nxc(g, input_tensor, input_shape):
+    target_permute = [0] + list(range(2, len(input_shape))) + [1]
+    return g.call_function(ttnn.permute, (input_tensor, target_permute))
 
 
-def insert_sharded_nhwc_to_nchw(g, output_tensor, output_shape):
-    is_1d = len(output_shape) < 4
-    if is_1d:
-        target_shape = (output_shape[0], output_shape[2], output_shape[1])
-    else:
-        target_shape = (output_shape[0], output_shape[2], output_shape[3], output_shape[1])
+# Convert sharded (1, 1, nx..., c) to interleaved (n, c, x, ...)
+def insert_sharded_nxc_to_ncx(g, output_tensor, output_shape):
     output_tensor = g.call_function(ttnn.sharded_to_interleaved, (output_tensor, TtnnL1MemoryConfig()))
+    target_shape = (output_shape[0], *output_shape[2:], output_shape[1])
     output_tensor = g.call_function(ttnn.reshape, (output_tensor, target_shape))
-    return g.call_function(ttnn.permute, (output_tensor, (0, 2, 1) if is_1d else (0, 3, 1, 2)))
+    target_permute = [0, len(output_shape) - 1] + list(range(1, len(output_shape) - 1))
+    return g.call_function(ttnn.permute, (output_tensor, target_permute))
 
 
 TTNN_POINTWISE_UNARY_OPS = {
@@ -992,7 +992,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 ):
                     return None
 
-                input_tensor = insert_nchw_to_nhwc(g, input_tensor, input_shape)
+                input_tensor = insert_ncx_to_nxc(g, input_tensor, input_shape)
                 # TODO(#423): reshape can be removed if (N, H, W, C) is supported
                 input_tensor = g.call_function(ttnn.reshape, (input_tensor, (1, 1, batch_size * in_h * in_w, in_c)))
                 # TODO(#418): max_pool2d fails with input tensors in tile layout for some shapes
@@ -1011,7 +1011,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                         dilation,
                     ),
                 )
-                output_tensor = insert_sharded_nhwc_to_nchw(g, output_tensor, node.meta["val"][0].size())
+                output_tensor = insert_sharded_nxc_to_ncx(g, output_tensor, node.meta["val"][0].size())
                 # TODO(tt-metal#12099): Currently it doesn't return indices. Pack into tuple to maintain the type
                 return g.call_function(target_wrappers.pack_to_tuple, (output_tensor,))
 
@@ -1056,7 +1056,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 in_nhw = math.prod([batch_size] + in_spatial_shape)
                 out_c = weight_shape[1] if transposed else weight_shape[0]
 
-                input_tensor = insert_nchw_to_nhwc(g, input_node, input_shape)
+                input_tensor = insert_ncx_to_nxc(g, input_node, input_shape)
                 # TODO(tt-metal#15148): ttnn.conv2d internal reshape fails with padding
                 input_tensor = g.call_function(ttnn.reshape, (input_tensor, (1, 1, in_nhw, in_c)))
                 bias_tensor = params.get("bias_tensor", None)
@@ -1088,7 +1088,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                     ),
                 )
                 output_shape = node.meta["val"].size()
-                return insert_sharded_nhwc_to_nchw(g, output_tensor, output_shape)
+                return insert_sharded_nxc_to_ncx(g, output_tensor, output_shape)
 
             if node.target == torch.ops.aten.slice_scatter.default:
                 tensor, src_tensor, dim, start, end, *step = args

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1068,7 +1068,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                     )
                     bias_tensor = g.call_function(target_wrappers.move_to_host, (bias_tensor, TtnnRowMajorLayout()))
                 output_tensor = g.call_function(
-                    target_wrappers.conv2d,
+                    target_wrappers.conv,
                     (
                         input_tensor,
                         weight_tensor,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1048,7 +1048,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 dilation = params.get("dilation", [1] * in_spatial_size)
                 output_padding = params.get("output_padding", [0] * in_spatial_size)
 
-                # TODO(TODO): conv1d API doesn't support transposed yet
+                # TODO(tt-metal#16258): conv1d API doesn't support transposed yet
                 if in_spatial_size == 1 and transposed:
                     return None
 


### PR DESCRIPTION
### Ticket
#429

### Problem description
Convert aten convolution 1d cases to `ttnn.Conv1d`

### What's changed
- Refactor aten.convolution conversion to support conv1d and conv2d
- Add tests
