### PR TITLE
Fuse operations in Bert attention

### DIFF
--- a/torch_ttnn/passes/fusion_pass.py
+++ b/torch_ttnn/passes/fusion_pass.py
@@ -6,6 +6,7 @@ import torch
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
 from torch_ttnn.passes.patterns.linear_pattern import LinearPatterns
 from torch_ttnn.passes.patterns.soft_max_pattern import SoftMaxPatterns
+from torch_ttnn.passes.patterns.attention_pattern import AttentionPatterns
 from pathlib import Path
 
 
@@ -18,6 +19,8 @@ class FusionPass(PassBase):
 
         # List of pattern classes to apply
         pattern_classes = [LinearPatterns, SoftMaxPatterns]
+        # AttentionPatterns must be applied last
+        pattern_classes.append(AttentionPatterns)
 
         for pattern_cls in pattern_classes:
             pattern = pattern_cls(gm)

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -182,6 +182,12 @@ TTNN_MAYBE_ROW_OPS = set(
     ]
 )
 
+TTNN_TRANSFORMER_OPS = [
+    ttnn.transformer.scaled_dot_product_attention,
+    ttnn.transformer.attention_softmax_,
+    ttnn.transformer.split_query_key_value_and_split_heads,
+]
+
 TTNN_HOST_ONLY_OPS = set()
 
 
@@ -205,6 +211,7 @@ def is_tt_compute(node) -> bool:
         + TTNN_DATAMOVE_OPS
         + TTNN_NORM_OPS
         + TTNN_POOL_OPS
+        + TTNN_TRANSFORMER_OPS
         + [
             ttnn.embedding,
             ttnn.ones,
@@ -225,8 +232,6 @@ def is_tt_compute(node) -> bool:
             ttnn.argmax,
             ttnn.fill,
             ttnn.empty,
-            ttnn.transformer.scaled_dot_product_attention,
-            ttnn.transformer.attention_softmax_,
         ]
     )
 

--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -186,6 +186,7 @@ TTNN_TRANSFORMER_OPS = [
     ttnn.transformer.scaled_dot_product_attention,
     ttnn.transformer.attention_softmax_,
     ttnn.transformer.split_query_key_value_and_split_heads,
+    ttnn.transformer.concatenate_heads,
 ]
 
 TTNN_HOST_ONLY_OPS = set()

--- a/torch_ttnn/passes/patterns/attention_pattern.py
+++ b/torch_ttnn/passes/patterns/attention_pattern.py
@@ -39,6 +39,10 @@ class AttentionPatterns(PatternMatcherBase):
             for k_candidate in key_candidates:
                 k_linear, k_view1, k_reshape, k_permute, k_transpose, k_view2, k_matmul = k_candidate
 
+                # check that the weights have the same shape
+                if q_linear.args[1].meta["val"].shape != k_linear.args[1].meta["val"].shape:
+                    continue
+
                 # Check if this is the QK matmul
                 if k_matmul is not q_matmul:
                     continue
@@ -73,6 +77,10 @@ class AttentionPatterns(PatternMatcherBase):
                 # Find matching value candidate
                 for v_candidate in value_candidates:
                     v_linear, v_view1, v_reshape, v_permute, v_view2, v_matmul = v_candidate
+
+                    # check that the weights have the same shape
+                    if q_linear.args[1].meta["val"].shape != v_linear.args[1].meta["val"].shape:
+                        continue
 
                     # Check if view output goes to matmul with value
                     matmul_sv = self._find_exclusive_user_of_type(view2, ttnn.matmul)
@@ -388,6 +396,7 @@ class AttentionPatterns(PatternMatcherBase):
             candidate = self._find_qkv_pattern(
                 linear, require_transpose=require_transpose, matmul_arg_idx=matmul_arg_idx
             )
+
             if candidate:
                 key_candidates.append(candidate)
         return key_candidates


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/pytorch2.0_ttnn/issues/992)

### Problem description
There are some operations in the compiled code that can be unified in a higher level call.
Bert attention should work with concatenated heads and reduce the amount of low level operations

### What's changed
Added a new compilation pass that unifies bert attention layers with higher level operations.




Before PR:
Runtime Iteration without cache: 9.11285948753357
Runtime Iteration with cache: 0.38252902030944824

After PR:
Runtime Iteration without cache: 8.339576005935669
Runtime Iteration with cache: 0.37560153007507324

Generated code here:
https://github.com/dgomezTT/BertCompiledOptimization/commit/1b31451af6c13ffaf66816bea95524afe67baad3

Before:
Runtime Iteration 0: 7.632845163345337
Runtime Iteration 1: 0.3204987049102783
Runtime Iteration 2: 0.30744123458862305
Runtime Iteration 3: 0.30896854400634766
Runtime Iteration 4: 0.3109018802642822

After:
Runtime Iteration 0: 7.582945108413696
Runtime Iteration 1: 0.3196885585784912
Runtime Iteration 2: 0.30839991569519043
Runtime Iteration 3: 0.3023970127105713
Runtime Iteration 4: 0.3016688823699951

One layer comparison and full code comparison:
https://github.com/dgomezTT/BertCompiledOptimization/commit/028db647fd771222d83f0915ddd3ea0e73869242

Hardware used:
n150d + ryzen 9 5950x3d
