### PR TITLE
Support <2 rank in Tile layout

### DIFF
--- a/tests/lowering/eltwise/binary/test_add.py
+++ b/tests/lowering/eltwise/binary/test_add.py
@@ -21,6 +21,7 @@ class AddModule(torch.nn.Module):
         ((32, 32), (32, 32)),
         ((64,), (32, 64)),
         ((64, 32), (64, 1)),
+        ((64, 32), ()),
         pytest.param(
             ((64, 1), (1, 64)),
             marks=pytest.mark.xfail(reason="broadcasting issues (#64)"),

--- a/tests/lowering/eltwise/binary/test_div.py
+++ b/tests/lowering/eltwise/binary/test_div.py
@@ -31,70 +31,22 @@ class DivModule(torch.nn.Module):
             ((1, 23, 40, 1), (128,)),
             marks=pytest.mark.xfail(reason="Bidirectional broadcasting issue (#64)"),
         ),
-        pytest.param(
-            ((), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 12, 9, 9), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 64, 9, 9), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 12, 25, 25), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 16, 9, 9), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 12, 7, 7), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 1280, 8, 8), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((10, 10), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((2, 2), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 16, 5, 5), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 16, 1, 6), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 128, 1568), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 64, 6272), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((1, 32, 25088), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((15, 15), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
-        pytest.param(
-            ((17, 17), ()),
-            marks=pytest.mark.xfail(reason="ttnn.div does not handle 0-D tensors (tt-metal#15630)"),
-        ),
+        ((), ()),
+        ((1, 12, 9, 9), ()),
+        ((1, 64, 9, 9), ()),
+        ((1, 12, 25, 25), ()),
+        ((1, 16, 9, 9), ()),
+        ((1, 12, 7, 7), ()),
+        ((1, 1280, 8, 8), ()),
+        ((10, 10), ()),
+        ((2, 2), ()),
+        ((1, 16, 5, 5), ()),
+        ((1, 16, 1, 6), ()),
+        ((1, 128, 1568), ()),
+        ((1, 64, 6272), ()),
+        ((1, 32, 25088), ()),
+        ((15, 15), ()),
+        ((17, 17), ()),
     ),
 )
 def test_div(device, input_shapes):

--- a/tests/lowering/eltwise/binary/test_mul.py
+++ b/tests/lowering/eltwise/binary/test_mul.py
@@ -22,6 +22,7 @@ class MulModule(torch.nn.Module):
         ((32, 32), (32, 32)),
         ((64,), (32, 64)),
         ((64, 32), (64, 1)),
+        ((64, 32), ()),
         pytest.param(
             ((64, 1), (1, 64)),
             marks=pytest.mark.xfail(reason="broadcasting issues (tt-metal#12852)"),

--- a/tests/lowering/eltwise/binary/test_sub.py
+++ b/tests/lowering/eltwise/binary/test_sub.py
@@ -42,6 +42,7 @@ class RSubScalarModule(torch.nn.Module):
             marks=pytest.mark.xfail(reason="broadcasting issues (#64)"),
         ),
         ((64, 32), (64, 1)),
+        ((64, 32), ()),
         pytest.param(
             ((64, 1), (1, 64)),
             marks=pytest.mark.xfail(reason="broadcasting issues (#64)"),

--- a/tests/lowering/eltwise/ternary/test_where.py
+++ b/tests/lowering/eltwise/ternary/test_where.py
@@ -26,30 +26,12 @@ class WhereModule(torch.nn.Module):
             ((8, 1), (1, 1), (1, 8)),
             marks=pytest.mark.xfail(reason="broadcasting issues (#64)"),
         ),
