### PR TITLE
Fixes the workflow that picks up the latest TT-NN wheel

### DIFF
--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -28,6 +28,7 @@ jobs:
         id: update-requirements
         run: |
           latest_version=${{ steps.fetch_release.outputs.release }}
+          latest_version_short=$(echo $latest_version | sed 's/-rc/rc/')
           # Remove any existing ttnn lines (adjust the regex if needed)
           sed -i '/^ttnn @ https:\/\/github\.com\/tenstorrent\/tt-metal\/releases\//d' requirements.txt
       


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/777)

### Problem description
The `update-ttnn-wheel` workflow was broken since adding support for 20.04 and 22.04.

### What's changed
It looks like a previous update removed the `latest_version_short` tag. This PR adds it back in to get the correct latest TT-NN Wheel.

closes #777 