### PR TITLE
Refactor AddDataMovePass

### DIFF
--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -146,7 +146,7 @@ def aten_backend(
     passes = [
         ConstantFoldingPass(),
         ToTtPass(option.device, option.use_less_ttnn_op_types),
-        AddDataMovePass(),
+        AddDataMovePass(option.device),
         EliminateCoreopsPass(),
         CSEPass(),
         PermuteReshapeTuple(),

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -294,6 +294,11 @@ class NodeInputAligner:
         if input_node.target == ttnn.sharded_to_interleaved and input_node.args[0].target == ttnn.max_pool2d:
             spec.layout = TtnnTileLayout
 
+        # be overly cautious and convert to tile layout. These could already be tilized
+        # TODO: only insert layout if needed
+        if input_node.target in [ttnn.ones, ttnn.ones_like, ttnn.zeros, ttnn.zeros_like]:
+            spec.layout = TtnnTileLayout
+
         # legalize to the default layout and device
         if input_node.target in TTNN_ROW_LAYOUT_OPS:
             spec.layout = TtnnTileLayout

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -355,16 +355,7 @@ class NodeInputAligner:
         if input_node.target == getitem and input_node.args[0].target == ttnn.split:
             spec.layout = TtnnTileLayout
         # legalize to the default layout and device
-        if input_node.target in TTNN_LAYOUT_CHANGE_OPS.union(
-            set(
-                [
-                    target_wrappers.repeat,
-                    target_wrappers.roll,
-                    target_wrappers.stack,
-                    ttnn.concat,
-                ]
-            )
-        ):
+        if input_node.target in TTNN_LAYOUT_CHANGE_OPS:
             spec.layout = TtnnTileLayout
             spec.device = TtnnDevice
         return spec

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -343,11 +343,6 @@ class NodeInputAligner:
             and spec.input_node.meta["val"].dtype in [torch.int32, torch.int64]
         ):
             spec.dtype = TtnnUint32
-        if node.target == ttnn.permute and len(node.meta["val"].size()) > 4:
-            # TODO(tt-metal#16188): to_layout on device fails for > 4D
-            # Otherwise ttnn.permute can do to_layout internally and this special spec can be removed
-            spec.layout = TtnnRowMajorLayout
-            spec.device = TtnnDevice
         return spec
 
     def _reset_to_default_layout(self, input_node, spec):
@@ -366,11 +361,6 @@ class NodeInputAligner:
                 ]
             )
         ):
-            spec.layout = TtnnTileLayout
-            spec.device = TtnnDevice
-        if input_node.target == ttnn.permute and len(input_node.meta["val"].size()) > 4:
-            # TODO(tt-metal#16188): to_layout on device fails for > 4D
-            # Otherwise ttnn.permute can do to_layout internally and this special spec can be removed
             spec.layout = TtnnTileLayout
             spec.device = TtnnDevice
         return spec

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -302,7 +302,7 @@ class NodeInputAligner:
             spec.layout = TtnnTileLayout
 
         # legalize to the default layout and device
-        if input_node.target in TTNN_LAYOUT_CHANGE_OPS:
+        if input_node.target in TTNN_LAYOUT_CHANGE_OPS.union(set([target_wrappers.repeat])):
             spec.layout = TtnnTileLayout
             spec.device = TtnnDevice
 

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -282,6 +282,10 @@ class NodeInputAligner:
         if input_node.target == getitem and input_node.args[0].target == ttnn.split:
             spec.layout = TtnnTileLayout
 
+        # re-tilize max_pool2d after sharded_to_interleaved call - may be able to remove after #418
+        if input_node.target == ttnn.sharded_to_interleaved and input_node.args[0].target == ttnn.max_pool2d:
+            spec.layout = TtnnTileLayout
+
         # legalize to the default layout and device
         if input_node.target in TTNN_ROW_LAYOUT_OPS:
             spec.layout = TtnnTileLayout
@@ -341,7 +345,6 @@ class NodeInputAligner:
                 return None
             return spec
         else:
-            logging.debug(f"Not inserting data movement between torch op ({node}) and its input ({input_node})")
             return None
 
     def _change_layout(self, spec):

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -167,6 +167,14 @@ TTNN_ROW_LAYOUT_OPS = set(
     ]
 )
 
+# Operations that might output row major layouts based on ToTtPass implementation
+TTNN_MAYBE_ROW_OPS = set(
+    [
+        ttnn.pad,
+        ttnn.concat,
+    ]
+)
+
 TTNN_HOST_ONLY_OPS = set()
 
 
@@ -288,6 +296,10 @@ class NodeInputAligner:
 
         # legalize to the default layout and device
         if input_node.target in TTNN_ROW_LAYOUT_OPS:
+            spec.layout = TtnnTileLayout
+        if input_node.target in TTNN_MAYBE_ROW_OPS:
+            # for now, convert to tile (might be nop)
+            # TODO: only insert to_layout call if needed
             spec.layout = TtnnTileLayout
         if input_node.target in TTNN_HOST_ONLY_OPS:
             spec.device = TtnnDevice

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -322,6 +322,9 @@ class NodeInputAligner:
             # Slice can only unpad tilized tensors with full tiles. Make input row major to be safe for now
             # Roll is included because it calls slice under the hood
             spec.layout = TtnnRowMajorLayout
+        if node.target == ttnn.split and input_site == 0:
+            # Runtime error for tilized inputs to split
+            spec.layout = TtnnRowMajorLayout
         if node.target == ttnn.argmax and (input_site_type == self.InputSiteType.ARGS and input_site == 0):
             # According to documentation, argmax input must be BFLOAT16 and ROW_MAJOR
             spec.dtype = TtnnBfloat16

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -353,6 +353,14 @@ class NodeInputAligner:
             # TODO(#417, tt-metal#15893): weight currently needs to be on host and can't be moved to device first
             spec.layout = TtnnRowMajorLayout
             spec.device = "host"
+        if (
+            node.target == ttnn.subtract
+            and isinstance(spec, self.AlignSpecFromTorch)
+            and get_dtype(node) in [torch.int32, torch.int64]
+        ):
+            # Needed to have GPT2 pass: from_torch -> subtract -> remainder -> indexing but subtract may go below 0
+            # TODO: remove when we have signed int support for required ops
+            spec.dtype = TtnnBfloat16
 
         return spec
 

--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -140,6 +140,9 @@ def stack(tensors, dim, output_shape):
     # Reshape each input tensor to add the new dimension
     unsqueezed_tensors = []
     for tensor in tensors:
+        # TODO: remove when reshape supports tiled uint32 inputs
+        if tensor.layout == ttnn.TILE_LAYOUT and tensor.dtype == ttnn.uint32:
+            tensor = ttnn.to_layout(tensor, ttnn.ROW_MAJOR_LAYOUT)
         unsqueezed_tensors.append(ttnn.reshape(tensor, unsqueezed_shape))
 
     # Concatenate all reshaped tensors along the stack dimension


### PR DESCRIPTION
I tried to separate changes into atomic commits. That is, each commit contains a (mostly) related set of changes, and I would expect tests to pass after any given commit.

There were a handful of functions that I was able to cut down significantly, but I would like to remove more of the special cases in the future.

I have been looking at most of this code long enough that I am losing a sense of what is unreadable, so hoping to get some other opinions.

I also considered making some bigger changes, but am not sure if it is worthwhile. Please let me know your thoughts in comments:
1. Changing variable name `spec` to something more descriptive like `desired_alignment`
2. Changing control flow. Right now each of the transitions (Torch->Ttnn, Ttnn->Torch, and Ttnn->Ttnn) flow through the same functions. Most of these functions case on transition type, so it could be cleaner to have a function per transition type that handles multiple steps (getting aligned spec and creating aligned nodes). I didn't do this yet because we use a dictionary to cache and reuse previous aligned nodes, which this would likely break.