### PR TITLE
Move lowered with aten to decompose as possible

### DIFF
--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1219,7 +1219,10 @@ class ToTtPass(PassBase):
         gm = ReplaceMoreTt(gm, self.device, self.use_less_ttnn_op_types).transform()
 
         # Replace patterns manually
-        while True:
+        max_try = 10
+        cnt = 0
+        while cnt < max_try:
+            cnt += 1
             gm, modified = ReplaceMoreTtManually(gm, self.use_less_ttnn_op_types)
             if not modified:
                 break

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -1181,7 +1181,7 @@ def decompose_aten_to_aten_ops(gm: torch.fx.GraphModule, g: GraphWrapper, node):
     if node.target == torch.ops.aten.sum.default:
         input_shape = get_shape(gm, args[0])
         output_shape = get_shape(gm, node)
-        if input_shape.numel() == output_shape.numel():
+        if input_shape.numel() == 1:
             return g.call_function(torch.ops.aten.squeeze.default, args=(args[0],))
         return None
 


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`torch.ops.aten.select.int` and `torch.ops.aten.sum.default` will generated aten op in lowered function, move it to `decompose_aten_to_aten_ops` as possible. `torch.ops.aten.sum.default` cannot fully moved to, so add `again` to check

`aten.select.int` and `aten.sum.default` will generate ATen operations in the lowered function. The former can moved to `decompose_aten_to_aten_ops` but later cannot, so add an `again` mechanism

### What's changed
Edit `torch.ops.aten.select.int` and `torch.ops.aten.sum.default`