### PR TITLE
Remove fallback for aten.squeeze.default, aten.full, aten.fill.Scalar, aten.memory_format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ graphviz
 matplotlib==3.7.1
 pysftp==0.2.9
 
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc56/ttnn-0.57.0rc56+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc56/ttnn-0.57.0rc56+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc57/ttnn-0.57.0rc57+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc57/ttnn-0.57.0rc57+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"

--- a/tests/autogen_op/ALL/test_ALL_aten_squeeze_dim.py
+++ b/tests/autogen_op/ALL/test_ALL_aten_squeeze_dim.py
@@ -40,7 +40,7 @@ def teardown_module(module):
         ["Tensor<[1, 256, 1]> self = ?", "int dim = -1"],
         ["Tensor<[1, 25, 1]> self = ?", "int dim = -1"],
         ["Tensor<[1, 1, 480, 640]> self = ?", "int dim = 1"],
-        ["Tensor self = ?", "int dim = 0"],
+        ["Tensor<[1, 19]> self = ?", "int dim = 0"],
         ["Tensor<[1, 160, 7, 7]> self = ?", "int dim = 0"],
         ["Tensor<[1, 112, 14, 14]> self = ?", "int dim = 0"],
         ["Tensor<[1, 80, 14, 14]> self = ?", "int dim = 0"],
@@ -55,6 +55,8 @@ def teardown_module(module):
         ["Tensor<[3, 1370, 1, 1, 1280]> self = ?", "int dim = -2"],
         ["Tensor<[3, 197, 1, 1, 1024]> self = ?", "int dim = -2"],
         ["Tensor<[3, 50, 1, 1, 1024]> self = ?", "int dim = -2"],
+        ["Tensor<[1]> self = ?", "int dim = 0"],
+        ["Tensor<[]> self = ?", "int dim = 0"],
     ],
 )
 def test_aten(device, input_strings, input_var_only_native, input_var_check_accu, input_var_check_ttnn):
@@ -135,6 +137,7 @@ def test_aten(device, input_strings, input_var_only_native, input_var_check_accu
 
     if not input_var_only_native:
         assert metric["run"] == True
+        assert metric["native_run"] == True
         if input_var_check_accu:
             assert metric["accuracy"] >= 0.99
         if input_var_check_ttnn:

--- a/tests/autogen_op/ALL/test_ALL_aten_squeeze_dim.py
+++ b/tests/autogen_op/ALL/test_ALL_aten_squeeze_dim.py
@@ -40,7 +40,7 @@ def teardown_module(module):
         ["Tensor<[1, 256, 1]> self = ?", "int dim = -1"],
         ["Tensor<[1, 25, 1]> self = ?", "int dim = -1"],
         ["Tensor<[1, 1, 480, 640]> self = ?", "int dim = 1"],
-        ["Tensor<[1, 19]> self = ?", "int dim = 0"],
+        ["Tensor self = ?", "int dim = 0"],
         ["Tensor<[1, 160, 7, 7]> self = ?", "int dim = 0"],
         ["Tensor<[1, 112, 14, 14]> self = ?", "int dim = 0"],
         ["Tensor<[1, 80, 14, 14]> self = ?", "int dim = 0"],
@@ -55,8 +55,6 @@ def teardown_module(module):
         ["Tensor<[3, 1370, 1, 1, 1280]> self = ?", "int dim = -2"],
         ["Tensor<[3, 197, 1, 1, 1024]> self = ?", "int dim = -2"],
         ["Tensor<[3, 50, 1, 1, 1024]> self = ?", "int dim = -2"],
-        ["Tensor<[1]> self = ?", "int dim = 0"],
-        ["Tensor<[]> self = ?", "int dim = 0"],
     ],
 )
 def test_aten(device, input_strings, input_var_only_native, input_var_check_accu, input_var_check_ttnn):
