### PR TITLE
Expand functionality of exporting code

### DIFF
--- a/.github/actions/common_model_tests/action.yaml
+++ b/.github/actions/common_model_tests/action.yaml
@@ -23,7 +23,7 @@ runs:
         else
           num_iterations=5
         fi
-        python3 -m pytest --github-report tests/models/ --report_nth_iteration=$num_iterations --gen_op_accuracy_tests --splits ${{ inputs.splits }} --group ${{ matrix.group }} -s
+        python3 -m pytest --github-report tests/models/ --report_nth_iteration=$num_iterations --export_code=accuracy --splits ${{ inputs.splits }} --group ${{ matrix.group }} -s
         exit_code=$?  # Capture the exit code
         if [ $exit_code -eq 5 ]; then
           if [ ${{ matrix.group }} -eq 0 ]; then

--- a/.github/workflows/run-accuracy-tests.yaml
+++ b/.github/workflows/run-accuracy-tests.yaml
@@ -76,8 +76,8 @@ jobs:
       - name: Upload Accuracy Tests Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: autogen-accuracy-tests-group-${{ matrix.group }}
-          path: tests/autogen_accuracy_tests/
+          name: export-accuracy-tests-group-${{ matrix.group }}
+          path: tests/export_code/accuracy/
 
   gen-model-accuracy:
     needs: [model-tests]
@@ -101,15 +101,15 @@ jobs:
       - name: Download All Accuracy Tests and Inputs Artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: autogen-accuracy-tests-group-*
+          pattern: export-accuracy-tests-group-*
           merge-multiple: true
-          path: tests/autogen_accuracy_tests/
+          path: tests/export_code/accuracy/
 
       - name: Calculate Number of Groups
         id: calculate-groups
         run: |
           # Count the number of test files
-          num_groups=$(find tests/autogen_accuracy_tests -type f -name "*.py" | wc -l)
+          num_groups=$(find tests/export_code/accuracy -type f -name "*.py" | wc -l)
           # Ensure at least 1 group
           num_groups=$((num_groups > 0 ? num_groups : 1))
           # Generate the list of groups as JSON
@@ -147,13 +147,14 @@ jobs:
       - name: Download Accuracy Tests Artifact
         uses: actions/download-artifact@v4
         with:
-          pattern: autogen-accuracy-tests-group-*
-          path: tests/autogen_accuracy_tests/
+          pattern: export-accuracy-tests-group-*
+          path: tests/export_code/accuracy/
 
       - name: Run Accuracy Tests
         run: |
-          cd tests/autogen_accuracy_tests
+          cd tests/export_code/accuracy
           test_file=$(find . -type f -name "*.py" | sed -n "${{ matrix.group }}p")
+          echo "$test_file"
           python3 $test_file -s
           exit_code=$?
           if [ $exit_code -ne 0 ]; then

--- a/docs/ProblemSolving.md
+++ b/docs/ProblemSolving.md
@@ -177,12 +177,12 @@ This usually happens because a `ttnn.from_torch` was not inserted for this parti
 
 
 # Mismatch between values
-If the model has a very low accuracy score and you want to be able to narrow down the Aten-TTNN op pair that produced low accuracy, you can run pytest with `--gen_op_accuracy_tests` to export a self-contained python script containing the graph and input data. This script will compare each original aten op and the corresponding TTNN op and report the first pair that has an accuracy score below a threshold. The scripts and input files can be found under `tests/autogen_accuracy_tests`.
+If the model has a very low accuracy score and you want to be able to narrow down the Aten-TTNN op pair that produced low accuracy, you can run pytest with `--export_code=accuracy` to export a self-contained python script containing the graph and input data. This script will compare each original aten op and the corresponding TTNN op and report the first pair that has an accuracy score below a threshold. The scripts and input files can be found under `tests/export_code/accuracy`.
 
 For example:
 ```
-pytest tests/models/mobilenet_ssd/test_mobilenet_ssd.py --gen_op_accuracy_tests
-python3 tests/autogen_accuracy_tests/MobileNetSSD_code.py
+pytest tests/models/mobilenet_ssd/test_mobilenet_ssd.py --export_code=accuracy
+python3 tests/export_code/accuracy/MobileNetSSD_code.py
 ```
 
 Output:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 import logging
 
-import tools.generate_op_accuracy_tests as generate_op_accuracy_tests
+import tools.export_code as export_code
 
 mb_in_bytes = 1048576
 
@@ -41,7 +41,11 @@ def pytest_addoption(parser):
         default=1,
         help="Run up to the specified iteration count and report metrics based on this iteration.",
     )
