### PR TITLE
Remove `print_tabular` from conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,9 +268,6 @@ def compile_and_run(device, reset_torch_dynamo, request):
             if export_code_opt:
                 export_code.export_code(option)
 
-            if len(option._out_fx_graphs) > 0:
-                option._out_fx_graphs[0].print_tabular()
-
             if model_name not in ["speecht5-tts", "ssd300_vgg16", "retinanet_resnet50_fpn_v2"]:
                 accuracy = calculate_accuracy(outputs, outputs_after)
                 if accuracy:


### PR DESCRIPTION
### Ticket
None

### Problem description
`print_tabular` prints out the graph in a table format. However, the information can be noisy and redundant. We are already printing out the graph in Python-code format in backend.py. 

### What's changed
Remove this printout. 