### PR TITLE
constant folding to handle tensor arguments of iterable type

### DIFF
--- a/torch_ttnn/passes/constant_folding_pass.py
+++ b/torch_ttnn/passes/constant_folding_pass.py
@@ -22,6 +22,12 @@ class ConstantFoldingPass(PassBase):
             torch.ops.aten.ceil.default,
             torch.ops.aten.clamp.default,
             torch.ops.aten.ones.default,
+            torch.ops.aten.cumsum.default,
+            torch.ops.aten._unsafe_index.Tensor,
+            torch.ops.aten.ne.Scalar,
+            torch.ops.aten.select.int,
+            torch.ops.aten.bitwise_not.default,
+            torch.ops.aten.floor_divide.default,
         }
 
     def call(self, gm: torch.fx.GraphModule):

--- a/torch_ttnn/passes/constant_folding_pass.py
+++ b/torch_ttnn/passes/constant_folding_pass.py
@@ -40,35 +40,72 @@ class ConstantFoldingPass(PassBase):
         if not can_lowering_to_ttnn(node):
             return False
 
+        def can_arg_fold(arg):
+            if (
+                isinstance(
+                    arg,
+                    (
+                        int,
+                        float,
+                    ),
+                )
+                or arg is None
+            ):
+                return True
+
+            if isinstance(arg, torch.fx.Node) and arg.op in ("get_attr", "constant"):
+                return True
+            return False
+
         for arg in node.args:
-            if not isinstance(
+            if isinstance(
                 arg,
                 (
-                    int,
-                    float,
+                    list,
+                    tuple,
+                    torch.fx.immutable_collections.immutable_list,
                 ),
-            ) and isinstance(arg, torch.fx.Node):
-                if arg.op not in ("get_attr", "constant"):
-                    return False
+            ):
+                for arg_element in arg:
+                    if not can_arg_fold(arg_element):
+                        return False
+            elif not can_arg_fold(arg):
+                return False
+
         return True
 
     def _evaluate_node(self, gm: torch.fx.GraphModule, node):
-        args = []
-        for arg in node.args:
+        def eval_arg(arg):
             if isinstance(arg, torch.fx.Node):
                 if arg.op == "get_attr":
-                    value = getattr(gm, arg.target)
-                    args.append(value)
+                    return getattr(gm, arg.target)
                 elif arg.op == "constant":
-                    args.append(arg.args[0])
+                    return arg.args[0]
+            return arg
+
+        args = []
+        for arg in node.args:
+            if isinstance(
+                arg,
+                (
+                    list,
+                    tuple,
+                    torch.fx.immutable_collections.immutable_list,
+                ),
+            ):
+                list_arg = []
+                for arg_element in arg:
+                    list_arg.append(eval_arg(arg_element))
+                args.append(list_arg)
             else:
-                args.append(arg)
+                args.append(eval_arg(arg))
 
         if node.target == torch.ops.aten.lift_fresh_copy.default:
             return args[0]
 
         if node.target in self.foldable_ops:
-            return node.target(*args, **node.kwargs)
+            result = node.target(*args, **node.kwargs)
+            return result
 
         # Add handlers for other operations...
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -841,8 +841,8 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 # masked_fill = (tensor * (ones - mask)) + (mask * full)
 
                 tensor, mask, fill_value = args
-                tensor_shape = tensor.meta["val"].size()
-                mask_shape = mask.meta["val"].size()
+                tensor_shape = get_shape(gm, tensor)
+                mask_shape = get_shape(gm, mask)
 
                 # check if divisible, otherwise skip
                 np_tensor_shp = np.array(tensor_shape)
@@ -904,7 +904,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
             if node.target == torch.ops.aten.cumsum.default:
                 tensor, dim = args
-                input_shape = tensor.meta["val"].size()
+                input_shape = get_shape(gm, tensor)
                 rank = len(input_shape)
                 if rank > 4:
                     return None


### PR DESCRIPTION
### Ticket
N/A

### Problem description
For operations that has input of iterable type, fails to constant folding. eg,
```
%_unsafe_index_tensor : [num_users=1] = call_function[target=torch.ops.aten._unsafe_index.Tensor](args = (%_folded__to_copy, [None, None, %_folded_unsqueeze_1, %_folded__to_copy_2]), kwargs = {})
```

### What's changed
Handle the check fold and evaluate fold for iterable types (list, tuple, torch.fx.immutable_collections.immutable_list).

