### PR TITLE
#0: Added a naive batching mechanism for some models in the tests folder

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
         help="Run up to the specified iteration count and report metrics based on this iteration.",
     )
     parser.addoption("--gen_op_accuracy_tests", action="store_true")
-
+    parser.addoption("--batch_size", action="store", default=None, help="Batch size for testing")
 
 @pytest.fixture(scope="session")
 def input_var_only_native(request):
@@ -69,6 +69,9 @@ def device():
     ttnn.synchronize_device(device)
     ttnn.close_device(device)
 
+@pytest.fixture(scope="session")
+def get_batch_size(request):
+    return request.config.getoption("--batch_size")
 
 def get_dispatch_core_type():
     # Instead of conditionally returning WORKER or ETH, here we always return ETH

--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -5,7 +5,8 @@ from torchvision import transforms
 from PIL import Image
 
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -32,12 +33,18 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_MobileNetV2(record_property, mode):
+def test_MobileNetV2(record_property, mode, get_batch_size):
     model_name = "MobileNetV2"
     record_property("model_name", model_name)
     record_property("mode", mode)
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     if mode == "eval":
         # Print the top 5 predictions
         _, indices = torch.topk(results, 5)

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -3,7 +3,7 @@
 from transformers import AutoTokenizer, AlbertForMaskedLM
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits
 
 
 class ThisTester(ModelTester):
@@ -40,15 +40,25 @@ class ThisTester(ModelTester):
         "albert/albert-xxlarge-v2",
     ],
 )
-def test_albert_masked_lm(record_property, model_name, mode):
+
+
+def test_albert_masked_lm(record_property, model_name, mode, get_batch_size):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+    
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
-
+    results = tester.test_model(batch_size=batch_size)
+    
     if mode == "eval":
         # retrieve index of [MASK]
+        
+        results.logits = process_batched_logits(results.logits, batch_size)
+        #print(results.logits.shape)
         logits = results.logits
         mask_token_index = (tester.inputs.input_ids == tester.tokenizer.mask_token_id)[0].nonzero(as_tuple=True)[0]
         predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -3,7 +3,7 @@
 from transformers import AutoTokenizer, AlbertForQuestionAnswering
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 
 
 class ThisTester(ModelTester):
@@ -24,17 +24,22 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.parametrize("model_name", ["twmkn9/albert-base-v2-squad2"])
-def test_albert_question_answering(record_property, model_name, mode):
+def test_albert_question_answering(record_property, model_name, mode, get_batch_size):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
 
     if mode == "eval":
-        answer_start_index = results.start_logits.argmax()
-        answer_end_index = results.end_logits.argmax()
-
+        answer_start_index = process_batched_logits(results.start_logits,batch_size).argmax()
+        answer_end_index = process_batched_logits(results.end_logits,batch_size).argmax()
         predict_answer_tokens = tester.inputs.input_ids[0, answer_start_index : answer_end_index + 1]
         answer = tester.tokenizer.decode(predict_answer_tokens, skip_special_tokens=True)
 

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -3,7 +3,7 @@
 from transformers import AlbertTokenizer, AlbertForSequenceClassification
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 
 
 class ThisTester(ModelTester):
@@ -23,15 +23,21 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.parametrize("model_name", ["textattack/albert-base-v2-imdb"])
-def test_albert_sequence_classification(record_property, model_name, mode):
+def test_albert_sequence_classification(record_property, model_name, mode, get_batch_size):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
 
+    tester = ThisTester(model_name, mode)
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
+    
     if mode == "eval":
-        logits = results.logits
+        logits = process_batched_logits(results.logits, batch_size)
         predicted_class_id = logits.argmax().item()
         predicted_label = tester.model.config.id2label[predicted_class_id]
 

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -3,7 +3,7 @@
 from transformers import AutoTokenizer, AlbertForTokenClassification
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 
 
 class ThisTester(ModelTester):
