### PR TITLE
Updates conversion of torch.expand to ttnn.repeat to allow repeating on last dimension.

### DIFF
--- a/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
+++ b/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
@@ -35,6 +35,7 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
+@pytest.mark.converted_end_to_end
 def test_mobilenet_ssd(record_property, mode):
     model_name = "MobileNetSSD"
     record_property("model_name", model_name)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -324,6 +324,13 @@ class NodeInputAligner:
             # TODO: Only uint32 needs to to_layout on host
             spec.layout = TtnnRowMajorLayout
             spec.device = TtnnDevice
+        if (
+            node.target == target_wrappers.stack
+            and isinstance(spec, self.AlignSpecFromTorch)
+            and get_dtype(node) in [torch.int32, torch.int64]
+        ):
+            spec.dtype = TtnnUint32
+
         if node.target == target_wrappers.conv and input_site == 1:
             # TODO(#417, tt-metal#15893): weight currently needs to be on host and can't be moved to device first
             spec.layout = TtnnRowMajorLayout

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -679,8 +679,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 # aten.expand and ttnn.repeat has different meaning for their `shape` argument
                 # aten.expand: the desired output shape, where respective singleton dims are broadcasted
                 # ttnn.repeat: the number of times to repeat a respective singleton dim
-                # Repeat fails if last dimension of input is 1
-                if input_tensor_shape[-1] != 1 and len(input_tensor_shape) == len(output_shape):
+                if len(input_tensor_shape) == len(output_shape):
                     return g.call_function(target_wrappers.repeat, args=(args[0], multiplier.tolist()))
 
                 return None


### PR DESCRIPTION
This has been fixed in tt-metal, so we can now use tensor expand on the last dimension. This also allows us to run mobilenet_ssd end to end.

closes 436

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/436)

### Problem description
Previously, we could not call ttnn.repeat to expand on the last dimension, but now we can.

### What's changed
Removed the check for expanding the last dimension. Marked MobileNet_ssd as end to end.