-    parser.addoption("--gen_op_accuracy_tests", action="store_true")
+    parser.addoption(
+        "--export_code",
+        action="store",
+        help=f"Export standalone Python code. Supported options: {export_code.export_code_options}",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -201,16 +205,24 @@ def compile_and_run(device, reset_torch_dynamo, request):
 
         try:
             logging.debug("Compiling model with ttnn backend.")
+            # verify --export_code has valid option
+            export_code_opt = request.config.getoption("--export_code")
+            if export_code_opt is not None:
+                assert export_code_opt in export_code.export_code_options
+
+            total_num_iterations = int(request.config.getoption("--report_nth_iteration"))
+
             option = torch_ttnn.TorchTtnnOption(
                 device=device,
                 gen_graphviz=False,
                 run_mem_analysis=False,
                 metrics_path=model_name,
                 verbose=True,
-                gen_op_accuracy_tests=request.config.getoption("--gen_op_accuracy_tests"),
+                export_code=export_code_opt,
+                total_num_iterations=total_num_iterations,
             )
 
-            for idx in range(int(request.config.getoption("--report_nth_iteration"))):
+            for idx in range(total_num_iterations):
                 start = time.perf_counter() * 1000
                 # Don't need to reset options if inputs don't change because of cache
                 outputs_after = model_tester.test_model(as_ttnn=True, option=option)
@@ -226,11 +238,8 @@ def compile_and_run(device, reset_torch_dynamo, request):
 
             logging.info(f"Compilation and run successful in {comp_runtime_metrics['run_time']} ms.")
 
-            # set to one variable?
-            if request.config.getoption("--gen_op_accuracy_tests"):
-                generate_op_accuracy_tests.generate_op_accuracy_tests(
-                    model_name, option._aten_fx_graphs, option._out_fx_graphs, option._all_inputs
-                )
+            if export_code_opt:
+                export_code.export_code(model_name, option)
 
             if len(option._out_fx_graphs) > 0:
                 option._out_fx_graphs[0].print_tabular()

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -11,6 +11,7 @@ import pickle
 from pathlib import Path
 import os
 from torch_ttnn.handle_input_aliasing import insert_clones_for_input_aliasing
+import tools.export_code as export_code
 import torch_ttnn.metrics as metrics
 from torch_ttnn import mem_utils
 import copy
@@ -32,7 +33,8 @@ class TorchTtnnOption:
         tracer_option=None,
         bypass_compile=False,
         use_less_ttnn_op_types=True,
-        gen_op_accuracy_tests=False,
+        export_code=None,
+        total_num_iterations=1,
     ):
         self.device = device
         self.gen_graphviz = gen_graphviz
@@ -42,6 +44,7 @@ class TorchTtnnOption:
         self.run_eviction_opt = run_eviction_opt
         self.verbose = verbose
         self.tracer_option = tracer_option
+        self.total_num_iterations = total_num_iterations
 
         self.metrics_path = metrics_path
         self.bypass_compile = bypass_compile
@@ -50,13 +53,15 @@ class TorchTtnnOption:
         self.compiled_schema_list = list()
 
         # Used for generate standalone python script
-        self.gen_op_accuracy_tests = gen_op_accuracy_tests
+        self.export_code = export_code
         self._aten_fx_graphs = list()
-        self._all_inputs = None
+        self._all_inputs = list()
+        self._ttnn_fx_graphs = list()
 
     def reset_containers(self):
         self._out_fx_graphs = list()
         self.original_schema_list = list()
+        self._ttnn_fx_graphs = list()
 
 
 def register_ttnn_objects(option: TorchTtnnOption):
@@ -108,11 +113,11 @@ def aten_backend(
     gm = remove_clones_for_input_aliasing(gm)
 
     # Save aten graph if requested
-    if options.gen_op_accuracy_tests:
+    if options.export_code:
         # Will this hamper memory usage?
         graph_copy = copy.deepcopy(gm.graph)
         graph_copy.owning_module = gm
-        option._aten_fx_graphs.append(graph_copy)
+        option._aten_fx_graphs[-1].append(graph_copy)
 
     # Save the number of aten ops before compilation
     if option.metrics_path:
@@ -217,6 +222,8 @@ def aten_backend(
         option.compiled_schema_list.extend(metrics.collect_input_variations_from_list_nodes(gm.graph.nodes))
 
     option._out_fx_graphs.append(gm.graph)
+    if options.export_code:
+        option._ttnn_fx_graphs[-1].append(gm.graph)
 
     for node in gm.graph.nodes:
         if node.op == "placeholder":
@@ -243,10 +250,12 @@ def ttnn_backend(
     options: TorchTtnnOption = None,
 ) -> torch.fx.GraphModule:
     # Save all parameters and inputs if requested
-    if options.gen_op_accuracy_tests and options._all_inputs is None:
-        import tools.generate_op_accuracy_tests as generate_op_accuracy_tests
+    if options.export_code:
+        import tools.export_code as export_code
 
-        options._all_inputs = generate_op_accuracy_tests.generate_flat_args(gm, example_inputs)
+        options._aten_fx_graphs.append(list())
+        options._ttnn_fx_graphs.append(list())
+        options._all_inputs.append(export_code.generate_flat_args(gm, example_inputs))
 
     tracer_option = options.tracer_option
     if tracer_option is not None:


### PR DESCRIPTION
### Problem description
The current implementation to generate standalone accuracy tests can be reused for other purposes like profiling.

### What's changed

- Change `gen_op_accuracy_tests` option to `export_code=[accuracy|profiling]`
  - Code will now be generated under `tests/export_code/[accuracy|profiling]`

TODO:
- [ ] Changes to `test/utils.py` has been split to https://github.com/tenstorrent/pytorch2.0_ttnn/pull/892. Wait for that to finish merging.