@@ -27,15 +27,27 @@ class ThisTester(ModelTester):
         pytest.param("albert/albert-base-v2", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_albert_token_classification(record_property, model_name, mode):
+def test_albert_token_classification(record_property, model_name, mode, get_batch_size):
     record_property("model_name", f"{model_name}-classification")
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
 
     if mode == "eval":
-        logits = results.logits
+        if batch_size is not None:
+            results.logits = results.logits.squeeze(0) # Temporary fix, not the neatest solution
+        
+        logits = process_batched_logits(results.logits, batch_size).unsqueeze(0)
+        if batch_size is None:
+            logits = logits.squeeze(0) # Adjust dimensions to account for batch reshaping ^
+        
         predicted_token_class_ids = logits.argmax(-1)
 
         # Note that tokens are classified rather then input words which means that

--- a/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
@@ -4,7 +4,8 @@ import torch
 import torchvision.transforms as transforms
 from datasets import load_dataset
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ConvAE(torch.nn.Module):
@@ -71,13 +72,19 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-def test_autoencoder_conv_v2(record_property, mode):
+def test_autoencoder_conv_v2(record_property, mode, get_batch_size):
     model_name = f"Autoencoder (conv)"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
 
     if mode == "eval":
         print("Output: ", results)

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -4,7 +4,8 @@ import torch
 import torchvision.transforms as transforms
 from datasets import load_dataset
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class LinearAE(torch.nn.Module):
@@ -80,13 +81,18 @@ class ThisTester(ModelTester):
     "mode",
     ["train", pytest.param("eval", marks=pytest.mark.converted_end_to_end)],
 )
-def test_autoencoder_linear(record_property, mode):
+def test_autoencoder_linear(record_property, mode, get_batch_size):
     model_name = "Autoencoder (linear)"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size)
 
     if mode == "eval":
         print("Output: ", results)

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -3,7 +3,7 @@ import pytest
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForQuestionAnswering
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 
 
 class ThisTester(ModelTester):
@@ -35,13 +35,19 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_bert(record_property, mode):
+def test_bert(record_property, mode, get_batch_size):
     model_name = "BERT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
 
     if mode == "eval":
         # Helper function to decode output to human-readable text

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -3,7 +3,8 @@ import pytest
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -33,13 +34,19 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_bloom(record_property, mode):
+def test_bloom(record_property, mode, get_batch_size):
     model_name = "Bloom"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
 
     if mode == "eval":
         # Helper function to decode output to human-readable text

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -1,7 +1,8 @@
 from transformers import DistilBertTokenizer, DistilBertModel
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -22,12 +23,18 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.parametrize("model_name", ["distilbert-base-uncased"])
-def test_distilbert(record_property, model_name, mode):
+def test_distilbert(record_property, model_name, mode, get_batch_size):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
 
     if mode == "eval":
         print(f"Model: {model_name} | Input: {tester.text} | Output: {results}")

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -2,7 +2,7 @@
 
 from transformers import DPRReader, DPRReaderTokenizer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 import torch
 
 
@@ -27,13 +27,20 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_dpr(record_property, mode):
+def test_dpr(record_property, mode, get_batch_size):
     model_name = "DPR"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
+
 
     if mode == "eval":
         start_logits = results.start_logits

--- a/tests/models/llama/test_llama.py
+++ b/tests/models/llama/test_llama.py
@@ -3,7 +3,8 @@ import pytest
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -36,13 +37,20 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_llama(record_property, mode):
+def test_llama(record_property, mode, get_batch_size):
     model_name = "Llama"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
+
     if mode == "eval":
         # Helper function to decode output to human-readable text
         def decode_output(outputs):

--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -1,7 +1,8 @@
 import torch
 from mlp_mixer_pytorch import MLPMixer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -23,11 +24,17 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-def test_mlpmixer(record_property, mode):
+def test_mlpmixer(record_property, mode, get_batch_size):
     model_name = "MLPMixer"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size) # This is necessary to avoid shape mismatch errors in tester processing
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -5,7 +5,7 @@ from torch.utils.data import DataLoader
 
 import torch.nn as nn
 import torch.nn.functional as F
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 
 
 # adapted from https://github.com/pytorch/examples/blob/main/mnist/main.py
@@ -54,12 +54,17 @@ class ThisTester(ModelTester):
     "mode",
     ["train", pytest.param("eval", marks=pytest.mark.converted_end_to_end)],
 )
-def test_mnist_train(record_property, mode):
+def test_mnist_train(record_property, mode, get_batch_size):
     model_name = "Mnist"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
 
