### PR TITLE
Handle nested outputs when calculating accuracy

### DIFF
--- a/tests/models/dino/test_dino.py
+++ b/tests/models/dino/test_dino.py
@@ -40,6 +40,5 @@ def test_dino(record_property, mode):
 
     tester = ThisTester(model_name, mode)
     results = tester.test_model()
-    results = results.last_hidden_state
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/tools/test_nested_output_accuracy.py
+++ b/tests/tools/test_nested_output_accuracy.py
@@ -1,0 +1,32 @@
+from tests.utils import calculate_accuracy, comp_pcc
+import torch
+import numpy as np
+
+
+def test_nested_output_accuracy():
+    # Some models like CLIP have nested Dict outputs. The old implementation skips these nested items. These example outputs have intentionally mismatching values for the nested items in order to illustrate the inconsistent accuracy calculations.
+    expected_outputs = {
+        "key0": torch.tensor([0.12345]),
+        "key1": {"subkey0": torch.tensor([0.12345])},
+        "key2": [torch.tensor([0.12345])],
+    }
+    actual_outputs = {
+        "key0": torch.tensor([0.12345]),
+        "key1": {"subkey0": torch.tensor([0.0])},
+        "key2": [torch.tensor([0.0])],
+    }
+
+    # Manually calculate pcc for every item.
+    _, pcc_key0 = comp_pcc(expected_outputs["key0"], actual_outputs["key0"])
+    _, pcc_key1_subkey0 = comp_pcc(expected_outputs["key1"]["subkey0"], actual_outputs["key1"]["subkey0"])
+    _, pcc_key2_sublist0 = comp_pcc(expected_outputs["key2"][0], actual_outputs["key2"][0])
+
+    # The mean result should be around 0.333333
+    manual_accuracy = np.mean([pcc_key0, pcc_key1_subkey0, pcc_key2_sublist0])
+    print(f"Manually calculated accuracy: {manual_accuracy}")
+
+    # Using calculate_accuracy. If the nested inputs are skipped, only "key0" will be factored into the final pcc calculation. The resulting pcc would be 1.0 which is incorrect.
+    utils_accuracy = calculate_accuracy(expected_outputs, actual_outputs)
+    print(f"Calculated accuracy through utils: {utils_accuracy}")
+
+    assert torch.allclose(torch.tensor(manual_accuracy), torch.tensor(utils_accuracy))


### PR DESCRIPTION
### Ticket
Issue was discovered because of inconsistent accuracy values between the pytest run and generated accuracy script https://github.com/tenstorrent/pytorch2.0_ttnn/issues/835

### Problem description
Some outputs are nested Dict types. For example, CLIP has an output that has the following keys:

```
CLIPOutput = {
    "logits_per_image",
    "logits_per_text",
    "text_embeds",
    "image_embeds",
    "text_model_output" : {
        "last_hidden_state",
        "pooler_output"
    },
    "vision_model_output" : {
        "last_hidden_state",
        "pooler_output"
    }
}
```
Currently, `calculate_accuracy` silently skips the nested outputs so only the first 4 items are factored into the calculation. 


### What's changed

- Recursively walk through each item including nested Dicts and Lists until torch tensors are found and calculate the mean of the accumulated pcc values.
- Include a unit test to demonstrate the bug
- Compare the whole output of dino model instead just one attribute