### PR TITLE
Integrate custom TTNN extension for Pytorch

### DIFF
--- a/tests/cpp_extension/test_cpp_extension.py
+++ b/tests/cpp_extension/test_cpp_extension.py
@@ -1,0 +1,165 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torchvision import transforms, datasets
+from torch.utils.data import DataLoader
+import ttnn
+import torch_ttnn
+from torch_ttnn.cpp_extension.custom_device_mode import ttnn_module, enable_ttnn_device
+import pytest
+
+from transformers import AutoTokenizer, AutoModelForQuestionAnswering
+
+import logging
+import sys
+
+@pytest.mark.parametrize(
+    "input_shape",
+    ((32, 1, 3, 3), (32,)),
+)
+def test_cpp_extension(device, input_shape):
+    torch.utils.rename_privateuse1_backend('ttnn')
+
+    # in pytest the device has already been initialized before this call
+    # so instead we can wrap this around the custom device
+    ttnn_device = ttnn_module.custom_device_from_ttnn(device)
+
+    logging.info("Creating bfloat tensor from -1 to 1")
+    torch_tensor = torch.empty(input_shape, dtype = torch.bfloat16).uniform_(-1, 1)
+    print(torch_tensor)
+    torch_tensor_abs = torch.abs(torch_tensor)
+    print(torch_tensor_abs)
+
+    logging.info("Transferring to ttnn")
+    torch_ttnn_tensor = torch_tensor.to(ttnn_device)
+
+    logging.info("get underlying ttnn tensor")
+    ttnn_tensor = ttnn_module.get_ttnn_tensor(torch_ttnn_tensor)
+
+    logging.info("Running abs on ttnn")
+    ttnn_tensor = ttnn.abs(ttnn_tensor)
+
+    logging.info("calling to_torch")
+    ttnn_to_torch = ttnn.to_torch(ttnn_tensor)
+    print(ttnn_to_torch)
+    
+    
+    assert torch.allclose(torch_tensor_abs, ttnn_to_torch, rtol=0.1, atol=0.1)
+
+    # logging.info("Closing device")
+    # ttnn_module.close_custom_device(ttnn_device)
+
+def test_bert_with_cpp_extension(device):
+    model_name = "phiyodr/bert-large-finetuned-squad2"
+    tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left", torch_dtype=torch.bfloat16)
+    m = AutoModelForQuestionAnswering.from_pretrained(model_name, torch_dtype=torch.bfloat16)
+    context = 'Johann Joachim Winckelmann was a German art historian and archaeologist. He was a pioneering Hellenist who first articulated the difference between Greek, Greco-Roman and Roman art. "The prophet and founding hero of modern archaeology", Winckelmann was one of the founders of scientific archaeology and first applied the categories of style on a large, systematic basis to the history of art. '
+    question = "What discipline did Winkelmann create?"
+    inputs = tokenizer.encode_plus(
+        question,
+        context,
+        add_special_tokens=True,
+        return_tensors="pt",
+        max_length=256,
+        padding="max_length",
+        truncation=True,
+    )
+
+    option = torch_ttnn.TorchTtnnOption(
+                    device=device,
+                    gen_graphviz=False,
+                    run_mem_analysis=False,
+                    metrics_path=model_name,
+                    verbose=True,
+                )
+
+    # custom device
+    torch.utils.rename_privateuse1_backend('ttnn')
+    ttnn_device = ttnn_module.custom_device_from_ttnn(device)
+    
+    # clone input_ids on cpu since this the data transfer is somehow inplace?
+    input_ids = inputs.input_ids.clone()
+    
+    inputs = inputs.to(ttnn_device)
+    # modules are inplace, tensors are not
+    m.to(ttnn_device)
+
+    model = torch.compile(m, backend=torch_ttnn.backend, options=option)
+    outputs = model(**inputs)
+    
+    # Helper function to decode output to human-readable text
+    def decode_output(outputs):
+        response_start = torch.argmax(outputs.start_logits)
+        response_end = torch.argmax(outputs.end_logits) + 1
+        response_tokens = input_ids[0, response_start:response_end]
+        return tokenizer.decode(response_tokens)
+
+    print("finished:")
+    print(outputs)
+    answer = decode_output(outputs)
+
+    print(
+        f"""
+    model_name: {model_name}
+    input:
+        context: {context}
+        question: {question}
+    answer: {answer}
+    """
+    )
+
+# adapted from https://github.com/pytorch/examples/blob/main/mnist/main.py
+class MnistModel(torch.nn.Module):
+    def __init__(self):      
+        super(MnistModel, self).__init__()
+        self.conv1 = nn.Conv2d(1, 32, 3, 1)
+        self.conv2 = nn.Conv2d(32, 64, 3, 1)
+        self.dropout1 = nn.Dropout(0.25)
+        self.dropout2 = nn.Dropout(0.5)
+        self.fc1 = nn.Linear(9216, 128)
+        self.fc2 = nn.Linear(128, 10)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = F.relu(x)
+        x = self.conv2(x)
+        x = F.relu(x)
+        x = F.max_pool2d(x, 2)
+        x = self.dropout1(x)
+        x = torch.flatten(x, 1)
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout2(x)
+        x = self.fc2(x)
+        x = F.log_softmax(x, dim=1)
+        return x
+    
+def test_mnist_with_cpp_extension(device):   
+    model_name = "Mnist"
+    transform = transforms.Compose([transforms.ToTensor()])
+    test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
+    dataloader = DataLoader(test_dataset, batch_size=1)
+    test_input, _ = next(iter(dataloader))
+    test_input = test_input.to(torch.bfloat16)
+
+    # Copy weights and biases to ttnn
+    torch.utils.rename_privateuse1_backend('ttnn')
+    ttnn_device = ttnn_module.custom_device_from_ttnn(device)
+    
+
+    
+    option = torch_ttnn.TorchTtnnOption(
+                    device=device,
+                    gen_graphviz=False,
+                    run_mem_analysis=False,
+                    metrics_path=model_name,
+                    verbose=True,
+                )
+
+    model = MnistModel()
+    model = model.to(torch.bfloat16)
+    test_input = test_input.to(ttnn_device)
+    model.to(ttnn_device)
+            
+    model = torch.compile(model, backend=torch_ttnn.backend, options=option)
+    results = model(test_input)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ import numpy as np
 import collections
 import re
 from typing import List, Dict, Tuple
+from torch_ttnn.cpp_extension.custom_device_mode import ttnn_module, enable_ttnn_device
 
 
 class ModelTester:
@@ -130,6 +131,9 @@ class ModelTester:
         model = self.set_model_eval(self.model)
         inputs = self.set_inputs_eval(self.inputs)
         if as_ttnn == True:
+            torch.utils.rename_privateuse1_backend("ttnn")
+            ttnn_device = ttnn_module.custom_device_from_ttnn(option.device)
+            inputs = inputs.to(ttnn_device)
             model = self.compile_model(model, option)
         outputs = self.run_model(model, inputs)
         results = self.get_results_eval(model, inputs, outputs)

