### PR TITLE
Fix workflow id in github workflows

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -257,7 +257,7 @@ jobs:
           fi
           
           python3 tools/send_to_data_team.py \
-              --github_workflow_id ${{ github.event.workflow_run.id }} \
+              --github_workflow_id ${{ github.run_id }} \
               --sftp_host ${{ secrets.SFTP_OPTEST_HOST }} \
               --sftp_user ${{ secrets.SFTP_OPTEST_USER }} \
               --sftp_private_key ${{ secrets.SFTP_OPTEST_PRIVATE_KEY }}


### PR DESCRIPTION
### Ticket
Not available

### Problem description
`Collect Metrics Report` step of the `collect-metrics` jobs fails due to not using the correct method to get run id. This happens when the before_merge workflow is triggered with anything other than `None`

### What's changed
Uses the correct syntax to get run id