### PR TITLE
Match tt-metal batch sizes for testing models

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,6 +301,7 @@ def compile_and_run(device, reset_torch_dynamo, request):
             comp_runtime_metrics["run_time"] = round(run_time, 2)
             comp_runtime_metrics["run_time_first_iter"] = round(first_iter_runtime, 2)
             comp_runtime_metrics["has_aten"] = None
+            comp_runtime_metrics["batch_size"] = model_tester.batch_size
 
             logging.info(f"Compilation and run successful in {comp_runtime_metrics['run_time']} ms.")
 

--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -8,7 +8,7 @@ from torchvision import transforms
 from PIL import Image
 
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -29,9 +29,7 @@ class ThisTester(ModelTester):
         batch_t = torch.unsqueeze(img_t, 0)
 
         # TODO: get unique data instead of just repeating
-        repeat_size = [1] * batch_t.dim()
-        repeat_size[0] = batch_size
-        batch_t = batch_t.repeat(*repeat_size)
+        batch_t = repeat_inputs(batch_t, batch_size)
 
         return batch_t.to(torch.bfloat16)
 

--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -18,7 +18,7 @@ class ThisTester(ModelTester):
         model = models.mobilenet_v2(weights=self.weights)
         return model.to(torch.bfloat16)
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Define a transformation to preprocess the input image using the weights transforms
         preprocess = self.weights.transforms()
 
@@ -27,6 +27,12 @@ class ThisTester(ModelTester):
         image = Image.open(requests.get(url, stream=True).raw)
         img_t = preprocess(image)
         batch_t = torch.unsqueeze(img_t, 0)
+
+        # TODO: get unique data instead of just repeating
+        repeat_size = [1] * batch_t.dim()
+        repeat_size[0] = batch_size
+        batch_t = batch_t.repeat(*repeat_size)
+
         return batch_t.to(torch.bfloat16)
 
 

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -6,17 +6,18 @@
 from transformers import AutoTokenizer, AlbertForMaskedLM
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         return AlbertForMaskedLM.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.text = "The capital of [MASK] is Paris."
         self.inputs = self.tokenizer(self.text, return_tensors="pt")