--- a/torch_ttnn/cpp_extension/TtnnOpaqueTensorImpl.h
+++ b/torch_ttnn/cpp_extension/TtnnOpaqueTensorImpl.h
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <ATen/OpaqueTensorImpl.h>
+#include "ttnn/tensor/tensor.hpp"
+#include <iostream>
+#include <string.h>
+
+template <typename Arg, typename... Args>
+void doPrint(std::ostream& out, const std::string_view& filename, int lineno, const std::string_view& fn, Arg&& arg, Args&&... args)
+{
+  out << std::format("{}({})({}): ", filename, lineno, fn);
+  out << std::forward<Arg>(arg);
+  ((out << std::forward<Args>(args)), ...);
+  out << std::endl;
+}
+#define LOGGING(...) doPrint(std::cout, __FILE_NAME__, __LINE__, __FUNCTION__, __VA_ARGS__)
+
+namespace at {
+
+struct TtnnTensorImpl : public TensorImpl {
+  TtnnTensorImpl(
+      at::DispatchKeySet key_set,
+      const caffe2::TypeMeta data_type,
+      c10::Device device,
+      ttnn::Tensor& ttnn_tensor,
+      c10::intrusive_ptr<c10::StorageImpl> storage) : TensorImpl(key_set, data_type, device), ttnn_tensor_(ttnn_tensor), ttnn_tensor_string_(ttnn_tensor.write_to_string()) {
+        storage_ = std::move(storage);
+        auto view = ttnn_tensor_.get_logical_shape().view();
+        std::vector<int64_t> view_int64;
+        std::copy(view.begin(), view.end(), std::back_inserter(view_int64));
+        IntArrayRef int_array_ref(&(*view_int64.begin()), &(*view_int64.end()));
+        sizes_and_strides_.set_sizes(int_array_ref);
+      }
+
+  TtnnTensorImpl(
+    at::DispatchKeySet key_set,
+    const caffe2::TypeMeta data_type,
+    c10::Device device,
+    const ttnn::Tensor& ttnn_tensor,
+    const Storage& storage) : TensorImpl(key_set, data_type, device), ttnn_tensor_(ttnn_tensor), ttnn_tensor_string_(ttnn_tensor.write_to_string()) {
+      storage_ = std::move(storage);
+      auto view = ttnn_tensor_.get_logical_shape().view();
+      std::vector<int64_t> view_int64;
+      std::copy(view.begin(), view.end(), std::back_inserter(view_int64));
+      IntArrayRef int_array_ref(&(*view_int64.begin()), &(*view_int64.end()));
+      sizes_and_strides_.set_sizes(int_array_ref);
+    }
+
+  void set_sizes_and_strides(const IntArrayRef& int_array_ref) {
+      sizes_and_strides_.set_sizes(int_array_ref);
+  }
+
+  void set_sizes_and_strides_as(const at::Tensor& the_template) {
+    sizes_and_strides_.set_sizes(the_template.sizes());
+  }
+
+  ttnn::Tensor get_ttnn_tensor() {
+    // LOGGING(ttnn_tensor_string_);
+    LOGGING(ttnn_tensor_.write_to_string());
+    return ttnn_tensor_;
+  }
+
+  void set_ttnn_tensor(const ttnn::Tensor& tensor) {
+    ttnn_tensor_ = tensor;
+  }
+
+  /**
+   * Return a TensorImpl that is a shallow-copy of this TensorImpl.
+   *
+   * For usage of `version_counter` and `allow_tensor_metadata_change`,
+   * see NOTE [ TensorImpl Shallow-Copying ].
+   */
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+    const c10::VariableVersion& version_counter,
+    bool allow_tensor_metadata_change) const override {
+    auto impl = c10::make_intrusive<TtnnTensorImpl>(
+        key_set(),
+        dtype(),
+        device(),
+        ttnn_tensor_,
+        storage_);
+    copy_tensor_metadata(
+        /*src_opaque_impl=*/this,
+        /*dest_opaque_impl=*/impl.get(),
+        /*version_counter=*/version_counter,
+        /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+    impl->refresh_numel();
+    return impl;
+}
+
+  /**
+   * Return a TensorImpl that is a shallow-copy of this TensorImpl.
+   *
+   * For usage of `version_counter` and `allow_tensor_metadata_change`,
+   * see NOTE [ TensorImpl Shallow-Copying ].
+   */
+  c10::intrusive_ptr<TensorImpl> shallow_copy_and_detach(
+    c10::VariableVersion&& version_counter,
+    bool allow_tensor_metadata_change) const override {
+  auto impl = c10::make_intrusive<TtnnTensorImpl>(
+      key_set(),
+      dtype(),
+      device(),
+      ttnn_tensor_,
+      storage_);
+  copy_tensor_metadata(
+      /*src_opaque_impl=*/this,
+      /*dest_opaque_impl=*/impl.get(),
+      /*version_counter=*/std::move(version_counter),
+      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change);
+  impl->refresh_numel();
+  return impl;
+}
+
+/**
+ * Shallow-copies data from another TensorImpl into this TensorImpl.
+ *
+ * For why this function doesn't check this TensorImpl's
+ * `allow_tensor_metadata_change_`, see NOTE [ TensorImpl Shallow-Copying ].
+ */
+void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
+  AT_ASSERT(has_compatible_shallow_copy_type(impl->key_set()));
+  auto ttnn_impl =
+      static_cast<const TtnnTensorImpl*>(impl.get());
+  copy_tensor_metadata(
+      /*src_impl=*/ttnn_impl,
+      /*dest_impl=*/this,
+      /*version_counter=*/version_counter(),
+      /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
+  refresh_numel();
+}
+
+  // protected:
+  //   static void copy_tensor_metadata(
+  //     const TtnnTensorImpl* src_impl,
+  //     TtnnTensorImpl* dest_impl,
+  //     const c10::VariableVersion& version_counter,
+  //     bool allow_tensor_metadata_change) {
+  //     TensorImpl::copy_tensor_metadata(
+  //         src_impl,
+  //         dest_impl,
+  //         version_counter,
+  //         allow_tensor_metadata_change);
+
+  //     // TtnnTensorImpl-specific fields.
+  //     dest_impl->ttnn_tensor_ = src_impl->ttnn_tensor_;
+  //     dest_impl->ttnn_tensor_string_ = src_impl->ttnn_tensor_string_;
+  //   }
+
+  //   static void copy_tensor_metadata(
+  //     const TtnnTensorImpl* src_impl,
+  //     TtnnTensorImpl* dest_impl,
+  //     c10::VariableVersion&& version_counter,
+  //     bool allow_tensor_metadata_change) {
+  //       TensorImpl::copy_tensor_metadata(
+  //           src_impl,
+  //           dest_impl,
+  //           std::move(version_counter),
+  //           allow_tensor_metadata_change);
+
+  //     // TtnnTensorImpl-specific fields.
+  //     dest_impl->ttnn_tensor_ = src_impl->ttnn_tensor_;
+  //     dest_impl->ttnn_tensor_string_ = src_impl->ttnn_tensor_string_;
+  //   }
+
+  private:
+    ttnn::Tensor ttnn_tensor_;
+    std::string ttnn_tensor_string_;
+};
+
+} // namespace at