-        pytest.param(
-            ((1, 1, 7, 7), (1, 12, 7, 7), ()),
-            marks=pytest.mark.xfail(reason="ttnn.where cannot handle 0-D tensors (tt-metal#16254)"),
-        ),
-        pytest.param(
-            ((1, 1, 45, 45), (1, 12, 45, 45), ()),
-            marks=pytest.mark.xfail(reason="ttnn.where cannot handle 0-D tensors (tt-metal#16254)"),
-        ),
-        pytest.param(
-            ((1, 1, 1, 46), (1, 12, 1, 46), ()),
-            marks=pytest.mark.xfail(reason="ttnn.where cannot handle 0-D tensors (tt-metal#16254)"),
-        ),
-        pytest.param(
-            ((1, 1, 5, 5), (1, 16, 5, 5), ()),
-            marks=pytest.mark.xfail(reason="ttnn.where cannot handle 0-D tensors (tt-metal#16254)"),
-        ),
-        pytest.param(
-            ((1, 1, 1, 6), (1, 16, 1, 6), ()),
-            marks=pytest.mark.xfail(reason="ttnn.where cannot handle 0-D tensors (tt-metal#16254)"),
-        ),
-        pytest.param(
-            ((1, 1, 256), (1, 1, 256), ()),
-            marks=pytest.mark.xfail(reason="ttnn.where cannot handle 0-D tensors (tt-metal#16254)"),
-        ),
+        ((1, 1, 7, 7), (1, 12, 7, 7), ()),
+        ((1, 1, 45, 45), (1, 12, 45, 45), ()),
+        ((1, 1, 1, 46), (1, 12, 1, 46), ()),
+        ((1, 1, 5, 5), (1, 16, 5, 5), ()),
+        ((1, 1, 1, 6), (1, 16, 1, 6), ()),
+        ((1, 1, 256), (1, 1, 256), ()),
         ((1, 1, 7, 7), (1, 12, 7, 7), (1,)),
         ((1, 1, 45, 45), (1, 12, 45, 45), (1,)),
         ((1, 1, 1, 46), (1, 12, 1, 46), (1,)),

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -299,9 +299,6 @@ class ReplaceMoreTt(torch.fx.Transformer):
             return self.call_function_prop_meta(ttnn.addcmul, args + (value,), kwargs)
 
         if target == torch.ops.aten.where.self:
-            if get_shape(None, args[2]) == torch.Size():
-                # ttnn.from_torch not yet support scalar tensor, see issue 442
-                return self.call_function_prop_meta(target, args, kwargs)
             return self.call_function_prop_meta(ttnn.where, args, kwargs)
 
         ############################################################

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -470,12 +470,6 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
             def lower_binary_eltwise(fn, args):
                 shapes = get_shape(gm, args[0]), get_shape(gm, args[1])
 
-                if (isinstance(args[0], torch.fx.node.Node) and shapes[0] == torch.Size()) or (
-                    isinstance(args[1], torch.fx.node.Node) and shapes[1] == torch.Size()
-                ):
-                    # ttnn.from_torch not yet support scalar tensor, see issue 442
-                    return None
-
                 if any(s is None for s in shapes):
                     return None
 

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -671,12 +671,6 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return tensor if tiled else g.call_function(ttnn.to_layout, (tensor, TtnnTileLayout()))
 
             if node.target == torch.ops.aten.div.Tensor:
-                shapes = get_shape(gm, args[0]), get_shape(gm, args[1])
-                if (isinstance(args[0], torch.fx.node.Node) and shapes[0] == torch.Size()) or (
-                    isinstance(args[1], torch.fx.node.Node) and shapes[1] == torch.Size()
-                ):
-                    # ttnn.from_torch not yet support scalar tensor, see issue 442
-                    return None
                 if isinstance(args[1], (float, int)):
                     return g.call_function(ttnn.mul, (args[0], 1.0 / args[1]), {})
 


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/442)

### Problem description
There are several places in ToTtPass where we guard against scalar inputs for functions that now have support from the tt-metal side. By removing these guards and updating tests, we can convert more calls to ttnn calls.

### What's changed
This PR has separates commits for each part of the ToTtPass that has been updated. Each commit also updates relevant tests to exercise the new behavior.

Note that this change leaves one reference to issue 422 in ToTtPass, but it is resolved by https://github.com/tenstorrent/pytorch2.0_ttnn/pull/968
