### PR TITLE
Do not use in-place attention softmax operation

### DIFF
--- a/torch_ttnn/passes/lowering/add_data_move_pass.py
+++ b/torch_ttnn/passes/lowering/add_data_move_pass.py
@@ -185,7 +185,7 @@ TTNN_MAYBE_ROW_OPS = set(
 
 TTNN_TRANSFORMER_OPS = [
     ttnn.transformer.scaled_dot_product_attention,
-    ttnn.transformer.attention_softmax_,
+    ttnn.transformer.attention_softmax,
     ttnn.transformer.split_query_key_value_and_split_heads,
     ttnn.transformer.concatenate_heads,
 ]

--- a/torch_ttnn/passes/patterns/attention_pattern.py
+++ b/torch_ttnn/passes/patterns/attention_pattern.py
@@ -53,7 +53,7 @@ class AttentionPatterns(PatternMatcherBase):
                     continue
 
                 # Check if view output goes to softmax and get the mask if it exists
-                softmax = self._find_exclusive_user_of_type(view1, ttnn.transformer.attention_softmax_)
+                softmax = self._find_exclusive_user_of_type(view1, ttnn.transformer.attention_softmax)
                 if not softmax:
                     continue
 
@@ -288,7 +288,7 @@ class AttentionPatterns(PatternMatcherBase):
                 )
 
                 attention_probabilities_node = self.gm.graph.call_function(
-                    ttnn.transformer.attention_softmax_,
+                    ttnn.transformer.attention_softmax,
                     args=(attention_scores_node,),
                     kwargs={
                         "attention_mask": attn_mask,

--- a/torch_ttnn/passes/patterns/soft_max_pattern.py
+++ b/torch_ttnn/passes/patterns/soft_max_pattern.py
@@ -23,7 +23,7 @@ class SoftMaxPatterns(PatternMatcherBase):
         3. Numerically stable softmax computation
 
         The expected output will be:
-        ttnn.transformer.attention_softmax_(input_tensor, head_size, attention_mask)
+        ttnn.transformer.attention_softmax(input_tensor, head_size, attention_mask)
 
         Please note that we are doing this in place
         """
@@ -72,7 +72,7 @@ class SoftMaxPatterns(PatternMatcherBase):
                 head_size = None if scale is None else (int(1 / (scale * scale)) if scale < 1 else int(scale))
                 attention_mask = add.args[1]
                 fused_node = self.gm.graph.call_function(
-                    ttnn.transformer.attention_softmax_,
+                    ttnn.transformer.attention_softmax,
                     args=(input_tensor,),
                     kwargs={"head_size": head_size, "attention_mask": attention_mask},
                 )


### PR DESCRIPTION
This fixes the issue where calling deallocate didn't actually deallocate the softmax tensor since we were previously using the in-place operation

The previous bug caused an issue for L1 memory configs since memory wasn't actually deallocated when tensor.deallocate() was called. This PR changes the op so memory will be deallocated
