### PR TITLE
Reverted tt-metal version to when the support python3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ graphviz
 matplotlib==3.7.1
 pysftp==0.2.9
 
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc40/ttnn-0.57.0rc40+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc40/ttnn-0.57.0rc40+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc37/ttnn-0.57.0rc37+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc37/ttnn-0.57.0rc37+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"


### PR DESCRIPTION
Newer version breaks the runners. Will change back once runners are updated
