### PR TITLE
Optimize out conversion from `aten.clone`

### DIFF
--- a/tests/lowering/creation/test_clone.py
+++ b/tests/lowering/creation/test_clone.py
@@ -53,6 +53,7 @@ def test_clone_from_arg(device, input_shapes):
     [[(4, 4)]],
 )
 def test_clone_from_node(device, input_shapes):
+    # This test checks that the clone op has been removed since there is no need
     m = CloneFromNodeModule()
     inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
     result_before = m.forward(*inputs)
@@ -66,8 +67,6 @@ def test_clone_from_node(device, input_shapes):
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
     target = [node.target for node in nodes]
-    assert target.count(torch_ttnn.target_wrappers.clone) == 1
-    clone_arg_0 = nodes[target.index(torch_ttnn.target_wrappers.clone)].args[0].target
-    assert isinstance(clone_arg_0, ttnn.decorators.FastOperation) or isinstance(clone_arg_0, ttnn.decorators.Operation)
+    assert target.count(torch_ttnn.target_wrappers.clone) == 0
     # Check inference result
     assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -526,6 +526,12 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return reshape_1d(ttnn.round, (args[0],), {"decimals": 0})
 
             if node.target == torch.ops.aten.clone.default:
+                # Only convert if the input is from graph arguments and node is also returned as an output
+                # Otherwise, optimize node out and return input
+                node_users = list(node.users.keys())
+                if not (args[0].op == "placeholder" and len(node_users) == 1 and node_users[0].op == "output"):
+                    return args[0]
+
                 arg_metadata = node.meta["val"]
                 try:
                     ttnn_dtype = torch_dtype_to_ttnn_dtype(arg_metadata.dtype)


### PR DESCRIPTION
### Problem description
`aten.clone` is used often to make sure the tensor is not a view of another tensor which can cause problems for some ops. Pytorch inserts this whenever it needs to. However, when we're dealing with TTNN tensors, we don't need to worry about this, so there's usually no need to convert to `ttnn.clone`. 

### What's changed
Unless `aten.clone` has an input from the graph arguments and is also returned as an output, we will remove the op entirely.

For example, `aten.clone` will not be removed and converted to `ttnn.clone` in this instance only. This is for unit testing purposes.

```
def forward(arg0):
    clone = aten.clone(arg0)
    return clone
```
