### PR TITLE
Reduce unnecessary reshape calls in generated code

### DIFF
--- a/tests/lowering/eltwise/unary/test_abs.py
+++ b/tests/lowering/eltwise/unary/test_abs.py
@@ -17,7 +17,7 @@ class AbsModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_abs(device, input_shape, init_offset):
     m = AbsModule()

--- a/tests/lowering/eltwise/unary/test_acos.py
+++ b/tests/lowering/eltwise/unary/test_acos.py
@@ -17,7 +17,7 @@ class AcosModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_acos(device, input_shape, init_offset):
     m = AcosModule()

--- a/tests/lowering/eltwise/unary/test_acosh.py
+++ b/tests/lowering/eltwise/unary/test_acosh.py
@@ -17,7 +17,7 @@ class AcoshModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 1)],
+    [((4, 4), 1), ((4,), 1)],
 )
 def test_acosh(device, input_shape, init_offset):
     m = AcoshModule()

--- a/tests/lowering/eltwise/unary/test_asin.py
+++ b/tests/lowering/eltwise/unary/test_asin.py
@@ -17,7 +17,7 @@ class AsinModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_asin(device, input_shape, init_offset):
     m = AsinModule()

--- a/tests/lowering/eltwise/unary/test_asinh.py
+++ b/tests/lowering/eltwise/unary/test_asinh.py
@@ -17,7 +17,7 @@ class AsinhModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_asinh(device, input_shape, init_offset):
     m = AsinhModule()

--- a/tests/lowering/eltwise/unary/test_atan.py
+++ b/tests/lowering/eltwise/unary/test_atan.py
@@ -17,7 +17,7 @@ class AtanModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_atan(device, input_shape, init_offset):
     m = AtanModule()

--- a/tests/lowering/eltwise/unary/test_atanh.py
+++ b/tests/lowering/eltwise/unary/test_atanh.py
@@ -17,7 +17,7 @@ class AtanhModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_atanh(device, input_shape, init_offset):
     m = AtanhModule()

--- a/tests/lowering/eltwise/unary/test_clamp.py
+++ b/tests/lowering/eltwise/unary/test_clamp.py
@@ -19,7 +19,7 @@ class ClampModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [[(4, 4)]],
+    [[(4, 4)], [(4,)]],
 )
 def test_clamp(device, input_shapes):
     m = ClampModule()

--- a/tests/lowering/eltwise/unary/test_cos.py
+++ b/tests/lowering/eltwise/unary/test_cos.py
@@ -19,7 +19,7 @@ class CosModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shape",
-    ((4, 4), (1, 1066)),
+    ((4, 4), (1, 1066), (1066,)),
 )
 def test_cos(device, input_shape):
     m = CosModule()

--- a/tests/lowering/eltwise/unary/test_cosh.py
+++ b/tests/lowering/eltwise/unary/test_cosh.py
@@ -17,7 +17,7 @@ class CoshModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_cosh(device, input_shape, init_offset):
     m = CoshModule()

--- a/tests/lowering/eltwise/unary/test_elu.py
+++ b/tests/lowering/eltwise/unary/test_elu.py
@@ -23,7 +23,7 @@ class EluModule(torch.nn.Module):
         ((1, 128, 28, 28), 2.0),
         ((16, 32, 128, 28, 28), 1.0),
         ((1, 28), 1.0),
-        pytest.param((28,), 1.0, marks=pytest.mark.xfail(reason="lost 1D shape with tile layout (tt-metal#12671)")),
+        ((28,), 1.0),
     ],
 )
 def test_elu(device, input_shape, alpha):

