### PR TITLE
Set accuracy to True in `ttnn.tanh`

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -128,6 +128,7 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0    
+      - uses: ./.github/actions/common_repo_setup
       - name: docker-cleanup
         run: |
           docker system prune -a -f --volumes

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -508,6 +508,11 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
             if node.target in TTNN_POINTWISE_UNARY_OPS:
                 code = TTNN_POINTWISE_UNARY_OPS[node.target]
+                # TODO: Remove once tanh accuracy implementation is realized as a device operation in tt-metal
+                if code == ttnn.tanh:
+                    kwargs = {
+                        "accuracy": True,
+                    }
 
             # NOTE(jdh8): Workaround for tenstorrent/tt-metal#12671
             # Passing a tensor shaped `(N,)` to the kernel results in `(1, N)`.


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-metal/issues/15132)

### Problem description
`ttnn.tanh` in it's current implementation causes low accuracy in at least 5 models (4 being e2e). Setting accuracy argument to True in `ttnn.tanh`, which internally sets it's implementation to a sequence of ttnn ops on tt-metal side, resolves this issue. 

### What's changed
Added line in to_tt_pass.py which sets kwargs if target node is `ttnn.tanh`.
