### PR TITLE
Temporarily revert changes that rely on nonexistent tt-metal version

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -128,7 +128,6 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0    
-      - uses: ./.github/actions/common_repo_setup
       - name: docker-cleanup
         run: |
           docker system prune -a -f --volumes

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ graphviz
 matplotlib==3.7.1
 pysftp==0.2.9
 
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc63/ttnn-0.57.0rc63+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc63/ttnn-0.57.0rc63+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc60/ttnn-0.57.0rc60+any-cp38-cp38-linux_x86_64.whl ; python_version=="3.8"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.57.0-rc60/ttnn-0.57.0rc60+any-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"

--- a/tests/lowering/eltwise/unary/test_tanh.py
+++ b/tests/lowering/eltwise/unary/test_tanh.py
@@ -6,8 +6,6 @@ import torch_ttnn
 import pytest
 import ttnn
 
-from tests.utils import assert_with_pcc
-
 
 class TanhModule(torch.nn.Module):
     def __init__(self):
@@ -36,4 +34,4 @@ def test_tanh(device, input_shapes):
     nodes = list(option._out_fx_graphs[0].nodes)
     assert [node.target for node in nodes].count(ttnn.tanh) == 1
     # Check inference result
-    assert_with_pcc(result_before, result_after)
+    assert torch.allclose(result_before, result_after, rtol=0.2)

--- a/tests/lowering/tensor_manipulation/test_squeeze.py
+++ b/tests/lowering/tensor_manipulation/test_squeeze.py
@@ -39,7 +39,13 @@ def test_squeeze_dim(device, input_shape, dim):
     option._out_fx_graphs[0].print_tabular()
     # Check the graph has be rewritten and contain ttnn ops
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.squeeze) == 1
+    if option.use_less_ttnn_op_types:
+        # squeeze is lowered to reshape
+        assert [node.target for node in nodes].count(ttnn.reshape) == 1
+    else:
+        assert [node.target for node in nodes].count(ttnn.squeeze) == 1
+    # TODO: use following line when we update tt-metal
+    # assert [node.target for node in nodes].count(ttnn.squeeze) == 1
     # Check inference result
     assert torch.allclose(result_before, result_after)
 
@@ -77,6 +83,8 @@ def test_squeeze_none_dim(device, input_shape):
     option._out_fx_graphs[0].print_tabular()
     # Check the graph has be rewritten and contain ttnn ops (squeeze without provided dim is lowered to reshape)
     nodes = list(option._out_fx_graphs[0].nodes)
-    assert [node.target for node in nodes].count(ttnn.squeeze) == 1
+    assert [node.target for node in nodes].count(ttnn.reshape) == 1
+    # TODO: use following line when we update tt-metal
+    # assert [node.target for node in nodes].count(ttnn.squeeze) == 1
     # Check inference result
     assert torch.allclose(result_before, result_after)

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -35,6 +35,7 @@ class ThisTester(ModelTester):
     "mode",
     [pytest.param("eval", marks=pytest.mark.compilation_xfail)],
 )
+@pytest.mark.converted_end_to_end
 def test_bloom(record_property, mode):
     model_name = "Bloom"
     record_property("model_name", model_name)

--- a/torch_ttnn/passes/lowering/target_wrappers.py
+++ b/torch_ttnn/passes/lowering/target_wrappers.py
@@ -52,7 +52,7 @@ def conv(
     if len(in_spatial_shape) == 1:
         # TODO(tt-metal#16258): conv1d API doesn't support transposed yet
         assert not transposed, "conv1d doesn't support transposed yet"
-        return ttnn.conv1d(
+        return ttnn.Conv1d(
             input_tensor=input_tensor,
             weight_tensor=weight_tensor,
             bias_tensor=bias_tensor,

--- a/torch_ttnn/passes/lowering/to_tt_pass.py
+++ b/torch_ttnn/passes/lowering/to_tt_pass.py
@@ -509,11 +509,6 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
 
             if node.target in TTNN_POINTWISE_UNARY_OPS:
                 code = TTNN_POINTWISE_UNARY_OPS[node.target]
-                # TODO: Remove once tanh accuracy implementation is realized as a device operation in tt-metal
-                if code == ttnn.tanh:
-                    kwargs = {
-                        "accuracy": True,
-                    }
 
             # NOTE(jdh8): Workaround for tenstorrent/tt-metal#12671
             # Passing a tensor shaped `(N,)` to the kernel results in `(1, N)`.
@@ -778,7 +773,15 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule, use_less_ttnn_op_types: bool
                 return None
 
             if node.target == torch.ops.aten.squeeze.dim or node.target == torch.ops.aten.squeeze.default:
-                return g.call_function(ttnn.squeeze, args=args, kwargs=kwargs)
+                if use_less_ttnn_op_types or node.target == torch.ops.aten.squeeze.default:
+                    # ttnn.squeeze does not support calling the OP without provided dim (torch.ops.aten.squeeze.default)
+                    # squeezing is the same as reshaping to shape of output tensor of squeeze
+                    output_size = list(node.meta["val"].size())
+                    return g.call_function(ttnn.reshape, args=(args[0], output_size))
+                else:
+                    return g.call_function(ttnn.squeeze, args=(args[0], args[1]))
+                # TODO: use the following line instead when we have a newer tt-metal
+                # return g.call_function(ttnn.squeeze, args=args, kwargs=kwargs)
 
             if node.target == torch.ops.aten.unsqueeze.default:
                 output_shape_num_element = node.meta["val"].numel()


### PR DESCRIPTION
Revert recent changes that depend on RC63. In particular, the following
commits were reverted:

1d1b23a5e4ab3534aae0680bb6052c592ba2358d
0683def63d7670f98d1452f0f957de6eba74332d
part of afac9cfc81a925140199559ef2b15029c1f33cfa