@@ -137,7 +135,6 @@ def test_aten(device, input_strings, input_var_only_native, input_var_check_accu
 
     if not input_var_only_native:
         assert metric["run"] == True
-        assert metric["native_run"] == True
         if input_var_check_accu:
             assert metric["accuracy"] >= 0.99
         if input_var_check_ttnn:

--- a/tests/lowering/creation/test_full.py
+++ b/tests/lowering/creation/test_full.py
@@ -15,22 +15,24 @@ class FullModule(torch.nn.Module):
 
 
 @pytest.mark.parametrize(
-    "input_shapes",
+    "input_shape",
     [
-        [(64, 128)],
-        [(19, 19)],
-        [(59, 59)],
+        [64, 128],
+        [19, 19],
+        [59, 59],
+        [33,],
+        [],   # scalar
     ],
 )
-def test_full(device, input_shapes):
+def test_full(device, input_shape):
     m = FullModule()
     fill_value = 1.23
-    result_before = m.forward(input_shapes[0], fill_value).to(torch.bfloat16)
+    result_before = m.forward(input_shape, fill_value).to(torch.bfloat16)
     option = torch_ttnn.TorchTtnnOption(device=device)
     option.gen_graphviz = True
     # The compilation is lazy, so we need to run forward once to trigger the compilation
     m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-    result_after = m.forward(input_shapes[0], fill_value).to(torch.bfloat16)
+    result_after = m.forward(input_shape, fill_value).to(torch.bfloat16)
     option._out_fx_graphs[0].print_tabular()
 
     # Check the graph has be rewritten and contain ttnn ops

--- a/tests/lowering/creation/test_full.py
+++ b/tests/lowering/creation/test_full.py
@@ -20,8 +20,8 @@ class FullModule(torch.nn.Module):
         [64, 128],
         [19, 19],
         [59, 59],
-        [33,],
-        [],   # scalar
+        [33],
+        [],  # scalar
     ],
 )
 def test_full(device, input_shape):

--- a/tests/lowering/creation/test_full_like.py
+++ b/tests/lowering/creation/test_full_like.py
@@ -22,6 +22,8 @@ class FullLikeModule(torch.nn.Module):
         (1, 1),
         (2, 2),
         (17, 17),
+        (33,),
+        (),
     ],
 )
 def test_full_like(device, input_shape):

--- a/tests/lowering/tensor_manipulation/test_squeeze.py
+++ b/tests/lowering/tensor_manipulation/test_squeeze.py
@@ -22,6 +22,9 @@ class SqueezeDimModule(torch.nn.Module):
         ((1, 256, 1), -1),
         ((33, 44, 1, 32, 16), 1),
         ((33, 44, 1, 32, 16), 2),
+        ((1, 12), 0),
+        ((1), 0),
+        ((), 0),
     ],
 )
 def test_squeeze_dim(device, input_shape, dim):
@@ -36,11 +39,7 @@ def test_squeeze_dim(device, input_shape, dim):
     option._out_fx_graphs[0].print_tabular()
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
-    if option.use_less_ttnn_op_types:
-        # squeeze is lowered to reshape
-        assert [node.target for node in nodes].count(ttnn.reshape) == 1
-    else:
-        assert [node.target for node in nodes].count(ttnn.squeeze) == 1
+    assert [node.target for node in nodes].count(ttnn.squeeze) == 1
     # Check inference result
     assert torch.allclose(result_before, result_after)
 
@@ -60,6 +59,10 @@ class SqueezeNoneDimModule(torch.nn.Module):
         ((1, 1, 55, 23, 44, 32, 32)),
         ((22, 1, 55, 23, 44, 32, 1)),
         ((1, 1, 55, 1, 1, 1, 1)),
+        ((1, 12)),
+        ((1, 1)),
+        ((1)),
+        (()),
     ],
 )
 def test_squeeze_none_dim(device, input_shape):
@@ -74,6 +77,6 @@ def test_squeeze_none_dim(device, input_shape):
     option._out_fx_graphs[0].print_tabular()
     # Check the graph has be rewritten and contain ttnn ops (squeeze without provided dim is lowered to reshape)
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.reshape) == 1
+    assert [node.target for node in nodes].count(ttnn.squeeze) == 1
     # Check inference result
     assert torch.allclose(result_before, result_after)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -216,6 +216,7 @@ def is_tt_compute(node) -> bool:
             ttnn.sum,
             ttnn.typecast,
             ttnn.argmax,
+            ttnn.fill,
         ]
     )
 

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -217,6 +217,7 @@ def is_tt_compute(node) -> bool:
             ttnn.typecast,
             ttnn.argmax,
             ttnn.fill,
+            ttnn.empty,
         ]
     )
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -738,16 +738,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return None
 
             if node.target == torch.ops.aten.squeeze.dim or node.target == torch.ops.aten.squeeze.default:
