### PR TITLE
`aten.split.Tensor` lowering fix

### DIFF
--- a/tools/generate_op_accuracy_tests.py
+++ b/tools/generate_op_accuracy_tests.py
@@ -289,6 +289,7 @@ def _build_code_from_aten_ttnn_graphs(aten_graph, ttnn_graph, output_nodes):
     # comment out signature if not the first graph
     graph_code = [forward_signature] if len(output_nodes) == 0 else ["   # " + forward_signature]
     graph_code.append("  device = ttnn.open_device(device_id=0, l1_small_size=16384)")
+    graph_code.append("""  inf = float("inf")""")
     for node in aten_all_nodes:
         if node.op == "output":
             output_nodes.append(node.args[0])

--- a/tools/generate_op_accuracy_tests.py
+++ b/tools/generate_op_accuracy_tests.py
@@ -289,7 +289,6 @@ def _build_code_from_aten_ttnn_graphs(aten_graph, ttnn_graph, output_nodes):
     # comment out signature if not the first graph
     graph_code = [forward_signature] if len(output_nodes) == 0 else ["   # " + forward_signature]
     graph_code.append("  device = ttnn.open_device(device_id=0, l1_small_size=16384)")
-    graph_code.append("""  inf = float("inf")""")
     for node in aten_all_nodes:
         if node.op == "output":
             output_nodes.append(node.args[0])

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -859,7 +859,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
                 # convert from PyTorch size of chunk to ttnn number of chunks
                 if isinstance(args[1], int):
-                    num_chunks = math.floor(args[0].meta["val"].size()[split_dim] / args[1])
+                    num_chunks = args[1]
                 else:
                     # ttnn.split only supports chunks of same size.
                     return None

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -859,12 +859,12 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
                 # convert from PyTorch size of chunk to ttnn number of chunks
                 if isinstance(args[1], int):
-                    num_chunks = args[1]
+                    chunk_size = args[1]
                 else:
                     # ttnn.split only supports chunks of same size.
                     return None
 
-                new_args = (args[0], num_chunks, split_dim)
+                new_args = (args[0], chunk_size, split_dim)
                 return g.call_function(ttnn.split, args=new_args)
 
             if node.target == torch.ops.aten._to_copy.default:


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/887)

### Problem description
Original lowering rule for `aten.split.Tensor` treated second argument of `ttnn.split `as a number of chunks instead of chunk size.

### What's changed
Simply removed the line of code which was doing calculation of number of chunks based on chunk size.
