### PR TITLE
Fix docker update to only update when tests pass

### DIFF
--- a/.github/workflows/community-issue-tagging.yml
+++ b/.github/workflows/community-issue-tagging.yml
@@ -1,4 +1,4 @@
-name: "Community Issue / PR Labeling Workflow""
+name: "Community Issue / PR Labeling Workflow"
 
 on:
   issues:

--- a/.github/workflows/update-docker-container.yaml
+++ b/.github/workflows/update-docker-container.yaml
@@ -107,7 +107,7 @@ jobs:
         run: |
           checkout_passed="${{ needs.check-docker-images.result == 'success' }}"
           tests_passed="${{needs.run-tests.outputs.tests_passed == 0 }}"
-          if [[ $checkout_passed && $tests_passed ]] ; then
+          if [[ $checkout_passed == "true" && $tests_passed == "true" ]] ; then
             IMAGE_REPO="ghcr.io/tenstorrent/pytorch2.0_ttnn/ubuntu-22.04-amd64"
             LATEST_TAG="${IMAGE_REPO}:latest"
             DEV_TAG="${{ needs.check-docker-images.outputs.dev-tag }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ graphviz
 matplotlib==3.7.1
 pysftp==0.2.9
 
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.58.0-rc25/ttnn-0.58.0rc25-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.58.0-rc36/ttnn-0.58.0rc36-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"


### PR DESCRIPTION
Previously, the docker update workflow would update regardless of whether tests pass. This PR fixes that issue.

It also bundles in the dependency update since the new docker container should work with updated dependences.
