### PR TITLE
Update TT-NN to 0.56.0-rc47

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ networkx==3.1
 graphviz
 matplotlib==3.7.1
 
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc43/ttnn-0.56.0rc43+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc43/ttnn-0.56.0rc43+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc47/ttnn-0.56.0rc47+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.56.0-rc47/ttnn-0.56.0rc47+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"


### PR DESCRIPTION
This PR updates TT-NN wheel to the latest pre-release version.