### PR TITLE
Workflows - update-readme: Add permissions that seem to be missing

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -21,6 +21,12 @@ jobs:
 
   approve-pr:
     name: "Approve and Merge PR"
+    permissions:
+      actions: read
+      contents: write
+      pages: write
+      pull-requests: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: create-pr
     if: ${{ needs.create-pr.outputs.pull_request_number }}


### PR DESCRIPTION
Pretty sure the token involved here doesn't have the ability to grant `gh` the power to do the approval as it is, I believe this sorts it.

### Ticket
Link to Github Issue

### Problem description
Provide context for the problem

### What's changed
Describe the approach used to solve the problem.
Summarize the changes made and their impact
