### PR TITLE
AttributeError fix for graph analysis pass

### DIFF
--- a/torch_ttnn/passes/analysis/graph_module_analysis_pass.py
+++ b/torch_ttnn/passes/analysis/graph_module_analysis_pass.py
@@ -46,7 +46,7 @@ def is_train_forward(gm):
     # If this assumption fails in the future, we will need to update this function
     outputs = [node for node in gm.graph.nodes if node.op == "output"]
     for node in outputs:
-        placeholder_args = [arg for arg in node.args[0] if arg.op == "placeholder"]
+        placeholder_args = [arg for arg in node.args[0] if arg is not None and arg.op == "placeholder"]
         if len(placeholder_args) > 0:
             return True
 


### PR DESCRIPTION
This fixes an error which was thrown while compiling this Gaussian splatting implementation:
[torch-splatting](https://github.com/hbb1/torch-splatting)

The error was: 
`Traceback (most recent call last):
  File "/home/user/tt-metal/pytorch2.0_ttnn/torch_ttnn/passes/analysis/graph_module_analysis_pass.py", line 49, in <listcomp>
    placeholder_args = [arg for arg in node.args[0] if arg.op == "placeholder"]
AttributeError: 'NoneType' object has no attribute 'op'`

### What's changed
Accounted for the fact that node args can be None for certain conditional execution paths in the graph.  This is done by adding `NoneType` checking to the node arguments before accessing their attributes.  This eliminates the error, and doesn't affect the function or logic of the code in any other way.
