### PR TITLE
Remove OOM guard for `aten.max_pool2d_with_indices.default`

### DIFF
--- a/tests/lowering/pool/test_max_pool_2d.py
+++ b/tests/lowering/pool/test_max_pool_2d.py
@@ -20,6 +20,7 @@ class MaxPool2dModule(torch.nn.Module):
         ((1, 128, 112, 112), (2, 2), 2, 0, 1, False),
         ((1, 512, 19, 19), (3, 3), 1, 1, 1, False),
         ((1, 192, 28, 28), (3, 3), 1, 1, 1, False),
+        ((1, 64, 360, 640), (3, 3), 2, 1, 1, False),
         pytest.param(
             (1, 320, 28, 28),
             (3, 3),
@@ -37,15 +38,6 @@ class MaxPool2dModule(torch.nn.Module):
             1,
             True,
             marks=pytest.mark.xfail(reason="ceil_mode=True is not supported yet (tt-metal#14976)"),
-        ),
-        pytest.param(
-            (1, 64, 360, 640),
-            (3, 3),
-            2,
-            1,
-            1,
-            False,
-            marks=pytest.mark.xfail(reason="OOM (#385)"),
         ),
         pytest.param(
             (1, 4, 14, 14),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -989,13 +989,9 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 padding = params.get("padding", (0, 0))
                 dilation = params.get("dilation", (1, 1))
                 ceil_mode = params.get("ceil_mode", False)
-                # Assume the element size is bfloat16
-                volume = (batch_size * in_c * in_h * in_w) * 2
                 if (
                     # TODO(tt-metal#14976): ceil mode isn't supported yet
                     ceil_mode
-                    # TODO(#385): OOM
-                    or volume > 16 * 1024 * 1024
                     # TODO(tt-metal#13901): Wide input channels can only be multiple of 8 tiles
                     or (in_c > (ttnn.TILE_SIZE * 8) and in_c % (ttnn.TILE_SIZE * 8) != 0)
                     # TODO(#419): Currently fails with in_c < 16


### PR DESCRIPTION
### Ticket
#430

### Problem description
Remove OOM guard for `aten.max_pool2d_with_indices.default` as those shapes passed now

### What's changed
- Remove OOM guard for `aten.max_pool2d_with_indices.default`
