### PR TITLE
Update TT-NN to 0.56.0-rc28

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ networkx==3.1
 graphviz
 matplotlib==3.7.1
 
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc16/ttnn-0.0.dev1+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc16/ttnn-0.0.dev1+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc28/ttnn-+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc28/ttnn-+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"


### PR DESCRIPTION
This PR updates TT-NN wheel to the latest pre-release version.