### PR TITLE
Mark argmax test as working

### DIFF
--- a/docs/DevelopWithMetalFromSources.md
+++ b/docs/DevelopWithMetalFromSources.md
@@ -8,7 +8,7 @@ Fetch repo and install dependencies
 git clone https://github.com/tenstorrent/tt-metal.git
 cd tt-metal
 sudo ./install_dependencies.sh
-git submodule foreach 'git lfs fetch --all && git lfs pull'
+git submodule update --init --recursive
 ```
 setup env
 ```console

--- a/tests/lowering/misc/test_argmax.py
+++ b/tests/lowering/misc/test_argmax.py
@@ -17,7 +17,6 @@ class ArgmaxModule(torch.nn.Module):
         return torch.argmax(input, dim=dim)
 
 
-@pytest.mark.xfail(reason="argmax issues (#605)")
 @pytest.mark.parametrize(
     "input_shapes, dim",
     [


### PR DESCRIPTION
1. Remove xfail tag for argmax

### Ticket
https://github.com/tenstorrent/tt-metal/issues/19576

### Problem description
Argmax op failed for some inputs, this is resolved now. More details in the PR linked above.

### What's changed
1. Remove xfail tag for argmax
2. Update documentation to remove reference to lfs in tt-metal repo.