### PR TITLE
Enable several passing models that were falsely marked `compilation_xfail`

### DIFF
--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -47,10 +47,7 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "mode",
     [
-        pytest.param(
-            "train",
-            marks=pytest.mark.compilation_xfail,
-        ),
+        "train",
         "eval",
     ],
 )

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -55,7 +55,7 @@ class ThisTester(ModelTester):
 
 @pytest.mark.parametrize(
     "mode",
-    ["train", pytest.param("eval", marks=pytest.mark.compilation_xfail)],
+    ["train", "eval"],
 )
 def test_mnist_train(record_property, mode):
     model_name = "Mnist"

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -38,13 +38,13 @@ class ThisTester(ModelTester):
 
 
 model_and_mode_list = [
-    pytest.param(["tf_efficientnet_lite0.in1k", "train"], marks=pytest.mark.compilation_xfail),
-    pytest.param(["tf_efficientnet_lite1.in1k", "train"], marks=pytest.mark.compilation_xfail),
-    pytest.param(["tf_efficientnet_lite2.in1k", "train"], marks=pytest.mark.compilation_xfail),
-    pytest.param(["tf_efficientnet_lite3.in1k", "train"], marks=pytest.mark.compilation_xfail),
-    pytest.param(["tf_efficientnet_lite4.in1k", "train"], marks=pytest.mark.compilation_xfail),
-    pytest.param(["ghostnet_100.in1k", "train"], marks=pytest.mark.compilation_xfail),
-    pytest.param(["ghostnetv2_100.in1k", "train"], marks=pytest.mark.compilation_xfail),
+    ["tf_efficientnet_lite0.in1k", "train"],
+    ["tf_efficientnet_lite1.in1k", "train"],
+    ["tf_efficientnet_lite2.in1k", "train"],
+    ["tf_efficientnet_lite3.in1k", "train"],
+    ["tf_efficientnet_lite4.in1k", "train"],
+    ["ghostnet_100.in1k", "train"],
+    ["ghostnetv2_100.in1k", "train"],
     ["inception_v4.tf_in1k", "train"],
     ["mixer_b16_224.goog_in21k", "train"],
     ["mobilenetv1_100.ra4_e3600_r224_in1k", "train"],

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -43,7 +43,7 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "model_info",
     [
-        pytest.param(("ssd300_vgg16", "SSD300_VGG16_Weights"), marks=pytest.mark.compilation_xfail),
+        ("ssd300_vgg16", "SSD300_VGG16_Weights"),
         ("ssdlite320_mobilenet_v3_large", "SSDLite320_MobileNet_V3_Large_Weights"),
         ("retinanet_resnet50_fpn", "RetinaNet_ResNet50_FPN_Weights"),
         ("retinanet_resnet50_fpn_v2", "RetinaNet_ResNet50_FPN_V2_Weights"),


### PR DESCRIPTION
Enables CLIP_train by removing the `compilation_xfail` mark
Enables several timm models by removing the `compilation_xfail` mark

### Ticket
N/A

### Problem description
The models listed above were erroneously marked `compilation_xfail`

### What's changed
Remove the incorrect pytest marks