--- a/tests/lowering/eltwise/unary/test_expm1.py
+++ b/tests/lowering/eltwise/unary/test_expm1.py
@@ -17,7 +17,7 @@ class Expm1Module(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_expm1(device, input_shape, init_offset):
     m = Expm1Module()

--- a/tests/lowering/eltwise/unary/test_isinf.py
+++ b/tests/lowering/eltwise/unary/test_isinf.py
@@ -17,7 +17,7 @@ class IsinfModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_isinf(device, input_shape, init_offset):
     m = IsinfModule()

--- a/tests/lowering/eltwise/unary/test_isnan.py
+++ b/tests/lowering/eltwise/unary/test_isnan.py
@@ -17,7 +17,7 @@ class IsnanModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_isnan(device, input_shape, init_offset):
     m = IsnanModule()

--- a/tests/lowering/eltwise/unary/test_log.py
+++ b/tests/lowering/eltwise/unary/test_log.py
@@ -17,7 +17,7 @@ class LogModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0), ((15, 15), 0), ((1, 1), 0), ((2, 2), 0), ((17, 17), 0), ((10, 10), 0)],
+    [((4, 4), 0), ((4,), 0), ((15, 15), 0), ((1, 1), 0), ((2, 2), 0), ((17, 17), 0), ((10, 10), 0)],
 )
 def test_log(device, input_shape, init_offset):
     m = LogModule()

--- a/tests/lowering/eltwise/unary/test_log10.py
+++ b/tests/lowering/eltwise/unary/test_log10.py
@@ -17,7 +17,7 @@ class Log10Module(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_log10(device, input_shape, init_offset):
     m = Log10Module()

--- a/tests/lowering/eltwise/unary/test_log1p.py
+++ b/tests/lowering/eltwise/unary/test_log1p.py
@@ -17,7 +17,7 @@ class Log1pModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_log1p(device, input_shape, init_offset):
     m = Log1pModule()

--- a/tests/lowering/eltwise/unary/test_log2.py
+++ b/tests/lowering/eltwise/unary/test_log2.py
@@ -17,7 +17,7 @@ class Log2Module(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_log2(device, input_shape, init_offset):
     m = Log2Module()

--- a/tests/lowering/eltwise/unary/test_logical_not.py
+++ b/tests/lowering/eltwise/unary/test_logical_not.py
@@ -17,7 +17,7 @@ class LogicalNotModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [[(4, 4)]],
+    [[(4, 4)], [(4,)]],
 )
 def test_logical_not(device, input_shapes):
     m = LogicalNotModule()

--- a/tests/lowering/eltwise/unary/test_reciprocal.py
+++ b/tests/lowering/eltwise/unary/test_reciprocal.py
@@ -17,7 +17,7 @@ class ReciprocalModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), -1)],
+    [((4, 4), -1), ((4,), -1)],
 )
 def test_reciprocal(device, input_shape, init_offset):
     m = ReciprocalModule()

--- a/tests/lowering/eltwise/unary/test_relu.py
+++ b/tests/lowering/eltwise/unary/test_relu.py
@@ -17,7 +17,7 @@ class ReluModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [[(4, 4)]],
+    [[(4, 4)], [(4,)]],
 )
 def test_relu(device, input_shapes):
     m = ReluModule()

--- a/tests/lowering/eltwise/unary/test_sigmoid.py
+++ b/tests/lowering/eltwise/unary/test_sigmoid.py
@@ -19,7 +19,7 @@ class SigmoidModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [[(4, 4)]],
+    [[(4, 4)], [(4,)]],
 )
 def test_sigmoid(device, input_shapes):
     m = SigmoidModule()

--- a/tests/lowering/eltwise/unary/test_sign.py
+++ b/tests/lowering/eltwise/unary/test_sign.py
@@ -17,7 +17,7 @@ class SignModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_sign(device, input_shape, init_offset):
     m = SignModule()

--- a/tests/lowering/eltwise/unary/test_silu.py
+++ b/tests/lowering/eltwise/unary/test_silu.py
@@ -19,7 +19,7 @@ class SiluModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [[(4, 4)]],
+    [[(4, 4)], [(4,)]],
 )
 def test_silu(device, input_shapes):
     m = SiluModule()