+        self.inputs = repeat_inputs(self.inputs, batch_size)
         return self.inputs
 
     def set_inputs_train(self, inputs):

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -6,7 +6,7 @@
 from transformers import AutoTokenizer, AlbertForQuestionAnswering
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -14,10 +14,11 @@ class ThisTester(ModelTester):
         model = AlbertForQuestionAnswering.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.question, self.text = "Who was Jim Henson?", "Jim Henson was a nice puppet"
         inputs = self.tokenizer(self.question, self.text, return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -6,17 +6,18 @@
 from transformers import AlbertTokenizer, AlbertForSequenceClassification
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         return AlbertForSequenceClassification.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         self.tokenizer = AlbertTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.input_text = "Hello, my dog is cute."
         self.inputs = self.tokenizer(self.input_text, return_tensors="pt")
+        self.inputs = repeat_inputs(self.inputs, batch_size)
         return self.inputs
 
 

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -6,17 +6,18 @@
 from transformers import AutoTokenizer, AlbertForTokenClassification
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
     def _load_model(self):
         return AlbertForTokenClassification.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         self.text = "HuggingFace is a company based in Paris and New York."
         self.inputs = self.tokenizer(self.text, add_special_tokens=False, return_tensors="pt")
+        self.inputs = repeat_inputs(self.inputs, batch_size)
         return self.inputs
 
 

--- a/tests/models/autoencoder_conv/test_autoencoder_conv.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv.py
@@ -4,7 +4,7 @@
 import torch
 from diffusers import DiffusionPipeline, AutoencoderTiny
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -36,9 +36,10 @@ AutoencoderTiny(
         """
         return pipe
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         prompt = "slice of delicious New York-style berry cheesecake"
         arguments = {"prompt": prompt, "num_inference_steps": 25}
+        arguments = repeat_inputs(arguments, batch_size)
         return arguments
 
 

--- a/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
@@ -7,7 +7,7 @@ import torch
 import torchvision.transforms as transforms
 from datasets import load_dataset
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ConvAE(torch.nn.Module):
@@ -52,7 +52,7 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Define transform to normalize data
         transform = transforms.Compose(
             [
@@ -67,6 +67,7 @@ class ThisTester(ModelTester):
         n_sample_tensor = [transform(sample).unsqueeze(0)]
         batch_tensor = torch.cat(n_sample_tensor, dim=0)
         batch_tensor = batch_tensor.to(torch.bfloat16)
+        batch_tensor = repeat_inputs(batch_tensor, batch_size)
         return batch_tensor
 
 

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -7,7 +7,7 @@ import torch
 import torchvision.transforms as transforms
 from datasets import load_dataset
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class LinearAE(torch.nn.Module):
@@ -60,7 +60,7 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Define transform to normalize data
         transform = transforms.Compose(
             [
@@ -76,6 +76,7 @@ class ThisTester(ModelTester):
         sample_tensor = [transform(sample).squeeze(0)]
         batch_tensor = torch.cat(sample_tensor, dim=0)
         batch_tensor = batch_tensor.to(torch.bfloat16)
+        batch_tensor = repeat_inputs(batch_tensor, batch_size)
         return batch_tensor
 
 

--- a/tests/models/beit/test_beit_image_classification.py
+++ b/tests/models/beit/test_beit_image_classification.py
@@ -6,7 +6,7 @@ from PIL import Image
 import requests
 import pytest
 import torch
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -15,12 +15,13 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
         processor = BeitImageProcessor.from_pretrained(self.model_name)
         inputs = processor(images=image, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
     def set_inputs_train(self, inputs):

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -53,13 +53,17 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
+@pytest.mark.parametrize(
+    "batch_size",
+    [8],
+)
 @pytest.mark.converted_end_to_end
-def test_bert(record_property, mode):
+def test_bert(record_property, mode, batch_size):
     model_name = "BERT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
+    tester = ThisTester(model_name, mode, batch_size)
     results = tester.test_model()
 
     if mode == "eval":

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -20,9 +20,8 @@ class ThisTester(ModelTester):
         m = AutoModelForQuestionAnswering.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return m
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Set up sample input
-        batch_size = 1
         this_file_path = os.path.dirname(__file__)
         input_path = os.path.join(this_file_path, "../../inputs/bert/input_data.json")
         with open(input_path) as f:

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -6,7 +6,7 @@ import pytest
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -17,7 +17,7 @@ class ThisTester(ModelTester):
         m = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return m
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Set up sample input
         self.test_input = "This is a sample text from "
         inputs = self.tokenizer.encode_plus(
@@ -28,6 +28,7 @@ class ThisTester(ModelTester):
             add_special_tokens=True,
             truncation=True,
         )
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -6,7 +6,7 @@ import requests
 import torch
 from transformers import CLIPProcessor, CLIPModel
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -15,7 +15,7 @@ class ThisTester(ModelTester):
         self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32", torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
 
@@ -26,6 +26,7 @@ class ThisTester(ModelTester):
             padding=True,
         )
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
     def set_inputs_train(self, inputs):
@@ -47,7 +48,7 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "mode",
     [
-        "train",
+        # "train",
         "eval",
     ],
 )

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -48,7 +48,7 @@ class ThisTester(ModelTester):
 @pytest.mark.parametrize(
     "mode",
     [
-        # "train",
+        "train",
         "eval",
     ],
 )

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -5,7 +5,7 @@
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -16,9 +16,10 @@ class ThisTester(ModelTester):
         self.tokenizer = AutoTokenizer.from_pretrained(checkpoint)
         return model.generate
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         text = "def hello_world():"
         inputs = self.tokenizer(text, return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
     def set_model_eval(self, model):

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -8,7 +8,7 @@ from PIL import Image
 import requests
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -18,11 +18,12 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
         inputs = self.feature_extractor(images=image, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
     def set_inputs_train(self, inputs):

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -7,7 +7,7 @@ import torch
 import numpy as np
 from torchvision import transforms
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -21,7 +21,7 @@ class ThisTester(ModelTester):
         )
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Images
         img_url = "https://ultralytics.com/images/zidane.jpg"  # batch of images
         input_image = Image.open(requests.get(img_url, stream=True).raw)
@@ -34,6 +34,7 @@ class ThisTester(ModelTester):
         )
         input_tensor = preprocess(input_image)
         input_batch = input_tensor.unsqueeze(0).to(torch.bfloat16)
+        input_batch = repeat_inputs(input_batch, batch_size)
         return input_batch
 
 

--- a/tests/models/dino/test_dino.py
+++ b/tests/models/dino/test_dino.py
@@ -6,7 +6,7 @@ import requests
 
 from PIL import Image
 from transformers import AutoImageProcessor, AutoModel
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -19,13 +19,14 @@ class ThisTester(ModelTester):
         model = AutoModel.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Set up sample input
         self.test_input = "http://images.cocodataset.org/val2017/000000039769.jpg"
         self.image = Image.open(requests.get(self.test_input, stream=True).raw)
 
         inputs = self.image_processor(images=self.image, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -4,7 +4,7 @@
 from transformers import DistilBertTokenizer, DistilBertModel
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -13,9 +13,10 @@ class ThisTester(ModelTester):
         model = DistilBertModel.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         self.text = "Transformers provide state-of-the-art results in NLP."
         inputs = self.tokenizer(self.text, return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -5,7 +5,7 @@
 
 from transformers import DPRReader, DPRReaderTokenizer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -15,13 +15,14 @@ class ThisTester(ModelTester):
         model = DPRReader.from_pretrained("facebook/dpr-reader-single-nq-base", torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         encoded_inputs = self.tokenizer(
             questions=["What is love ?"],
             titles=["Haddaway"],
             texts=["'What Is Love' is a song recorded by the artist Haddaway"],
             return_tensors="pt",
         )
+        encoded_inputs = repeat_inputs(encoded_inputs, batch_size)
         return encoded_inputs
 
 

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -6,7 +6,7 @@ import pytest
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -17,10 +17,11 @@ class ThisTester(ModelTester):
         m = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return m
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Set up sample input
         self.test_input = "This is a sample text from "
         inputs = self.tokenizer(self.test_input, return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -29,12 +29,17 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_falcon(record_property, mode):
-    model_name = "Falcon"
+@pytest.mark.parametrize(
+    "batch_size",
+    # TODO: tt-metal uses batch_size=32 for Falcon-7B. Change when it runs successfully
+    [1],
+)
+def test_falcon(record_property, mode, batch_size):
+    model_name = "Falcon-7B"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
+    tester = ThisTester(model_name, mode, batch_size)
     results = tester.test_model()
 
     if mode == "eval":

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -5,7 +5,7 @@
 
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -15,8 +15,9 @@ class ThisTester(ModelTester):
         model = AutoModelForSeq2SeqLM.from_pretrained("google/flan-t5-small", torch_dtype=torch.bfloat16)
         return model.generate
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         inputs = self.tokenizer("A step by step recipe to make bolognese pasta:", return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
     def set_model_eval(self, model):

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -7,7 +7,7 @@ from PIL import Image
 import requests
 from transformers import GLPNImageProcessor, GLPNForDepthEstimation
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -16,12 +16,13 @@ class ThisTester(ModelTester):
         model = GLPNForDepthEstimation.from_pretrained("vinvino02/glpn-kitti", torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         self.image = Image.open(requests.get(url, stream=True).raw)
         # prepare image for the model
         inputs = self.processor(images=self.image, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -6,7 +6,7 @@ import pytest
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -17,10 +17,11 @@ class ThisTester(ModelTester):
         m = AutoModelForSequenceClassification.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return m
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Set up sample input
         self.test_input = "This is a sample text from "
         inputs = self.tokenizer(self.test_input, return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -5,7 +5,7 @@
 
 from transformers import GPTNeoForCausalLM, GPT2Tokenizer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -15,7 +15,7 @@ class ThisTester(ModelTester):
         self.tokenizer = GPT2Tokenizer.from_pretrained("EleutherAI/gpt-neo-125M")
         return model.generate
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         prompt = (
             "In a shocking finding, scientists discovered a herd of unicorns living in a remote, "
             "previously unexplored valley, in the Andes Mountains. Even more surprising to the "
@@ -24,6 +24,7 @@ class ThisTester(ModelTester):
 
         input_ids = self.tokenizer(prompt, return_tensors="pt").input_ids
         arguments = {"input_ids": input_ids, "do_sample": True, "temperature": 0.9, "max_length": 100}
+        arguments = repeat_inputs(arguments, batch_size)
         return arguments
 
     def set_model_eval(self, model):

--- a/tests/models/hand_landmark/test_hand_landmark.py
+++ b/tests/models/hand_landmark/test_hand_landmark.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from pathlib import Path
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 dependencies = ["mediapipe"]
 
@@ -24,11 +24,12 @@ class ThisTester(ModelTester):
         detector = vision.HandLandmarker.create_from_options(options)
         return detector.detect
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         import mediapipe as mp
 
         image_path = Path(__file__).parent / "woman_hands.jpg"
         image = mp.Image.create_from_file(str(image_path))
+        image = repeat_inputs(image, batch_size)
         return image
 
     def set_model_eval(self, model):

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -9,7 +9,7 @@ from torchvision import transforms
 import requests
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -20,7 +20,7 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         url = "https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png"
         input_image = Image.open(requests.get(url, stream=True).raw)
         preprocess = transforms.Compose(
@@ -34,6 +34,7 @@ class ThisTester(ModelTester):
         input_tensor = preprocess(input_image)
         input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model
         input_batch = input_batch.to(torch.bfloat16)
+        input_batch = repeat_inputs(input_batch, batch_size)
         return input_batch
 
 

--- a/tests/models/llama/test_llama.py
+++ b/tests/models/llama/test_llama.py
@@ -6,7 +6,7 @@ import pytest
 
 # Load model directly
 from transformers import AutoTokenizer, AutoModelForCausalLM
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -20,7 +20,7 @@ class ThisTester(ModelTester):
             param.requires_grad = False
         return m
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Set up sample input
         self.test_input = "This is a sample text from "
         inputs = self.tokenizer.encode_plus(
@@ -31,6 +31,7 @@ class ThisTester(ModelTester):
             add_special_tokens=True,
             truncation=True,
         )
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -16,8 +16,8 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
-        img = torch.randn(1, 3, 256, 256)
+    def _load_inputs(self, batch_size):
+        img = torch.randn(batch_size, 3, 256, 256)
         img = img.to(torch.bfloat16)
         return img
 

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -44,10 +44,10 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         transform = transforms.Compose([transforms.ToTensor()])
         test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
-        dataloader = DataLoader(test_dataset, batch_size=1)
+        dataloader = DataLoader(test_dataset, batch_size=batch_size)
         test_input, _ = next(iter(dataloader))
         test_input = test_input.to(torch.bfloat16)
         return test_input

--- a/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
+++ b/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
@@ -10,7 +10,7 @@ from PIL import Image
 from torchvision import transforms
 import requests
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 # TODO: RuntimeError: "nms_kernel" not implemented for 'BFloat16'
@@ -21,13 +21,14 @@ class ThisTester(ModelTester):
         )
         return model  # .to(torch.bfloat16)
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Image preprocessing
         image_url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(image_url, stream=True).raw)
         transform = transforms.Compose([transforms.Resize((320, 320)), transforms.ToTensor()])
         img_tensor = [transform(image).unsqueeze(0)]
         batch_tensor = torch.cat(img_tensor, dim=0)
+        batch_tensor = repeat_inputs(batch_tensor, batch_size)
         return batch_tensor  # .to(torch.bfloat16)
 
 

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -5,7 +5,7 @@
 
 from transformers import AutoProcessor, MusicgenForConditionalGeneration
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -14,7 +14,7 @@ class ThisTester(ModelTester):
         model = MusicgenForConditionalGeneration.from_pretrained("facebook/musicgen-small")
         return model.generate
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         inputs = self.processor(
             text=["80s pop track with bassy drums and synth", "90s rock song with loud guitars and heavy drums"],
             padding=True,
@@ -22,6 +22,7 @@ class ThisTester(ModelTester):
         )
 
         inputs["max_new_tokens"] = 256
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
     def set_model_eval(self, model):

--- a/tests/models/openpose/test_openpose.py
+++ b/tests/models/openpose/test_openpose.py
@@ -7,7 +7,7 @@ import torch
 from pathlib import Path
 from diffusers.utils import load_image
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 dependencies = ["controlnet_aux==0.0.9"]
 
@@ -20,9 +20,10 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         image = load_image("https://huggingface.co/lllyasviel/control_v11p_sd15_openpose/resolve/main/images/input.png")
         arguments = {"input_image": image, "hand_and_face": True}
+        arguments = repeat_inputs(arguments, batch_size)
         return arguments
 
 

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -9,7 +9,7 @@ from PIL import Image
 from pytorchcv.model_provider import get_model as ptcv_get_model
 from torchvision import transforms
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 def get_image_tensor():
@@ -36,10 +36,11 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         input_batch = [get_image_tensor()]
         batch_input = torch.cat(input_batch, dim=0)
         batch_input = batch_input.to(torch.bfloat16)
+        batch_input = repeat_inputs(batch_input, batch_size)
         return batch_input
 
 

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -6,7 +6,7 @@
 import torch
 from transformers import OPTForCausalLM, GPT2Tokenizer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -15,7 +15,7 @@ class ThisTester(ModelTester):
         self.tokenizer = GPT2Tokenizer.from_pretrained("facebook/opt-350m")
         return model.generate
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         prompt = (
             "A chat between a curious human and the Statue of Liberty.\n\nHuman: What is your name?\nStatue: I am the "
             "Statue of Liberty.\nHuman: Where do you live?\nStatue: New York City.\nHuman: How long have you lived "
@@ -26,6 +26,7 @@ class ThisTester(ModelTester):
 
         model_inputs["max_new_tokens"] = 30
         model_inputs["do_sample"] = False
+        model_inputs = repeat_inputs(model_inputs, batch_size)
         return model_inputs
 
     def set_model_eval(self, model):

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -5,7 +5,7 @@
 
 from transformers import PerceiverTokenizer, PerceiverForMaskedLM
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -15,7 +15,7 @@ class ThisTester(ModelTester):
         model = PerceiverForMaskedLM.from_pretrained("deepmind/language-perceiver", torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         text = "This is an incomplete sentence where some words are missing."
         # prepare input
         encoding = self.tokenizer(text, padding="max_length", return_tensors="pt")
@@ -24,6 +24,7 @@ class ThisTester(ModelTester):
         ######inputs, input_mask = encoding.input_ids.to(device), encoding.attention_mask.to(device)
 
         arguments = {"inputs": encoding.input_ids, "attention_mask": encoding.attention_mask}
+        arguments = repeat_inputs(arguments, batch_size)
         return arguments
 
 

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -13,8 +13,8 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
-        inputs = torch.rand((1, 3, 224, 224), dtype=torch.bfloat16)
+    def _load_inputs(self, batch_size):
+        inputs = torch.rand((batch_size, 3, 224, 224), dtype=torch.bfloat16)
         inputs = inputs.to(torch.bfloat16)
         return inputs
 

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -34,18 +34,19 @@ class ThisTester(ModelTester):
 
 
 @pytest.mark.parametrize(
-    "mode",
+    "mode, batch_size",
     [
-        "train",
-        pytest.param("eval", marks=pytest.mark.converted_end_to_end),
+        ("train", 1),
+        # TODO: tt-metal uses batch_size=16, but we OOM. Change to 16 when we don't
+        pytest.param("eval", 4, marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_resnet(record_property, mode):
+def test_resnet(record_property, mode, batch_size):
     model_name = "ResNet50"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
+    tester = ThisTester(model_name, mode, batch_size)
     results = tester.test_model()
     if mode == "eval":
         # Print the top 5 predictions

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -8,7 +8,7 @@ from torchvision import transforms
 from PIL import Image
 
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -19,7 +19,7 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Define a transformation to preprocess the input image using the weights transforms
         preprocess = self.weights.transforms()
 
@@ -29,6 +29,7 @@ class ThisTester(ModelTester):
         img_t = preprocess(image)
         batch_t = torch.unsqueeze(img_t, 0)
         batch_t = batch_t.to(torch.bfloat16)
+        batch_t = repeat_inputs(batch_t, batch_size)
         return batch_t
 
 

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -6,7 +6,7 @@
 from transformers import AutoTokenizer, XLMRobertaForMaskedLM
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -15,8 +15,9 @@ class ThisTester(ModelTester):
         model = XLMRobertaForMaskedLM.from_pretrained("FacebookAI/xlm-roberta-base", torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         inputs = self.tokenizer("The capital of France is <mask>.", return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -7,7 +7,7 @@ from transformers import SegformerImageProcessor, SegformerForSemanticSegmentati
 from PIL import Image
 import requests
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -18,11 +18,12 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
         inputs = self.processor(images=image, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
     def set_inputs_train(self, inputs):

--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -8,7 +8,7 @@ import torch
 import requests
 from PIL import Image
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -21,8 +21,9 @@ class ThisTester(ModelTester):
         predictor.set_image(image)
         return predictor
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         prompt = "Beautiful thing"
+        prompt = repeat_inputs(prompt, batch_size)
         return prompt
 
     def run_model(self, model, inputs):

--- a/tests/models/speecht5_tts/test_speecht5_tts.py
+++ b/tests/models/speecht5_tts/test_speecht5_tts.py
@@ -7,7 +7,7 @@ from transformers import SpeechT5Processor, SpeechT5ForTextToSpeech, SpeechT5Hif
 from datasets import load_dataset
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -17,7 +17,7 @@ class ThisTester(ModelTester):
         self.vocoder = SpeechT5HifiGan.from_pretrained("microsoft/speecht5_hifigan", torch_dtype=torch.bfloat16)
         return model.generate_speech
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         inputs = self.processor(text="Hello, my dog is cute.", return_tensors="pt")
         # load xvector containing speaker's voice characteristics from a dataset
         embeddings_dataset = load_dataset("Matthijs/cmu-arctic-xvectors", split="validation")
@@ -27,6 +27,7 @@ class ThisTester(ModelTester):
             "speaker_embeddings": speaker_embeddings,
             "vocoder": self.vocoder,
         }
+        arguments = repeat_inputs(arguments, batch_size)
         return arguments
 
     def set_model_eval(self, model):

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -6,7 +6,7 @@
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -17,8 +17,9 @@ class ThisTester(ModelTester):
         )
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         inputs = self.tokenizer("Hello, my dog is cute", return_tensors="pt")
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/stable_diffusion/test_stable_diffusion.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion.py
@@ -5,7 +5,7 @@
 from diffusers import StableDiffusionPipeline
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -14,8 +14,9 @@ class ThisTester(ModelTester):
         pipe = StableDiffusionPipeline.from_pretrained(model_id)
         return pipe
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         prompt = "a photo of an astronaut riding a horse on mars"
+        prompt = repeat_inputs(prompt, batch_size)
         return prompt
 
 

--- a/tests/models/stable_diffusion/test_stable_diffusion_v2.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_v2.py
@@ -5,7 +5,7 @@ import torch
 from diffusers import StableDiffusionPipeline, UNet2DConditionModel, LMSDiscreteScheduler
 from transformers import CLIPTextModel, CLIPTokenizer
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -19,7 +19,7 @@ class ThisTester(ModelTester):
         self.scheduler = LMSDiscreteScheduler.from_pretrained("CompVis/stable-diffusion-v1-4", subfolder="scheduler")
         return unet
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Prepare the text prompt
         prompt = "A fantasy landscape with mountains and rivers"
         text_input = self.tokenizer(prompt, return_tensors="pt")
@@ -44,6 +44,7 @@ class ThisTester(ModelTester):
             "timestep": 0,
             "encoder_hidden_states": text_embeddings.to(torch.bfloat16),
         }
+        arguments = repeat_inputs(arguments, batch_size)
         return arguments
 
 

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from transformers import T5Tokenizer, T5ForConditionalGeneration
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -13,9 +13,10 @@ class ThisTester(ModelTester):
         model = T5ForConditionalGeneration.from_pretrained(self.model_name, torch_dtype=torch.bfloat16)
         return model.generate
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         self.input_text = "translate English to French: How are you?"
         input_ids = self.tokenizer.encode(self.input_text, return_tensors="pt")
+        input_ids = repeat_inputs(input_ids, batch_size)
         return input_ids
 
     def set_model_eval(self, model):

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -8,7 +8,7 @@ from urllib.request import urlopen
 from PIL import Image
 import torch
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 dependencies = ["timm==1.0.9"]
 
@@ -21,7 +21,7 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         import timm
 
         img = Image.open(
@@ -34,6 +34,7 @@ class ThisTester(ModelTester):
         transforms = timm.data.create_transform(**data_config, is_training=False)
         input_batch = transforms(img).unsqueeze(0)  # unsqueeze single image into batch of 1
         input_batch = input_batch.to(torch.bfloat16)
+        input_batch = repeat_inputs(input_batch, batch_size)
         return input_batch
 
 

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -11,13 +11,13 @@ from tests.utils import ModelTester, repeat_inputs
 
 class ThisTester(ModelTester):
     # pass model_info instead of model_name
-    def __init__(self, model_info, mode):
+    def __init__(self, model_info, mode, batch_size=1):
         if mode not in ["train", "eval"]:
             raise ValueError(f"Current mode is not supported: {mode}")
         self.model_info = model_info
         self.mode = mode
         self.model = self._load_model()
-        self.inputs = self._load_inputs()
+        self.inputs = self._load_inputs(batch_size)
 
     def _load_model(self):
         model_name, weights_name = self.model_info

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -17,7 +17,8 @@ class ThisTester(ModelTester):
         self.model_info = model_info
         self.mode = mode
         self.model = self._load_model()
-        self.inputs = self._load_inputs(batch_size)
+        self.batch_size = batch_size
+        self.inputs = self._load_inputs(self.batch_size)
 
     def _load_model(self):
         model_name, weights_name = self.model_info

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -6,7 +6,7 @@ from PIL import Image
 import torch
 import requests
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -25,13 +25,14 @@ class ThisTester(ModelTester):
         model = models.get_model(model_name, weights=self.weights).to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         preprocess = self.weights.transforms()
         # Load and preprocess the image
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
         img_t = preprocess(image)
         batch_t = torch.unsqueeze(img_t, 0).to(torch.bfloat16)
+        batch_t = repeat_inputs(batch_t, batch_size)
         return batch_t
 
 

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -18,7 +18,8 @@ class ThisTester(ModelTester):
         self.model_info = model_info
         self.mode = mode
         self.model = self._load_model()
-        self.inputs = self._load_inputs(batch_size)
+        self.batch_size = batch_size
+        self.inputs = self._load_inputs(self.batch_size)
 
     def _load_model(self):
         model_name, weights_name = self.model_info

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -6,7 +6,7 @@ from PIL import Image
 import torch
 import requests
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 # TODO: RuntimeError: "nms_kernel" not implemented for 'BFloat16'
@@ -26,13 +26,14 @@ class ThisTester(ModelTester):
         model = getattr(models.detection, model_name)(weights=self.weights)  # .to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         preprocess = self.weights.transforms()
         # Load and preprocess the image
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
         img_t = preprocess(image)
         batch_t = torch.unsqueeze(img_t, 0)  # .to(torch.bfloat16)
+        batch_t = repeat_inputs(batch_t, batch_size)
         return batch_t
 
 

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -12,13 +12,13 @@ from tests.utils import ModelTester, repeat_inputs
 # TODO: RuntimeError: "nms_kernel" not implemented for 'BFloat16'
 class ThisTester(ModelTester):
     # pass model_info instead of model_name
-    def __init__(self, model_info, mode):
+    def __init__(self, model_info, mode, batch_size=1):
         if mode not in ["train", "eval"]:
             raise ValueError(f"Current mode is not supported: {mode}")
         self.model_info = model_info
         self.mode = mode
         self.model = self._load_model()
-        self.inputs = self._load_inputs()
+        self.inputs = self._load_inputs(batch_size)
 
     def _load_model(self):
         model_name, weights_name = self.model_info

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -10,7 +10,7 @@ from torchvision import transforms
 import requests
 import torch
 import pytest
-from tests.utils import ModelTester, get_cached_image_or_reload
+from tests.utils import ModelTester, get_cached_image_or_reload, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -27,7 +27,7 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         image_file = get_cached_image_or_reload(
             relative_cache_path="inputs/TCGA_CS_4944.png",
             url="https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png",
@@ -43,6 +43,7 @@ class ThisTester(ModelTester):
         input_tensor = preprocess(input_image)
         input_batch = input_tensor.unsqueeze(0)
         input_batch = input_batch.to(torch.bfloat16)
+        input_batch = repeat_inputs(input_batch, batch_size)
         return input_batch
 
 

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -7,7 +7,7 @@ import numpy as np
 from PIL import Image
 from torchvision import transforms
 import pytest
-from tests.utils import ModelTester, get_cached_image_or_reload
+from tests.utils import ModelTester, get_cached_image_or_reload, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -28,7 +28,7 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         filename = get_cached_image_or_reload(
             relative_cache_path="inputs/TCGA_CS_4944.png",
             url="https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png",
@@ -45,6 +45,7 @@ class ThisTester(ModelTester):
         input_tensor = preprocess(input_image)
         input_batch = input_tensor.unsqueeze(0)
         input_batch = input_batch.to(torch.bfloat16)
+        input_batch = repeat_inputs(input_batch, batch_size)
         return input_batch
 
 

--- a/tests/models/unet_carvana/test_unet_carvana.py
+++ b/tests/models/unet_carvana/test_unet_carvana.py
@@ -21,8 +21,8 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
-        input_batch = torch.rand((1, 3, 224, 224))
+    def _load_inputs(self, batch_size):
+        input_batch = torch.rand((batch_size, 3, 224, 224))
         input_batch = input_batch.to(torch.bfloat16)
         return input_batch
 

--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -7,7 +7,7 @@ from transformers import ViltProcessor, ViltForQuestionAnswering
 import requests
 from PIL import Image
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -17,7 +17,7 @@ class ThisTester(ModelTester):
         model = ViltForQuestionAnswering.from_pretrained("dandelin/vilt-b32-finetuned-vqa", torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # prepare image + question
         url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         image = Image.open(requests.get(url, stream=True).raw)
@@ -25,6 +25,7 @@ class ThisTester(ModelTester):
         # prepare inputs
         encoding = self.processor(image, text, return_tensors="pt")
         encoding["pixel_values"] = encoding["pixel_values"].to(torch.bfloat16)
+        encoding = repeat_inputs(encoding, batch_size)
         return encoding
 
 

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -4,7 +4,7 @@
 from transformers import WhisperProcessor, WhisperForConditionalGeneration
 from datasets import load_dataset
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 import torch
 
 
@@ -16,13 +16,14 @@ class ThisTester(ModelTester):
         model.config.forced_decoder_ids = None
         return model.generate
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # load dummy dataset and read audio files
         ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
         sample = ds[0]["audio"]
         input_features = self.processor(
             sample["array"], sampling_rate=sample["sampling_rate"], return_tensors="pt"
         ).input_features
+        input_features = repeat_inputs(input_features, batch_size)
         return input_features.to(torch.bfloat16)
 
     def run_model(self, model, input_features):

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 
 from transformers import XGLMTokenizer, XGLMForCausalLM
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -17,11 +17,12 @@ class ThisTester(ModelTester):
         model = XGLMForCausalLM.from_pretrained("facebook/xglm-564M", torch_dtype=torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         inputs = self.tokenizer(
             "I wanted to conserve energy.\nI swept the floor in the unoccupied room.", return_tensors="pt"
         )
         inputs["labels"] = inputs["input_ids"]
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -8,7 +8,7 @@ import requests
 
 # Load model directly
 from transformers import AutoImageProcessor, AutoModelForObjectDetection
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 
 class ThisTester(ModelTester):
@@ -21,12 +21,13 @@ class ThisTester(ModelTester):
         m = AutoModelForObjectDetection.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return m
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Set up sample input
         self.test_input = "http://images.cocodataset.org/val2017/000000039769.jpg"
         self.image = Image.open(requests.get(self.test_input, stream=True).raw)
         inputs = self.image_processor(images=self.image, return_tensors="pt")
         inputs["pixel_values"] = inputs["pixel_values"].to(torch.bfloat16)
+        inputs = repeat_inputs(inputs, batch_size)
         return inputs
 
 

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -51,7 +51,7 @@ class ThisTester(ModelTester):
 
 @pytest.mark.parametrize(
     "mode",
-    [pytest.param("eval", marks=pytest.mark.compilation_xfail(reason="OOM with preprocessed conv"))],
+    ["eval"],
 )
 def test_yolov3(record_property, mode):
     model_name = "YOLOv3"

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import os
 import pytest
-from tests.utils import ModelTester
+from tests.utils import ModelTester, repeat_inputs
 
 dependencies = ["ultralytics==8.2.92", "ultralytics-thop==2.0.6"]
 
@@ -22,13 +22,14 @@ class ThisTester(ModelTester):
         )
         return model.to(torch.bfloat16)
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         # Image preprocessing
         image_url = "https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg"
         image = Image.open(requests.get(image_url, stream=True).raw)
         transform = transforms.Compose([transforms.Resize((512, 512)), transforms.ToTensor()])
         img_tensor = [transform(image).unsqueeze(0)]
         batch_tensor = torch.cat(img_tensor, dim=0)
+        batch_tensor = repeat_inputs(batch_tensor, batch_size)
         return batch_tensor.to(torch.bfloat16)
 
 

--- a/tests/multi_device/test_multi_bert.py
+++ b/tests/multi_device/test_multi_bert.py
@@ -56,13 +56,17 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
+@pytest.mark.parametrize(
+    "batch_size",
+    [2],
+)
 @pytest.mark.converted_end_to_end
-def test_bert(record_property, mode):
+def test_bert(record_property, mode, batch_size):
     model_name = "BERT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
+    tester = ThisTester(model_name, mode, batch_size)
     results = tester.test_model()
 
     if mode == "eval":

--- a/tests/multi_device/test_multi_bert.py
+++ b/tests/multi_device/test_multi_bert.py
@@ -20,9 +20,10 @@ class ThisTester(ModelTester):
         m = AutoModelForQuestionAnswering.from_pretrained(model_name, torch_dtype=torch.bfloat16)
         return m
 
-    def _load_inputs(self):
-        # Set up sample input
-        batch_size = 2
+    def _load_inputs(self, batch_size):
+        # temp fixup batch_size
+        if batch_size == 1:
+            batch_size = 2
         this_file_path = os.path.dirname(__file__)
         input_path = os.path.join(this_file_path, "../inputs/bert/input_data.json")
         with open(input_path) as f:

--- a/tests/multi_device/test_multi_mnist.py
+++ b/tests/multi_device/test_multi_mnist.py
@@ -44,10 +44,13 @@ class ThisTester(ModelTester):
         model = model.to(torch.bfloat16)
         return model
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
+        # temp fixup batch_size
+        if batch_size == 1:
+            batch_size = 2
         transform = transforms.Compose([transforms.ToTensor()])
         test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
-        dataloader = DataLoader(test_dataset, batch_size=2)
+        dataloader = DataLoader(test_dataset, batch_size=batch_size)
         test_input, _ = next(iter(dataloader))
         test_input = test_input.to(torch.bfloat16)
         return test_input

--- a/tests/multi_device/test_multi_mnist.py
+++ b/tests/multi_device/test_multi_mnist.py
@@ -45,9 +45,6 @@ class ThisTester(ModelTester):
         return model
 
     def _load_inputs(self, batch_size):
-        # temp fixup batch_size
-        if batch_size == 1:
-            batch_size = 2
         transform = transforms.Compose([transforms.ToTensor()])
         test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
         dataloader = DataLoader(test_dataset, batch_size=batch_size)
@@ -60,12 +57,13 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_mnist_train(record_property, mode):
+@pytest.mark.parametrize("batch_size", [2])
+def test_mnist_train(record_property, mode, batch_size):
     model_name = "Mnist"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
-    tester = ThisTester(model_name, mode)
+    tester = ThisTester(model_name, mode, batch_size)
     results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,18 +11,19 @@ from typing import List, Dict, Tuple
 
 
 class ModelTester:
-    def __init__(self, model_name, mode):
+    def __init__(self, model_name, mode, batch_size=1):
         if mode not in ["train", "eval"]:
             raise ValueError(f"Current mode is not supported: {mode}")
         self.model_name = model_name
         self.mode = mode
         self.model = self._load_model()
-        self.inputs = self._load_inputs()
+        self.batch_size = batch_size
+        self.inputs = self._load_inputs(self.batch_size)
 
     def _load_model(self):
         raise NotImplementedError("This method should be implemented in the derived class")
 
-    def _load_inputs(self):
+    def _load_inputs(self, batch_size):
         raise NotImplementedError("This method should be implemented in the derived class")
 
     def set_model_train(self, model):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -156,7 +156,8 @@ def repeat_inputs(inputs, batch_size):
     if hasattr(inputs, "keys"):
         for key in inputs.keys():
             if isinstance(inputs[key], torch.Tensor):
-                inputs[key] = inputs[key].repeat(batch_size, 1)
+                repeat_size = [batch_size] + ([1] * (inputs[key].dim() - 1))
+                inputs[key] = inputs[key].repeat(*repeat_size)
         return inputs
     elif isinstance(inputs, torch.Tensor):
         repeat_size = [batch_size] + ([1] * (inputs.dim() - 1))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -152,11 +152,12 @@ class ModelTester:
 
 def repeat_inputs(inputs, batch_size):
     if batch_size is None:
-        return
+        return None
     if hasattr(inputs, "keys"):
         for key in inputs.keys():
             if isinstance(inputs[key], torch.Tensor):
                 inputs[key] = inputs[key].repeat(batch_size, 1)
+        return inputs
     elif isinstance(inputs, torch.Tensor):
         repeat_size = [batch_size] + ([1] * (inputs.dim() - 1))
         inputs = inputs.repeat(*repeat_size)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -150,6 +150,21 @@ class ModelTester:
             raise ValueError(f"Current mode is not supported: {self.mode}")
 
 
+def repeat_inputs(inputs, batch_size):
+    if batch_size is None:
+        return
+    if hasattr(inputs, "keys"):
+        for key in inputs.keys():
+            if isinstance(inputs[key], torch.Tensor):
+                inputs[key] = inputs[key].repeat(batch_size, 1)
+    elif isinstance(inputs, torch.Tensor):
+        repeat_size = [batch_size] + ([1] * (inputs.dim() - 1))
+        inputs = inputs.repeat(*repeat_size)
+        return inputs
+    else:
+        raise TypeError(f"Inputs type not supported for batching: {type(inputs)}")
+
+
 def get_absolute_cache_path(path_relative_to_cache):
     # convenience method to use NFS if available
     nfs_cache_base = "/mnt/tt-metal-pytorch-cache/.cache"

--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -34,13 +34,17 @@ csv_header_mappings = {
         "To/From Device Ops",
         "The number of `to/from_device` operations (data transfer to/from the device).",
     ),
-    "original_run_time": (
-        "Original Run Time (ms)",
-        "Execution time (in seconds) of the model before conversion.",
+    "original_throughput": (
+        "Original Throughput (Inferences Per Second)",
+        "Execution throughput (in inferences per second) of the model before conversion.",
     ),
-    "compiled_run_time": (
-        "Compiled Run Time for 5th Iteration (ms)",
-        "Execution time (in seconds) of the model after conversion for the 5th iteration.",
+    "compiled_first_run": (
+        "Compiled First Run",
+        "Time until the first compiled run finishes (ms), including compilation time and warming caches.",
+    ),
+    "compiled_throughput": (
+        "Compiled Throughput (Inferences Per Second)",
+        "Execution throughput (in inferences per second) of the model after conversion once caches are warm.",
     ),
     "accuracy": (
         "Accuracy (%)",
@@ -482,14 +486,17 @@ if __name__ == "__main__":
         pydantic_model = pydantic_models.ModelRun(name=model)
 
         # Rename run_time keys to distinguish between original or compiled
+        batch_size = original_runtime_metrics["batch_size"]
+        pydantic_model.batch_size = batch_size
         if "run_time" in original_runtime_metrics:
             run_time = original_runtime_metrics.pop("run_time")
-            original_runtime_metrics["original_run_time"] = run_time
+            original_runtime_metrics["original_throughput"] = batch_size / run_time
             pydantic_model.original_run_time = float(run_time)
         if "run_time" in compiled_runtime_metrics:
             run_time = compiled_runtime_metrics.pop("run_time")
-            compiled_runtime_metrics["compiled_run_time"] = run_time
+            compiled_runtime_metrics["compiled_throughput"] = batch_size / run_time
             pydantic_model.compiled_run_time = float(run_time)
+        compiled_runtime_metrics["compiled_first_run"] = compiled_runtime_metrics["run_time_first_iter"]
 
         # Replace compiled runtime with average if available
         if "avg_run_time" in compiled_runtime_metrics:

--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -34,6 +34,10 @@ csv_header_mappings = {
         "To/From Device Ops",
         "The number of `to/from_device` operations (data transfer to/from the device).",
     ),
+    "batch_size": (
+        "Batch",
+        "Batch size used for inference",
+    ),
     "original_throughput": (
         "Original Throughput (Inferences Per Second)",
         "Execution throughput (in inferences per second) of the model before conversion.",

--- a/tools/data_collection/pydantic_models.py
+++ b/tools/data_collection/pydantic_models.py
@@ -48,6 +48,7 @@ class ModelRun(BaseModel):
         None,
         description="What is the peak SRAM usage (in MB) for a model during its execution phase.",
     )
+    batch_size: int = Field(1, description="Batch size of model inputs.")
 
 
 class TensorDesc(BaseModel):


### PR DESCRIPTION
Changing batch size can greatly impact both throughput and TTFT for models.
This PR:
* Adds the ability to set batch_size in `_load_inputs` for each model
* Matches the batch sizes listed for tt-metal's front page as closely as possible (sometimes we need to choose a lower batch size to not hit an OOM)
* Adds batch size and throughput to the README for reporting performance, as well as an approximation of TTFT

Note that all models have batch_size=1 in this PR except ResNet50 and BERT (4 and 8 respectively). This PR just attempts to match batch size for models on the tt-metal front page. Increasing batch sizes for other models will be left for another PR.