--- a/torch_ttnn/cpp_extension/TtnnTensorImpl.hpp
+++ b/torch_ttnn/cpp_extension/TtnnTensorImpl.hpp
@@ -1,23 +1,14 @@
 #pragma once
 
-#include <ATen/OpaqueTensorImpl.h>
 #include "ttnn/tensor/tensor.hpp"
+#include "extension_utils.hpp"
 #include <iostream>
 #include <string.h>
-
-template <typename Arg, typename... Args>
-void doPrint(std::ostream& out, const std::string_view& filename, int lineno, const std::string_view& fn, Arg&& arg, Args&&... args)
-{
-  out << std::format("{}({})({}): ", filename, lineno, fn);
-  out << std::forward<Arg>(arg);
-  ((out << std::forward<Args>(args)), ...);
-  out << std::endl;
-}
-#define LOGGING(...) doPrint(std::cout, __FILE_NAME__, __LINE__, __FUNCTION__, __VA_ARGS__)
 
 namespace at {
 
 struct TtnnTensorImpl : public TensorImpl {
+  // TODO: Only difference is the storage type, combine these two
   TtnnTensorImpl(
       at::DispatchKeySet key_set,
       const caffe2::TypeMeta data_type,
@@ -55,8 +46,7 @@ struct TtnnTensorImpl : public TensorImpl {
   }
 
   ttnn::Tensor get_ttnn_tensor() {
-    // LOGGING(ttnn_tensor_string_);
-    LOGGING(ttnn_tensor_.write_to_string());
+    LOGGING("");
     return ttnn_tensor_;
   }
 
@@ -129,42 +119,9 @@ void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override {
       /*allow_tensor_metadata_change=*/allow_tensor_metadata_change());
   refresh_numel();
 }
-
-  // protected:
-  //   static void copy_tensor_metadata(
-  //     const TtnnTensorImpl* src_impl,
-  //     TtnnTensorImpl* dest_impl,
-  //     const c10::VariableVersion& version_counter,
-  //     bool allow_tensor_metadata_change) {
-  //     TensorImpl::copy_tensor_metadata(
-  //         src_impl,
-  //         dest_impl,
-  //         version_counter,
-  //         allow_tensor_metadata_change);
-
-  //     // TtnnTensorImpl-specific fields.
-  //     dest_impl->ttnn_tensor_ = src_impl->ttnn_tensor_;
-  //     dest_impl->ttnn_tensor_string_ = src_impl->ttnn_tensor_string_;
-  //   }
-
-  //   static void copy_tensor_metadata(
-  //     const TtnnTensorImpl* src_impl,
-  //     TtnnTensorImpl* dest_impl,
-  //     c10::VariableVersion&& version_counter,
-  //     bool allow_tensor_metadata_change) {
-  //       TensorImpl::copy_tensor_metadata(
-  //           src_impl,
-  //           dest_impl,
-  //           std::move(version_counter),
-  //           allow_tensor_metadata_change);
-
-  //     // TtnnTensorImpl-specific fields.
-  //     dest_impl->ttnn_tensor_ = src_impl->ttnn_tensor_;
-  //     dest_impl->ttnn_tensor_string_ = src_impl->ttnn_tensor_string_;
-  //   }
-
   private:
     ttnn::Tensor ttnn_tensor_;
+    // TODO: Debug only, should probably remove as it might be costly
     std::string ttnn_tensor_string_;
 };
 

--- a/torch_ttnn/cpp_extension/custom_device_mode.py
+++ b/torch_ttnn/cpp_extension/custom_device_mode.py
@@ -1,0 +1,100 @@
+import torch
+import torch.utils.cpp_extension
+from torch.overrides import TorchFunctionMode
+import os
+from pathlib import Path
+import glob
+import logging
+
+assert os.environ.get('TT_METAL_HOME') is not None
+tt_metal_home = Path(os.environ["TT_METAL_HOME"])
+
+cpmcache_pattern = Path(".cpmcache/**/include")
+cpmcache_dirs = glob.glob(str(tt_metal_home / cpmcache_pattern), recursive=True)
+
+ttnn_include_paths = [
+    tt_metal_home,
+    tt_metal_home / Path("tt_metal"),
+    tt_metal_home / Path("tt_metal/third_party/umd"),
+    tt_metal_home / Path("tt_metal/third_party/fmt"),
+    tt_metal_home / Path("tt_metal/hw/inc/wormhole"),
+    tt_metal_home / Path("tt_metal/hw/inc/wormhole/wormhole_b0_defines"),
+    tt_metal_home / Path("tt_metal/hw/inc/"),
+    tt_metal_home / Path("tt_metal/third_party/umd/src/firmware/riscv/wormhole"),
+    tt_metal_home / Path("tt_metal/third_party/umd/device"),
+    tt_metal_home / Path("ttnn/cpp"),
+    tt_metal_home / Path("ttnn"),
+    tt_metal_home / Path("ttnn/cpp/ttnn/deprecated"),
+    tt_metal_home / Path("tt_metal/third_party/magic_enum"),
+    tt_metal_home / Path("tt_metal/third_party/umd/device/api"),
+    tt_metal_home / Path("tt_metal/hostdevcommon/api"),
+    tt_metal_home / Path(".cpmcache/reflect/e75434c4c5f669e4a74e4d84e0a30d7249c1e66f"),
+    tt_metal_home / Path("tt_metal/third_party/tracy/public"),
+    tt_metal_home / Path("tt_metal/include"),
+    tt_metal_home / Path("tt_metal/api"),
+    tt_metal_home / Path("tt_metal/tt_stl"),
+    tt_metal_home / Path("tt_metal/include/tt_metal/internal"),
+    ] + cpmcache_dirs
+ttnn_include_paths = [str(p) for p in ttnn_include_paths]
+
+# Load the C++ extension containing your custom kernels.
+tt_metal_lib_paths = [
+    tt_metal_home / Path("build/lib"),
+]
+tt_metal_lib_paths = ["-L" + str(p) + " -Wl,-rpath=" + str(p) for p in tt_metal_lib_paths]
+tt_metal_libs = [
+    "tt_metal",
+    "c++",
+    ":_ttnn.so",
+    "device",
+]
+tt_metal_libs = ["-l" + p for p in tt_metal_libs]
+
+# Use clang to match ttnn build
+os.environ["CXX"] = "clang++-17"
+# c++20 needed for __cpp_concepts
+# c++20 -std=libc++ needed for source_location
+
+working_file_path = Path(os.path.realpath(__file__))
+working_directory = working_file_path.parents[0]
+
+ttnn_module = torch.utils.cpp_extension.load(
+    name="custom_device_extension",
+    sources=[
+        str(working_directory / "open_registration_extension.cpp"),
+    ],
+    extra_include_paths=[str(working_directory)] + ttnn_include_paths,
+    extra_cflags=["-g", "-DFMT_HEADER_ONLY", '-std=c++20', '-stdlib=libc++'],
+    extra_ldflags=tt_metal_lib_paths + tt_metal_libs,
+    verbose=True,
+)
+
+logging.info('Loaded custom extension.')
+
+# The user will globally enable the below mode when calling this API
+def enable_ttnn_device():
+    m = TtnnDeviceMode()
+    m.__enter__()
+    # If you want the mode to never be disabled, then this function shouldn't return anything.
+    return m
+
+# This is a simple TorchFunctionMode class that:
+# (a) Intercepts all torch.* calls
+# (b) Checks for kwargs of the form `device="foo:i"`
+# (c) Turns those into custom device objects: `device=ttnn_module.custom_device(i)`
+# (d) Forwards the call along into pytorch.
+class TtnnDeviceMode(TorchFunctionMode):
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if 'device' in kwargs and 'ttnn' in kwargs['device']:
+            device_and_idx = kwargs['device'].split(':')
+            if len(device_and_idx) == 1:
+                # Case 1: No index specified
+                kwargs['device'] = ttnn_module.custom_device()
+            else:
+                # Case 2: The user specified a device index.
+                device_idx = int(device_and_idx[1])
+                kwargs['device'] = ttnn_module.custom_device(device_idx)
+        with torch._C.DisableTorchFunction():
+            return func(*args, **kwargs)

--- a/torch_ttnn/cpp_extension/custom_device_mode.py
+++ b/torch_ttnn/cpp_extension/custom_device_mode.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import glob
 import logging
 
-assert os.environ.get('TT_METAL_HOME') is not None
+assert os.environ.get("TT_METAL_HOME") is not None
 tt_metal_home = Path(os.environ["TT_METAL_HOME"])
 
 cpmcache_pattern = Path(".cpmcache/**/include")
@@ -34,7 +34,7 @@ ttnn_include_paths = [
     tt_metal_home / Path("tt_metal/api"),
     tt_metal_home / Path("tt_metal/tt_stl"),
     tt_metal_home / Path("tt_metal/include/tt_metal/internal"),
-    ] + cpmcache_dirs
+] + cpmcache_dirs
 ttnn_include_paths = [str(p) for p in ttnn_include_paths]
 
 # Load the C++ extension containing your custom kernels.
