### PR TITLE
Adds DINOv2 model to model tests

### DIFF
--- a/tests/models/dino/test_dino.py
+++ b/tests/models/dino/test_dino.py
@@ -1,0 +1,45 @@
+# Reference: https://huggingface.co/facebook/dinov2-base
+
+import torch
+import pytest
+import requests
+
+from PIL import Image
+from transformers import AutoImageProcessor, AutoModel
+from tests.utils import ModelTester
+
+
+class ThisTester(ModelTester):
+    def _load_model(self):
+        # Download model from cloud
+        model_name = "facebook/dinov2-base"
+        self.image_processor = AutoImageProcessor.from_pretrained(
+            model_name,
+        )
+        model = AutoModel.from_pretrained(model_name, torch_dtype=torch.bfloat16)
+        return model
+
+    def _load_inputs(self):
+        # Set up sample input
+        self.test_input = "http://images.cocodataset.org/val2017/000000039769.jpg"
+        self.image = Image.open(requests.get(self.test_input, stream=True).raw)
+
+        inputs = self.image_processor(images=self.image, return_tensors="pt")
+        inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        return inputs
+
+
+@pytest.mark.parametrize(
+    "mode",
+    ["eval"],
+)
+def test_dino(record_property, mode):
+    model_name = "DINOv2"
+    record_property("model_name", model_name)
+    record_property("mode", mode)
+
+    tester = ThisTester(model_name, mode)
+    results = tester.test_model()
+    results = results.last_hidden_state
+
+    record_property("torch_ttnn", (tester, results))


### PR DESCRIPTION
This is just an embedding model, so there is no attempt to make the model results human-readable.

### Ticket
N/A

### Problem description
Learning workflow of adding models

### What's changed
Adds the DINOv2 model for testing based on the example at https://huggingface.co/facebook/dinov2-base
