### PR TITLE
Update base docker image to stay synchronized with tt-metal

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-amd64-release:latest-rc AS release
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest-rc AS release
 
 # Install system-level dependencies (using apt-get)
 RUN apt-get update && \


### PR DESCRIPTION
### Problem description
From Wilder on Slack:
>Along with the cleanup, it was renamed from
docker pull [ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-amd64-release:latest-rc](http://ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-amd64-release:latest-rc)
to
docker pull [ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest-rc](http://ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest-rc)
matching our naming scheme for the dev container...

### What's changed
Update the Dockerfile to reflect this new name