### PR TITLE
Update docker base container

### DIFF
--- a/.github/actions/common_model_tests/action.yaml
+++ b/.github/actions/common_model_tests/action.yaml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       run: |
         set +e
-        if [ "${{ github.event.inputs.commit_report }}" == "None" ]; then
+        if [ "${{ inputs.commit_report }}" == "None" ]; then
           num_iterations=1
         else
           num_iterations=5

--- a/.github/workflows/update-docker-container.yaml
+++ b/.github/workflows/update-docker-container.yaml
@@ -81,6 +81,12 @@ jobs:
   run-tests:
     needs: [create-new-container-and-upload, check-docker-images]
     if: ${{ always() }}
+    permissions:
+      actions: read
+      contents: write
+      pages: write
+      pull-requests: write
+      id-token: write
     uses: ./.github/workflows/run-tests.yaml
     secrets: inherit
     with:

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,12 +1,10 @@
-FROM ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64:latest-rc AS release
+FROM ghcr.io/tenstorrent/tt-metal/tt-metalium/ubuntu-22.04-dev-amd64:latest AS release
 
 # Install system-level dependencies (using apt-get)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         sudo \
         libgl1-mesa-glx \
-        libopenmpi-dev \
-        openmpi-bin \
         git-lfs \
         libsndfile1 \
         docker.io && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ graphviz
 matplotlib==3.7.1
 paramiko==3.5.1
 
-ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.59.0-rc15/ttnn-0.59.0rc15-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"
+ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v0.59.0-rc31/ttnn-0.59.0rc31-cp310-cp310-linux_x86_64.whl ; python_version=="3.10"


### PR DESCRIPTION
Recently, dependency updates have been failing because metal now uses a custom MPI branch. To fix this, and other related issues going forward, we can change the base CI docker image to be the `dev` version from metal.

Additionally, this PR:
* Fixes the num_iterations input for run-tests to speed up CI merge runs
* Adds the right permissions for run-tests inside the update-docker-container workflow
* Updates dependencies to the latest RC