@@ -64,12 +64,13 @@ ttnn_module = torch.utils.cpp_extension.load(
         str(working_directory / "open_registration_extension.cpp"),
     ],
     extra_include_paths=[str(working_directory)] + ttnn_include_paths,
-    extra_cflags=["-g", "-DFMT_HEADER_ONLY", '-std=c++20', '-stdlib=libc++'],
+    extra_cflags=["-g", "-DFMT_HEADER_ONLY", "-std=c++20", "-stdlib=libc++"],
     extra_ldflags=tt_metal_lib_paths + tt_metal_libs,
     verbose=True,
 )
 
-logging.info('Loaded custom extension.')
+logging.info("Loaded custom extension.")
+
 
 # The user will globally enable the below mode when calling this API
 def enable_ttnn_device():
@@ -77,6 +78,7 @@ def enable_ttnn_device():
     m.__enter__()
     # If you want the mode to never be disabled, then this function shouldn't return anything.
     return m
+
 
 # This is a simple TorchFunctionMode class that:
 # (a) Intercepts all torch.* calls
@@ -87,14 +89,14 @@ class TtnnDeviceMode(TorchFunctionMode):
     def __torch_function__(self, func, types, args=(), kwargs=None):
         if kwargs is None:
             kwargs = {}
-        if 'device' in kwargs and 'ttnn' in kwargs['device']:
-            device_and_idx = kwargs['device'].split(':')
+        if "device" in kwargs and "ttnn" in kwargs["device"]:
+            device_and_idx = kwargs["device"].split(":")
             if len(device_and_idx) == 1:
                 # Case 1: No index specified
-                kwargs['device'] = ttnn_module.custom_device()
+                kwargs["device"] = ttnn_module.custom_device()
             else:
                 # Case 2: The user specified a device index.
                 device_idx = int(device_and_idx[1])
-                kwargs['device'] = ttnn_module.custom_device(device_idx)
+                kwargs["device"] = ttnn_module.custom_device(device_idx)
         with torch._C.DisableTorchFunction():
             return func(*args, **kwargs)

--- a/torch_ttnn/cpp_extension/extension_utils.hpp
+++ b/torch_ttnn/cpp_extension/extension_utils.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <vector>
+#include "c10/util/Exception.h"
+#include "ttnn/operations/core/core.hpp"
+#include "c10/core/ScalarType.h"
+
+template <typename Arg, typename... Args>
+void doPrint(std::ostream& out, const std::string_view& filename, int lineno, const std::string_view& fn, Arg&& arg, Args&&... args)
+{
+  out << std::format("{}({})({}): ", filename, lineno, fn);
+  out << std::forward<Arg>(arg);
+  ((out << std::forward<Args>(args)), ...);
+  out << std::endl;
+}
+#define LOGGING(...) doPrint(std::cout, __FILE_NAME__, __LINE__, __FUNCTION__, __VA_ARGS__)
+
+
+template <typename T>
+void vector_compare(const std::vector<T>& first, const std::vector<T>& second) {
+  TORCH_CHECK(first.size() == second.size());
+  for (int i = 0; i < first.size(); ++i) {
+    if (fabs(first[i] - second[i]) > 0.000001) {
+      LOGGING("mismatch: ", first[i], " vs ", second[i]);
+    }
+  }
+}
+
+ttnn::DataType dtype_torch_to_ttnn(at::ScalarType dtype) {
+    switch(dtype) {
+      case at::ScalarType::Int:
+      case at::ScalarType::Long:
+        return ttnn::DataType::UINT32;
+      case at::ScalarType::BFloat16:
+        return ttnn::DataType::BFLOAT16;
+      default:
+        return ttnn::DataType::BFLOAT16;
+    }
+  }
+  