-                if get_shape(gm, args[0]) in [torch.Size([1]), torch.Size([])]:
-                    # see #442
-                    return None
-                if use_less_ttnn_op_types or node.target == torch.ops.aten.squeeze.default:
-                    # ttnn.squeeze does not support calling the OP without provided dim (torch.ops.aten.squeeze.default)
-                    # squeezing is the same as reshaping to shape of output tensor of squeeze
-                    output_size = list(node.meta["val"].size())
-                    return g.call_function(ttnn.reshape, args=(args[0], output_size))
-                else:
-                    return g.call_function(ttnn.squeeze, args=(args[0], args[1]))
+                return g.call_function(ttnn.squeeze, args=args, kwargs=kwargs)
 
             if node.target == torch.ops.aten.unsqueeze.default:
                 output_shape_num_element = node.meta["val"].numel()

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -888,6 +888,9 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 # Essentially remove this op
                 return node.args[0]
 
+            if node.target == torch.ops.aten.fill.Scalar:
+                return g.call_function(ttnn.fill, args=args)
+            
             if node.target in [torch.ops.aten.masked_fill.Scalar, torch.ops.aten.masked_fill.Tensor]:
                 # aten.masked_fill is equivalent to the following:
                 # masked_fill = (tensor * (ones - mask)) + (mask * full)

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -375,11 +375,9 @@ def torch_dtype_to_ttnn_dtype(dtype: torch.dtype):
     dtype_map = {
         torch.float32: TtnnBfloat16(),  # Should this be changed to TtnnFloat32?
         torch.bfloat16: TtnnBfloat16(),
-
         torch.int8: TtnnInt8(),
         torch.int32: TtnnInt32(),
         torch.int64: TtnnInt32(),
-
         # Note: uint16, uint32, uint64 have limited support only in eager mode in pytorch
         torch.uint8: TtnnUint8(),
     }
@@ -900,7 +898,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
             if node.target == torch.ops.aten.fill.Scalar:
                 return g.call_function(ttnn.fill, args=args)
-            
+
             if node.target in [torch.ops.aten.masked_fill.Scalar, torch.ops.aten.masked_fill.Tensor]:
                 # aten.masked_fill is equivalent to the following:
                 # masked_fill = (tensor * (ones - mask)) + (mask * full)

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -108,15 +108,21 @@ class TtnnTileLayout:
         return f"ttnn_TILE_LAYOUT"
 
 
-class TtnnUint32:
+class TtnnInt8:
     def __repr__(self):
-        return f"ttnn_uint32"
+        return f"ttnn_int8"
 
+class TtnnUint8:
+    def __repr__(self):
+        return f"ttnn_uint8"
 
 class TtnnInt32:
     def __repr__(self):
         return f"ttnn_int32"
 
+class TtnnUint32:
+    def __repr__(self):
+        return f"ttnn_uint32"
 
 class TtnnBfloat16:
     def __repr__(self):

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -108,16 +108,6 @@ class TtnnTileLayout:
         return f"ttnn_TILE_LAYOUT"
 
 
-class TtnnInt8:
-    def __repr__(self):
-        return f"ttnn_int8"
-
-
-class TtnnUint8:
-    def __repr__(self):
-        return f"ttnn_uint8"
-
-
 class TtnnInt32:
     def __repr__(self):
         return f"ttnn_int32"

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -112,17 +112,21 @@ class TtnnInt8:
     def __repr__(self):
         return f"ttnn_int8"
 
+
 class TtnnUint8:
     def __repr__(self):
         return f"ttnn_uint8"
+
 
 class TtnnInt32:
     def __repr__(self):
         return f"ttnn_int32"
 
+
 class TtnnUint32:
     def __repr__(self):
         return f"ttnn_uint32"
+
 
 class TtnnBfloat16:
     def __repr__(self):


### PR DESCRIPTION
### Ticket
Github Issues:
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/588 
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/110 
https://github.com/tenstorrent/pytorch2.0_ttnn/issues/635
https://github.com/tenstorrent/tt-metal/issues/19746
https://github.com/tenstorrent/tt-metal/issues/16263

### Problem description
aten.squeeze.default, aten.full, aten.fill.Scalar, aten.memory_format used to fallback fully, or partially because of limited 0-rank tensor support in ttnn. aten.squeeze.default was not supported by ttnn till recently. 

### What's changed
Removed fallback for those operations. 
Updated tests to cover 0-rank shapes
