### PR TITLE
Average compiled runtime over several runs

### DIFF
--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -491,6 +491,12 @@ if __name__ == "__main__":
             compiled_runtime_metrics["compiled_run_time"] = run_time
             pydantic_model.compiled_run_time = float(run_time)
 
+        # Replace compiled runtime with average if available
+        if "avg_run_time" in compiled_runtime_metrics:
+            avg_run_time = compiled_runtime_metrics.pop("avg_run_time")
+            compiled_runtime_metrics["compiled_run_time"] = avg_run_time
+            pydantic_model.compiled_run_time = float(avg_run_time)
+
         # Load op schema metrics
         original_schema_metrics_path = model_path / "original-schema_list.pickle"
         original_schema_metrics = load_pickle(original_schema_metrics_path) or {}


### PR DESCRIPTION
Recently, we have seen lots of variability in compiled model runtime. This may be due to only reporting the 5th iteration instead of averaging over several iterations.

This PR changes the reported number to be averaged over any iterations after the first (creates program cache, much slower) and the second (may still be warming up caches). The new metric is reported as `avg_run_time` in the model metrics.

In the future, it may also be good to report TTFT in the front page (basically the first iteration, but we might need to report when the output begins streaming if it takes a while to return multiple values)