--- a/torch_ttnn/cpp_extension/open_registration_extension.cpp
+++ b/torch_ttnn/cpp_extension/open_registration_extension.cpp
@@ -1,0 +1,575 @@
+#include <c10/core/impl/alloc_cpu.h>
+#include <c10/core/Allocator.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/core/impl/DeviceGuardImplInterface.h>
+
+#include <torch/csrc/Device.h>
+#include <torch/extension.h>
+
+#include <ATen/native/cpu/Loops.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/EmptyTensor.h>
+#include <ATen/ops/empty_strided.h>
+#include <ATen/ops/abs_native.h>
+
+#include <iostream>
+#include <string.h>
+
+#include <ATen/native/Resize.h>
+#include <ATen/native/UnaryOps.h> // abs_stub
+
+#include <list>
+
+// Order of header matters here because c10 has a Layout type as well. If this is before Aten headers, there will be errors about ambiguity.
+#include "ttnn/device.hpp"
+#include "ttnn/operations/creation.hpp"
+#include "tt-metalium/small_vector.hpp"
+#include "ttnn/common/queue_id.hpp"
+#include <tt-metalium/bfloat16.hpp>
+
+#include "TtnnOpaqueTensorImpl.h"
+#include "tt-metalium/event.hpp"
+#include "ttnn/async_runtime.hpp"
+
+#include <torch/csrc/utils/pybind.h>
+
+#include <format>
+
+
+#define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+// use glog instead maybe?
+// #define LOGGING(s) std::cout << __FILE_NAME__ << "(" << __LINE__ << ")" << "(" << __FUNCTION__ << ")" << ": " << s << std::endl
+
+
+
+namespace {
+
+void abs_kernel(at::TensorIteratorBase& iter) {
+  // empty because we don't need it, but it has to be defined
+}
+
+} // namespace
+
+namespace at::native {
+REGISTER_PRIVATEUSE1_DISPATCH(abs_stub, &abs_kernel);
+}
+
+// A dummy allocator for our custom device, that secretly uses the CPU
+struct DummyCustomAllocator final : at::Allocator {
+  DummyCustomAllocator() = default;
+  // at::DataPtr allocate(size_t nbytes) override {
+  at::DataPtr allocate(size_t nbytes) const override {
+    LOGGING("");
+    void* data = c10::alloc_cpu(nbytes);
+    return {data, data, &ReportAndDelete, c10::Device(c10::DeviceType::PrivateUse1, 0)};
+  }
+
+  // void copy_data(void* dest, const void* src, std::size_t count) const override {
+  //   std::cout << __FILENAME__ << " Custom copy copy_data() called!" << std::endl;
+  //   std::memcpy(dest, src, count);
+  // }
+
+  static void ReportAndDelete(void* ptr) {
+    LOGGING("");
+    if (!ptr) {
+      return;
+    }
+    c10::free_cpu(ptr);
+  }
+
+  at::DeleterFnPtr raw_deleter() const override {
+  // at::DeleterFnPtr raw_deleter() {
+    return &ReportAndDelete;
+  }
+};
+
+// Register our dummy allocator
+static DummyCustomAllocator global_custom_alloc;
+REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &global_custom_alloc);
+
+
+// =====================================
+// ============= Device Guards =========
+// =====================================
+
+// PyTorch has an API for registering device guards.
+// Device guards can be used to set the current "active" device,
+// and e.g. error if the user provides an invalid device index.
+//
+// If your device doesn't support indices (e.g. foo:0 vs. foo:1),
+// then the guards probably aren't needed.
+//
+// You can use it by creating a DeviceGuard class, registering it
+// in PyTorch, and invoking the device guard before any kernels are called.
+// For a more full-featured example of a device guard,
+// check out the code at c10/cuda/CUDAGuard.h
+
+// Represents the current "active" device.
+// The dummy device guard registered below is meant to show how a backend
+// can integrate custom device guard with pytorch.
+// For something like cuda this represents the current active cuda device,
+// which is directly set using the cuda API calls cudaGetDevice/cudaSetDevice.
+static uint16_t CURR_DEVICE = -1;
+
+// Create and register a dummy device guard.
+struct DummyDeviceGuardImpl final : public c10::impl::DeviceGuardImplInterface {
+  static constexpr c10::DeviceType static_type = c10::DeviceType::PrivateUse1;
+  DummyDeviceGuardImpl() {
+    LOGGING("");
+  }
+  explicit DummyDeviceGuardImpl(c10::DeviceType t) {
+    LOGGING("");
+    TORCH_INTERNAL_ASSERT(t == c10::DeviceType::PrivateUse1);
+  }
+  at::DeviceType type() const override {
+    LOGGING("");
+    return at::DeviceType::PrivateUse1;
+  }
+  at::Device exchangeDevice(at::Device d) const override {
+    LOGGING("");
+    TORCH_INTERNAL_ASSERT(d.type() == at::DeviceType::PrivateUse1);
+    TORCH_INTERNAL_ASSERT(d.index() < deviceCount(), "Error: device index ", d.index(), " does not exist.");
+    at::Device old_device = getDevice();
+    if (old_device.index() != d.index()) {
+      // "set the active device"
+      CURR_DEVICE = d.index();
+    }
+    return old_device;
+  }
+  at::Device getDevice() const override {
+    LOGGING("");
+    return at::Device(at::DeviceType::PrivateUse1, CURR_DEVICE);
+  }
+  void setDevice(at::Device d) const override {
+    LOGGING("");
+    TORCH_INTERNAL_ASSERT(d.type() == at::DeviceType::PrivateUse1);
+    TORCH_INTERNAL_ASSERT(d.index() < deviceCount(), "Error: device index ", d.index(), " does not exist.");
+    at::Device current_device = getDevice();
+    if (current_device != d) {
+      CURR_DEVICE = d.index();
+    }
+  }
+  void uncheckedSetDevice(at::Device d) const noexcept override {
+    LOGGING("");
+    auto current_device = getDevice();
+    if (current_device != d) {
+      CURR_DEVICE = d.index();
+    }
+  }
+  at::Stream getStream(at::Device d) const noexcept override {
+    // no-op
+    return at::Stream(at::Stream::DEFAULT, d);
+  }
+  // NB: These do NOT set the current device
+  at::Stream exchangeStream(at::Stream) const noexcept override {
+    // no-op
+    return at::Stream(at::Stream::DEFAULT, at::Device(at::DeviceType::PrivateUse1, CURR_DEVICE));
+  }
+  at::DeviceIndex deviceCount() const noexcept override {
+    // Hardcoding the number of "valid" devices here at 2.
+    return 2;
+  }
+
+  // Event-related functions
+  void record(
+      void** /*event*/,
+      const at::Stream& /*stream*/,
+      const at::DeviceIndex /*device_index*/,
+      const c10::EventFlag /*flag*/) const override {
+    TORCH_CHECK(false, at::DeviceType::PrivateUse1, " backend doesn't support events.");
+  }
+  void block(void* /*event*/, const at::Stream& /*stream*/) const override {
+    LOGGING("");
+    TORCH_CHECK(false, at::DeviceType::PrivateUse1, " backend doesn't support events.")
+  }
+  bool queryEvent(void* /*event*/) const override {
+    LOGGING("");
+    TORCH_CHECK(false, at::DeviceType::PrivateUse1, " backend doesn't support events.")
+  }
+  void destroyEvent(void* /*event*/, const at::DeviceIndex /*device_index*/)
+      const noexcept override {}
+
+  // Stream-related functions
+  bool queryStream(const at::Stream& /*stream*/) const override {
+    return true;
+  }
+  void synchronizeStream(const at::Stream& /*stream*/) const override {
+    // Don't wait for anything.
+  }
+};
+
+struct DummyGuard {
+  explicit DummyGuard() = delete;
+  explicit DummyGuard(at::DeviceIndex device_index) : guard_(device_index) {}
+  explicit DummyGuard(at::Device device) : guard_(device) {}
+  DummyGuard(const DummyGuard&) = delete;
+  DummyGuard& operator=(const DummyGuard&) = delete;
+  DummyGuard(DummyGuard&& other) = delete;
+  DummyGuard& operator=(DummyGuard&& other) = delete;
+
+  void set_device(at::Device device) {
+    guard_.set_device(device);
+  }
+
+  void reset_device(at::Device device) {
+    guard_.reset_device(device);
+  }
+
+  void set_index(at::DeviceIndex device_index) {
+    guard_.set_index(device_index);
+  }
+
+  at::Device original_device() const {
+    return guard_.original_device();
+  }
+
+  at::Device current_device() const {
+    return guard_.current_device();
+  }
+
+  IDevice* get_ttnn_device() {
+    LOGGING("");
+    if (!ttnn_device) {
+      ttnn_device = &ttnn::open_device(0);
+    }
+    return ttnn_device;
+  }
+
+  static IDevice * ttnn_device;
+ private:
+  c10::impl::InlineDeviceGuard<DummyDeviceGuardImpl> guard_;
+};
+
+IDevice* DummyGuard::ttnn_device = nullptr;
+
+C10_REGISTER_GUARD_IMPL(PrivateUse1, DummyDeviceGuardImpl);
+
+
+// =====================================
+// ============= KERNELS ===============
+// =====================================
+
+// basic dummy empty function, so we can directly construct tensors on the custom device
+// This dummy test device will just use the CPU allocator, and ignores pinned memory.
+//
+// Note: this kernel is very simple because our "custom device" just uses the normal TensorImpl object
+// to store data under the hood.
+// In PyTorch core today, both cpu and cuda are implemented with an ordinary TensorImpl class.
+// Sometimes, backends prefer to subclass TensorImpl in order to store extra information.
+// If this is the case, then this kernel is where you'll be responsible for creating and returning
+// a fresh at::Tensor object, that properly stores a TensorImpl of your subclass.
+at::Tensor custom_empty_memory_format(at::IntArrayRef size, c10::optional<at::ScalarType> dtype_opt, c10::optional<at::Layout> layout_opt, c10::optional<at::Device> device_opt, c10::optional<bool> pin_memory_opt, c10::optional<at::MemoryFormat> memory_format_opt) {
+  LOGGING("");
+  constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
+  // Check for value to be safe
+  auto dtype = c10::scalarTypeToTypeMeta(dtype_opt.value());
+  // Shape
+  at::Device device = device_opt.value();
+  LOGGING(device);
+  DummyGuard device_guard(device);
+  IDevice* ttnn_device = device_guard.get_ttnn_device();
+  LOGGING(size);
+  ttnn::SmallVector<uint32_t> small_vector(size.begin(), size.end());
+  auto tensor = ttnn::empty(ttnn::Shape(small_vector),
+    ttnn::DataType::BFLOAT16,
+    ttnn::TILE_LAYOUT,
+    ttnn_device,
+    MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
+  LOGGING("");
+  auto size_bytes = at::detail::computeStorageNbytesContiguous(size, dtype.itemsize());
+  auto storage_impl = c10::make_intrusive<c10::StorageImpl>(
+    c10::StorageImpl::use_byte_size_t(),
+    0,
+    &global_custom_alloc,
+    /*resizeable=*/true);
+
+  auto tensor_ret = at::detail::make_tensor<at::TtnnTensorImpl>(private_use_ks, dtype, device, tensor, storage_impl);
+  LOGGING("");
+  return tensor_ret;
+}
+
+at::Tensor & custom_fill__scalar(at::Tensor & self, const at::Scalar & value) {
+  LOGGING("");
+  return self;
+}
+
+// basic dummy copy_() function, so we can copy from the custom device to/from CPU
+at::Tensor custom__copy_from(const at::Tensor& self, const at::Tensor& dst, bool non_blocking) {
+  LOGGING(self.device().type(), " ==> ", dst.device().type());
+  // Only supports cpu ==> ttnn or ttnn ==> cpu
+  // Check direction of copy
+  if (self.is_cpu() && dst.device().type() == c10::DeviceType::PrivateUse1) {
+    LOGGING("Copying from cpu to ttnn...");
+
+    DummyGuard device_guard(at::device_of(dst).value());
+
+    // Some dummy asserts for the basic use case: inputs are the same size / dtype, all contiguous.
+    LOGGING("CPU Tensor Size: ", self.sizes(), " dtype: ", self.dtype());
+    LOGGING("CPU Tensor Scalar Type: ", self.scalar_type());
+    LOGGING("CPU is Contiguous: ", self.is_contiguous());
+
+    LOGGING("TTNN Torch Tensor size: ", dst.sizes(), " dtype: ", dst.dtype());
+    // TORCH_CHECK(self.sizes() == dst.sizes());
+    TORCH_CHECK(self.scalar_type() == dst.scalar_type());
+    TORCH_CHECK(self.is_contiguous() && dst.is_contiguous());
+
+    at::TtnnTensorImpl* tensor_impl = static_cast<at::TtnnTensorImpl*>(dst.unsafeGetTensorImpl());
+    auto dst_tensor = tensor_impl->get_ttnn_tensor();
+    auto padded_shape = dst_tensor.get_padded_shape();
+    auto logical_shape = dst_tensor.get_logical_shape();
+    LOGGING("TTNN Tensor padded shape: ", padded_shape);
+    LOGGING("TTNN Tensor logical shape: ", logical_shape);
+
+    IDevice* ttnn_device = device_guard.get_ttnn_device();
+    // LOGGING(dst_tensor.write_to_string());
+    LOGGING("dst_tensor is contiguous: ", dst_tensor.is_contiguous());
+
+    auto volume = dst_tensor.volume();
+    auto element_size = dst_tensor.element_size();
+    auto logical_volume = dst_tensor.get_logical_volume();
+    LOGGING("volume: ", volume);
+    LOGGING("element_size: ", element_size);
+    LOGGING("logical_volume: ", logical_volume);
+#if 0
+
+    uint8_t* padded_self_ptr = new uint8_t[volume * element_size];
+    memcpy(padded_self_ptr, self.storage().data_ptr().get(), logical_volume * element_size);
+
+    tt::tt_metal::memcpy(dst_tensor, padded_self_ptr);
+
+    delete[] padded_self_ptr;
+#endif
+
+    auto on_creation_callback = [] {};
+    auto on_destruction_callback = [] {};
+    // calculate size better
+    ttnn::Tensor src_cpu = ttnn::Tensor(
+      tt::tt_metal::BorrowedStorage{
+        borrowed_buffer::Buffer(static_cast<bfloat16*>(self.storage().data_ptr().get()), logical_volume),
+        on_creation_callback,
+        on_destruction_callback},
+      logical_shape,
+      ttnn::DataType::BFLOAT16,
+      ttnn::Layout::ROW_MAJOR);
+    LOGGING("src_cpu: ", src_cpu.write_to_string());
+      
+    // Cannot automatically pad to 2D from 1D. https://github.com/tenstorrent/tt-metal/issues/18081
+    // Workaround is to reshape then pad?
+    Tensor src_padded;
+    auto logical_rank = logical_shape.rank();
+    if (logical_rank == 1) {
+      ttnn::Shape new_shape({1, logical_shape[0]});
+      Tensor src_reshaped = src_cpu.reshape(new_shape);
+      LOGGING("");
+      src_padded = src_reshaped.pad_to_tile(0);
+    }
+    else {
+      src_padded = src_cpu.pad_to_tile(0);
+    }
+    LOGGING("");
+    Tensor src_tiled = src_padded.to_layout(ttnn::Layout::TILE);
+    LOGGING("");
+    Tensor src_dev = src_tiled.to_device(ttnn_device);
+    LOGGING("");
+    // reshape back to original?
+    if (logical_rank == 1) {
+      ttnn::Shape new_shape({1, logical_shape[0]});
+      src_dev = src_dev.reshape(logical_shape);
+      LOGGING("");
+    }
+
+    tensor_impl->set_ttnn_tensor(src_dev);
+
+    LOGGING(src_dev.write_to_string());
+  }
+  else if (self.device().type() == c10::DeviceType::PrivateUse1 && dst.is_cpu()) {
+    LOGGING("");
+    DummyGuard device_guard(at::device_of(self).value());
+
+    // same as custom_resize_?
+    at::TensorImpl* dst_tensor_impl = dst.unsafeGetTensorImpl();
+    LOGGING(dst_tensor_impl->storage_initialized());
+    at::IntArrayRef size = self.sizes();
+    dst_tensor_impl->set_sizes_contiguous(size);
+    const auto itemsize = dst_tensor_impl->dtype().itemsize();
+    const auto offset = dst_tensor_impl->storage_offset();
+    const auto storage_size = at::detail::computeStorageNbytesContiguous(size, itemsize, offset);
+    LOGGING(storage_size);
+    LOGGING(dst_tensor_impl->numel());
+    at::native::maybe_resize_storage_cpu(dst_tensor_impl, storage_size);
+
+    LOGGING(dst_tensor_impl->storage_initialized());
+
+    // Some dummy asserts for the basic use case: inputs are the same size / dtype, all contiguous.
+    LOGGING(self.sizes());
+    LOGGING(dst.sizes());
+    // TORCH_CHECK(self.sizes() == dst.sizes());
+    TORCH_CHECK(self.scalar_type() == dst.scalar_type());
+
+    // ttnn tensor has contiguous check too
+    LOGGING(self.is_contiguous());
+    LOGGING(dst.is_contiguous());
+    TORCH_CHECK(self.is_contiguous() && dst.is_contiguous());
+
+    at::TtnnTensorImpl* tensor_impl = static_cast<at::TtnnTensorImpl*>(self.unsafeGetTensorImpl());
+    auto self_tensor = tensor_impl->get_ttnn_tensor();
+    // LOGGING(self_tensor.write_to_string());
+    LOGGING(self_tensor.get_padded_shape());
+    LOGGING(self_tensor.logical_shape());
+    auto volume = self_tensor.volume();
+    auto element_size = self_tensor.element_size();
+    auto logical_volume = self_tensor.get_logical_volume();
+    LOGGING(volume);
+
+    LOGGING("");
+    // better type for bytes?
+    uint8_t* temp_host_ptr = new uint8_t[volume * element_size];
+    tt::tt_metal::memcpy(temp_host_ptr, self_tensor);
+    // use better copy?
+    memcpy(dst.storage().data_ptr().get(), temp_host_ptr, logical_volume * element_size);
+    delete[] temp_host_ptr;
+  }
+
+  return dst;
+}
+
+at::Tensor custom_empty_strided(c10::IntArrayRef size,
+                                c10::IntArrayRef stride,
+                                c10::optional<at::ScalarType> dtype_opt,
+                                c10::optional<at::Layout> layout_opt,
+                                c10::optional<at::Device> device_opt,
+                                c10::optional<bool> pin_memory_opt) {
+
+  LOGGING("Creating empty strided tensor...");
+  constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
+  // Check for value to be safe
+  auto dtype = c10::scalarTypeToTypeMeta(dtype_opt.value());
+
+  LOGGING("Size: ", size);
+  LOGGING("Stride: ", stride);
+
+  at::Device device = device_opt.value();
+  LOGGING("Using at::Device: ", device);
+  DummyGuard device_guard(device);
+  IDevice* ttnn_device = device_guard.get_ttnn_device();
+  ttnn::SmallVector<uint32_t> small_vector(size.begin(), size.end());
+
+  auto ttnn_tensor = ttnn::empty(ttnn::Shape(small_vector),
+    ttnn::DataType::BFLOAT16,
+    ttnn::TILE_LAYOUT,
+    ttnn_device,
+    MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM, std::nullopt});
+  // LOGGING(ttnn_tensor.write_to_string());
+  
+  // auto shape = ttnn::Shape(small_vector);
+  // auto ttnn_tensor = ttnn::Tensor(ttnn::OwnedStorage{tt::tt_metal::owned_buffer::create<bfloat16>(shape.volume())}, shape, ttnn::DataType::BFLOAT16, ttnn::TILE_LAYOUT);
+
+  auto size_bytes = at::detail::computeStorageNbytesContiguous(size, dtype.itemsize());
+  auto storage_impl = c10::make_intrusive<c10::StorageImpl>(
+    c10::StorageImpl::use_byte_size_t(),
+    0,
+    &global_custom_alloc,
+    /*resizeable=*/true);
+
+  auto ttnn_tensor_ret = at::detail::make_tensor<at::TtnnTensorImpl>(private_use_ks, dtype, device, ttnn_tensor, storage_impl);
+  return ttnn_tensor_ret;
+}
+
+at::Tensor& custom_abs_out(const at::Tensor& self, at::Tensor& out) {
+  LOGGING("");
+  LOGGING(self.device().type());
+  LOGGING(out.device().type());
+  at::TtnnTensorImpl* tensor_impl = static_cast<at::TtnnTensorImpl*>(self.unsafeGetTensorImpl());
+  LOGGING("");
+  auto ttnn_tensor = tensor_impl->get_ttnn_tensor();
+  LOGGING("");
+  // LOGGING(ttnn_tensor.write_to_string());
+
+  LOGGING("");
+  auto result = ttnn::abs(ttnn_tensor);
+
+  // LOGGING(result.write_to_string());
+
+  // this might belong somewhere else?
+  LOGGING("");
+  at::TtnnTensorImpl* out_tensor_impl = static_cast<at::TtnnTensorImpl*>(out.unsafeGetTensorImpl());
+  LOGGING(out.device().type());
+  out_tensor_impl->set_sizes_and_strides_as(self);
+  LOGGING(out.device().type());
+  LOGGING("");
+
+  auto out_ttnn_tensor = out_tensor_impl->get_ttnn_tensor();
+  LOGGING("");
+  out_tensor_impl->set_ttnn_tensor(result);
+  LOGGING("");
+  
+  // return at::native::abs_out(self, out);
+  return out;
+}
+
+// This macro does the heavy lifting.
+// With TORCH_LIBRARY_IMPL, you can register custom kernels for your backend.
+// For open registration, we're registering all of our kernels to the PrivateUse1 dispatch key.
+// Later in this file, we map a custom device to the PrivateUse1 device type,
+// which allows user code that puts a tensor on your custom_device to eventually get plumbed
+// into the kernels registered here.
+//
+// This macro registers your kernels to the PyTorch Dispatcher.
+// More details on the dispatcher can be found at http://blog.ezyang.com/2020/09/lets-talk-about-the-pytorch-dispatcher/.
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
+  m.impl("aten::empty_strided", &custom_empty_strided);
+  m.impl("empty.memory_format", &custom_empty_memory_format);
+  m.impl("_copy_from", &custom__copy_from);
+  m.impl("abs.out", &custom_abs_out); 
+}
+
+// This basic implementation doesn't bother dealing with different device indices
+// (e.g. custom_device:0 vs. custom_device:1).
+// We could do that by letting the user pass in a device index in our exposed device function.
+// Note that if you do that, you'll also need to register a device guard to core.
+// See `c10/core/impl/DeviceGuardImplInterface.h:C10_REGISTER_GUARD_IMPL`.
+c10::Device get_custom_device(int idx) {
+  LOGGING("");
+  auto device = c10::Device(c10::DeviceType::PrivateUse1, idx);
+  return device;
+}
+
+c10::Device get_custom_device_from_ttnn(IDevice* ttnn_device) {
+  LOGGING("");
+  // Fix the index?
+  auto device = c10::Device(c10::DeviceType::PrivateUse1, 0);
+  if (DummyGuard::ttnn_device == nullptr) {
+    DummyGuard::ttnn_device = ttnn_device;
+  }
+  return device;
+}
+
+// How to automatically close device without explicit calling?
+void close_custom_device(c10::Device device) {
+  LOGGING("");
+  DummyGuard device_guard(device);
+  IDevice* ttnn_device = device_guard.get_ttnn_device();
+  TORCH_INTERNAL_ASSERT(ttnn_device != nullptr);
+  ttnn::close_device(*ttnn_device);
+  ttnn_device = nullptr;
+}
+
+// Get underlying ttnn tensor
+ttnn::Tensor get_ttnn_tensor(at::Tensor& tensor) {
+  // Check if this cast fails
+  LOGGING("");
+  at::TtnnTensorImpl* tensor_impl = static_cast<at::TtnnTensorImpl*>(tensor.unsafeGetTensorImpl());
+  auto ttnn_tensor = tensor_impl->get_ttnn_tensor();
+  return ttnn_tensor;
+}
+
+// Here, we're exposing a custom device object that corresponds to our custom backend.
+// We do this using pybind: exposing an "extension_name.custom_device()" function in python,
+// that's implemented in C++.
+// The implementation in this file maps directly to the `PrivateUse1` device type.
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("custom_device", &get_custom_device, "get custom device object");
+    m.def("custom_device_from_ttnn", &get_custom_device_from_ttnn, "get custom device object from existing ttnn device");
+    m.def("close_custom_device", &close_custom_device, "close custom device object");
+    m.def("get_ttnn_tensor", &get_ttnn_tensor, "get underlying ttnn tensor");
+}

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -428,8 +428,11 @@ class NodeInputAligner:
                 kwargs["layout"] = spec.layout()
             if spec.dtype is not None:
                 kwargs["dtype"] = spec.dtype()