--- a/tests/lowering/eltwise/unary/test_sin.py
+++ b/tests/lowering/eltwise/unary/test_sin.py
@@ -19,7 +19,7 @@ class SinModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shape",
-    ((4, 4), (1, 1066)),
+    ((4, 4), (1, 1066), (1066,)),
 )
 def test_sin(device, input_shape):
     m = SinModule()

--- a/tests/lowering/eltwise/unary/test_sinh.py
+++ b/tests/lowering/eltwise/unary/test_sinh.py
@@ -17,7 +17,7 @@ class SinhModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     ("input_shape", "init_offset"),
-    [((4, 4), 0)],
+    [((4, 4), 0), ((4,), 0)],
 )
 def test_sinh(device, input_shape, init_offset):
     m = SinhModule()

--- a/tests/lowering/eltwise/unary/test_tan.py
+++ b/tests/lowering/eltwise/unary/test_tan.py
@@ -22,6 +22,7 @@ class TanModule(torch.nn.Module):
     (
         ((4, 4), 1),
         ((1, 1066), 1),
+        ((1066,), 1),
         ((1, 1066), 1.5),
         pytest.param((1, 1066), 1.6, marks=pytest.mark.xfail(reason="tt-metal#14414: inaccurate reciprocal")),
     ),

--- a/tests/lowering/eltwise/unary/test_tanh.py
+++ b/tests/lowering/eltwise/unary/test_tanh.py
@@ -19,7 +19,7 @@ class TanhModule(torch.nn.Module):
 
 @pytest.mark.parametrize(
     "input_shapes",
-    [[(4, 4)]],
+    [[(4, 4)], [(4,)]],
 )
 def test_tanh(device, input_shapes):
     m = TanhModule()

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -507,30 +507,17 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
             if node.target == torch.ops.aten.sub.Tensor:
                 return lower_binary_eltwise(ttnn.sub, args)
 
-            if node.target in TTNN_POINTWISE_UNARY_OPS:
-                code = TTNN_POINTWISE_UNARY_OPS[node.target]
+            if node.target == torch.ops.aten.tanh.default:
                 # TODO: Remove once tanh accuracy implementation is realized as a device operation in tt-metal
-                if code == ttnn.tanh:
-                    kwargs = {
-                        "accuracy": True,
-                    }
-
-            # NOTE(jdh8): Workaround for tenstorrent/tt-metal#12671
-            # Passing a tensor shaped `(N,)` to the kernel results in `(1, N)`.
-            # Reshape the tensor back to get the correct shape.
-            def reshape_1d(code, args=args, kwargs=kwargs):
-                shape = get_shape(gm, node)
-                if shape == torch.Size():
-                    # ttnn.from_torch not yet support scalar tensor, see issue 442
-                    return None
-                result = g.call_function(code, args, kwargs)
-                return result if len(shape) > 1 else g.call_function(ttnn.reshape, (result, shape))
+                new_kwargs = kwargs.copy()
+                new_kwargs["accuracy"] = True
+                kwargs = new_kwargs
 
             if node.target in TTNN_POINTWISE_UNARY_OPS:
-                return reshape_1d(TTNN_POINTWISE_UNARY_OPS[node.target])
+                return g.call_function(TTNN_POINTWISE_UNARY_OPS[node.target], args, kwargs)
 
             if node.target == torch.ops.aten.round.default:
-                return reshape_1d(ttnn.round, (args[0],), {"decimals": 0})
+                return g.call_function(ttnn.round, (args[0],), {"decimals": 0})
 
             if node.target == torch.ops.aten.clone.default:
                 # Only convert if the input is from graph arguments and node is also returned as an output


### PR DESCRIPTION
Removes unneeded reshape calls for eltwise unary function calls
Updates tests to exercise new behavior

### Problem description
I noticed that `gelu` had reshape calls before and after in BERT that are unnecessary. This PR removes the reshape calls for all eltwise unary ttnn ops.

I also cleaned up the handling of `accuracy=True` for tanh to not squash any other kwargs passed in