+    tester = ThisTester(model_name, mode)
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -6,7 +6,8 @@ from PIL import Image
 from pytorchcv.model_provider import get_model as ptcv_get_model
 from torchvision import transforms
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 def get_image_tensor():
@@ -47,13 +48,18 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_openpose_v2(record_property, mode):
+def test_openpose_v2(record_property, mode, get_batch_size):
     model_name = "OpenPose V2"
     record_property("model_name", model_name)
     record_property("mode", mode)
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     if mode == "eval":
         print(f"Output: {results}")
 

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -2,7 +2,7 @@
 
 from transformers import PerceiverTokenizer, PerceiverForMaskedLM
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 import torch
 
 
@@ -29,13 +29,19 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_perceiver_io(record_property, mode):
+def test_perceiver_io(record_property, mode, get_batch_size):
     model_name = "Perceiver IO"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     if mode == "eval":
         logits = results.logits
         masked_tokens_predictions = logits[0, 51:61].argmax(dim=-1)

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -1,7 +1,7 @@
 import torch
 import torchvision
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
 
 
 class ThisTester(ModelTester):
@@ -23,13 +23,18 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_resnet(record_property, mode):
+def test_resnet(record_property, mode, get_batch_size):
     model_name = "ResNet18"
     record_property("model_name", model_name)
     record_property("mode", mode)
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
 
     # Check inference result
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -5,7 +5,8 @@ from torchvision import transforms
 from PIL import Image
 
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -36,13 +37,19 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_resnet(record_property, mode):
+def test_resnet(record_property, mode, get_batch_size):
     model_name = "ResNet50"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     if mode == "eval":
         # Print the top 5 predictions
         _, indices = torch.topk(results, 5)

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -3,7 +3,8 @@
 from transformers import AutoTokenizer, XLMRobertaForMaskedLM
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -22,13 +23,19 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_roberta(record_property, mode):
+def test_roberta(record_property, mode, get_batch_size):
     model_name = "RoBERTa"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     if mode == "eval":
         logits = results.logits
         # retrieve index of <mask>

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -3,7 +3,8 @@
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -24,13 +25,19 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_squeeze_bert(record_property, mode):
+def test_squeeze_bert(record_property, mode, get_batch_size):
     model_name = "SqueezeBERT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     if mode == "eval":
         logits = results.logits
         predicted_class_id = logits.argmax().item()

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -6,7 +6,8 @@ from torchvision import transforms
 import requests
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -45,13 +46,19 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_unet(record_property, mode):
+def test_unet(record_property, mode, get_batch_size):
     model_name = "U-Net"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
     if mode == "eval":
         results = torch.round(results[0])
 

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -4,7 +4,8 @@ import numpy as np
 from PIL import Image
 from torchvision import transforms
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -55,13 +56,20 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_unet_brain(record_property, mode):
+def test_unet_brain(record_property, mode, get_batch_size):
     model_name = "Unet-brain"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    print('\n\n\n', results.shape, '\n\n\n')
+    ##batch_object_inputs(tester, batch_size)
     if mode == "eval":
         print(torch.round(results[0]))
 

--- a/tests/models/unet_carvana/test_unet_carvana.py
+++ b/tests/models/unet_carvana/test_unet_carvana.py
@@ -9,7 +9,8 @@ import torch
 import pytest
 
 from tests.models.unet_carvana.carvana_unet_segmentation.model import UNET
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 
 class ThisTester(ModelTester):
@@ -31,12 +32,18 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_unet_carvana(record_property, mode):
+def test_unet_carvana(record_property, mode, get_batch_size):
     model_name = "Unet-carvana"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -6,7 +6,8 @@ import subprocess
 import sys
 import os
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, validate_batch_size, process_batched_logits, batch_object_inputs
+
 
 dependencies = ["ultralytics==8.2.92", "ultralytics-thop==2.0.6"]
 
@@ -98,12 +99,18 @@ def teardown_module(module):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.usefixtures("manage_dependencies")
-def test_yolov5(record_property, mode):
+def test_yolov5(record_property, mode, get_batch_size):
     model_name = "YOLOv5"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
+    batch_size = get_batch_size
+    if batch_size is not None:
+        batch_size = int(batch_size)
+    validate_batch_size(batch_size)
+
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = tester.test_model(batch_size=batch_size)
+    batch_object_inputs(tester, batch_size)
 
     record_property("torch_ttnn", (tester, results))


### PR DESCRIPTION
Added a batching flag for the some models in the test folder, repeats the same input tensor across a new dimension.  Also misc supporting functions for that. 