-            # g.get_attr(spec.)
-            if "val" in spec.input_node.meta and hasattr(spec.input_node.meta["val"], "device") and str(spec.input_node.meta["val"].device) == "ttnn:0":
+            if (
+                "val" in spec.input_node.meta
+                and hasattr(spec.input_node.meta["val"], "device")
+                and str(spec.input_node.meta["val"].device) == "ttnn:0"
+            ):
                 aligning_nodes.append(g.call_function(ttnn_module.get_ttnn_tensor, (spec.input_node,), {}))
             else:
                 aligning_nodes.append(g.call_function(ttnn.from_torch, (spec.input_node,), kwargs))


### PR DESCRIPTION
### Problem description
We want to be able to cache the model weights by calling`model.to("ttnn_device")` which should transfer the data to device before running the model.

We can utilize the [open_registration_extension](https://github.com/pytorch/pytorch/blob/v2.2.1/test/cpp_extensions/open_registration_extension.cpp) (or a more standalone example: [pytorch_open_registration_example](https://github.com/bdhirsh/pytorch_open_registration_example)) to intercept calls to `torch_tensor.to(device)`. 


### What's changed
We can subclass`TensorImpl` in order to hold our own custom data. In other words, we can copy data to device in advanced and store a reference to a TTNN tensor inside a Torch.tensor. That way we can avoid calling `ttnn.from_torch` when we encounter a Torch.tensor in our compiled graphs. This should be useful when calling the model for multiple iterations. 

Build changes:
The bulk of the implementation has to be done on C++, thus we will have to compile and link against tt-metal and Pytorch libraries. Currently, tt-metal uses `clang++-17` with `--std=c++20` and `--std=libc++`. However, the standard Pytorch wheels use `g++` and `--std=c++17` and `--std=stdlibc++`. The standard C++ libraries are incompatible, thus we have to recompile Pytorch. 

TODO:

- [ ] Integrate into conftest.py and add a commandline option. Also make sure to not load the extension at all (from import) if feature is disabled
- [ ] Make `torch.utils.rename_privateuse1_backend("ttnn")` more elegant
- [ ] Set up custom build of Pytorch with clang
- [ ] Can we link with ttnn wheel?
- [ ] Clean up `TtnnDeviceMode` class
- [ ] Clean up unused headers
- [ ] Review if we really need a custom `at::Allocator` class
- [ ] Clean up Logging in C++ files
- [ ] Clean up unused "kernels" in open_registration_extension.cpp
- [ ] Review accessing data via `unsafeGetTensorImpl`