### PR TITLE
Synchronize update-ttnn-wheel workflow with new tt-metal naming

### DIFF
--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -32,9 +32,8 @@ jobs:
           # Remove any existing ttnn lines (adjust the regex if needed)
           sed -i '/^ttnn @ https:\/\/github\.com\/tenstorrent\/tt-metal\/releases\//d' requirements.txt
       
-          # Append the two lines for the different python versions.
-          echo "ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v${latest_version}/ttnn-$latest_version_short+any-cp38-cp38-linux_x86_64.whl ; python_version==\"3.8\"" >> requirements.txt
-          echo "ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v${latest_version}/ttnn-$latest_version_short+any-cp310-cp310-linux_x86_64.whl ; python_version==\"3.10\"" >> requirements.txt
+          # Append the line for the newest version
+          echo "ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v${latest_version}/ttnn-$latest_version_short-cp310-cp310-linux_x86_64.whl ; python_version==\"3.10\"" >> requirements.txt
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Change update-ttnn-wheel to use new pattern for tt-metal RC names
Remove line for python3.8 since it is no longer supported

### Problem description
Problem showed up in this run:
https://github.com/tenstorrent/pytorch2.0_ttnn/actions/runs/14660010318/job/41142164195

It also showed up yesterday when trying to update to the newest RC, but I just manually changed dependencies. This should fix it going forward
