### PR TITLE
Fixes OOM error in DETR with workaround to layout conv input as row-major

### DIFF
--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -38,10 +38,7 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "mode",
     [
-        pytest.param(
-            "eval",
-            marks=pytest.mark.compilation_xfail,
-        ),
+        "eval",
     ],
 )
 def test_detr(record_property, mode):

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -331,6 +331,9 @@ class NodeInputAligner:
         ):
             spec.dtype = TtnnUint32
 
+        if node.target == target_wrappers.conv and input_site == 0:
+            # TODO(tt-metal#18231): input currently needs to be row major
+            spec.layout = TtnnRowMajorLayout
         if node.target == target_wrappers.conv and input_site == 1:
             # TODO(#417, tt-metal#15893): weight currently needs to be on host and can't be moved to device first
             spec.layout = TtnnRowMajorLayout


### PR DESCRIPTION
Fixes #794

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/794)

### Problem description
Will change back when tt-metal#18231 goes in

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and their impact
