### PR TITLE
Updated slices validations in the compiler

### DIFF
--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -709,7 +709,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                 [step] = step or [1]
                 rank = len(input_size)
 
-                if step != 1 or dim >= rank:
+                if dim >= rank:
                     return None
 
                 # Check if no-op, just return the input tensor
@@ -1244,9 +1244,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                 # slice_scatter could be concat([pre_slice_tensor, src_tensor, post_slice_tensor])
                 rank = len(tensor_shape)
                 [step] = step or [1]
-                if step != 1:
-                    return None
-
+                
                 assert dim < rank, f"The slice dim {dim} should be less than rank {rank}"
 
                 dim = (dim + rank) % rank

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -713,9 +713,6 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                 if dim >= rank:
                     return None
 
-                if step != 1:
-                    print(f"step: {step}")
-
                 # Check if no-op, just return the input tensor
                 if start == 0 and end >= input_size[dim] and step == 1:
                     return tensor

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -6,6 +6,7 @@ import ttnn
 import math
 from torch._guards import detect_fake_mode
 from torch._subclasses.fake_tensor import unset_fake_temporarily
+
 from torch_ttnn.utils import (
     GraphCleanup,
     TtnnBfloat16,
@@ -1244,7 +1245,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, device, use_less_ttnn_op_typ
                 # slice_scatter could be concat([pre_slice_tensor, src_tensor, post_slice_tensor])
                 rank = len(tensor_shape)
                 [step] = step or [1]
-                
+
                 assert dim < rank, f"The slice dim {dim} should be less than rank {rank}"
 
                 dim = (dim + rank) % rank


### PR DESCRIPTION
Updated step validations, now different than 1 is a valid scenario. Since the compiler already fills with 1 when the array is empty, we can assume that will be always equals or bigger than 1

### Ticket
[Link to Github Issue](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/876)

### Problem description
Metal updated it's code, allowing slices bigger than 1

### What's changed
Updated the compiler code to be compatible with this new validation
