### PR TITLE
String formatting fix in export code

### DIFF
--- a/tools/export_code.py
+++ b/tools/export_code.py
@@ -206,6 +206,8 @@ def _format_dict(obj):
     for k, v in obj.items():
         if k == "device" and isinstance(v, torch.device):
             v = f'"{v}"'
+        elif isinstance(v, str):  # Handle string values
+            v = f'"{v}"'
         to_kwargs.append(f"{k} = {v}")
     return ", ".join(to_kwargs)
 


### PR DESCRIPTION
### Problem description
When running `pytest tests/models/bert/test_bert.py --export_code profliling`
And then tracy `python -m tracy -r -v -p -o BERT tests/export_code/profiling/BERT_code.py`

The formatting of the generated code has an issue with function arguments which are strings.   In the BERT case, this translates to passing `ttnn.linear(. . . , activation = gelu)` when the correct syntax is: `ttnn.linear(. . . , activation = "gelu")`, with the argument being expressed as a string.  

This throws an error when tracy is called on the generated code.


### What's changed
Added explicit string handling in the formatting function `_format_dict(obj)`, checking if the attribute is a string, and making sure quotes are written to the file if it is.
