### PR TITLE
Migrate multi device tests to CIv2

### DIFF
--- a/.github/actions/common_cleanup/action.yaml
+++ b/.github/actions/common_cleanup/action.yaml
@@ -6,6 +6,7 @@ runs:
     - name: Cleanup model cache
       shell: bash
       run: |
+        pip cache dir
         df -h
         python3 -m pip cache purge
         # python3 tools/huggingface_delete_cache.py

--- a/.github/actions/common_cleanup/action.yaml
+++ b/.github/actions/common_cleanup/action.yaml
@@ -6,7 +6,6 @@ runs:
     - name: Cleanup model cache
       shell: bash
       run: |
-        pip cache dir
         df -h
         python3 -m pip cache purge
         # python3 tools/huggingface_delete_cache.py

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -21,7 +21,7 @@ runs:
         id -u
         id -g
         df -h
-        ls -l /__w/pytorch2.0_ttnn/pytorch2.0_ttnn/.pip_cache
+        ls -l /opt/runner/_work/pytorch2.0_ttnn/pytorch2.0_ttnn/.pip_cache
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -18,6 +18,8 @@ runs:
       shell: bash
       run: |
         df -h
+        python3 -m venv .venv
+        source .venv/bin/activate
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -18,8 +18,8 @@ runs:
       shell: bash
       run: |
         df -h
-        python3 -m venv .venv
-        source .venv/bin/activate
+        export PIP_CACHE_DIR=$HOME/.pip_cache
+        mkdir -p $PIP_CACHE_DIR
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -18,8 +18,6 @@ runs:
       shell: bash
       run: |
         df -h
-        export PIP_CACHE_DIR=$HOME/.pip_cache
-        mkdir -p $PIP_CACHE_DIR
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -17,16 +17,11 @@ runs:
     - name: Install Dependencies
       shell: bash
       run: |
-        whoami
-        id -u
-        id -g
         df -h
-        ls -l ${{ env.PIP_CACHE_DIR }}
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt
         python3 -m pip install pytest-github-report
-        pip cache dir
         df -h
 
     - uses: ./.github/actions/common_cleanup

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -17,6 +17,9 @@ runs:
     - name: Install Dependencies
       shell: bash
       run: |
+        whoami
+        id -u
+        id -g
         df -h
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -21,7 +21,7 @@ runs:
         id -u
         id -g
         df -h
-        ls -l /opt/runner/_work/pytorch2.0_ttnn/pytorch2.0_ttnn/.pip_cache
+        ls -l ${{ env.PIP_CACHE_DIR }}
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -5,6 +5,12 @@ runs:
   steps:
     - name: Setup Telemetry
       uses: catchpoint/workflow-telemetry-action@v2
+    - name: Create pip cache
+      shell: bash
+      run: |
+        if [ -n "${{ env.PIP_CACHE_DIR }}" ]; then
+          mkdir -p ${{ env.PIP_CACHE_DIR }}
+        fi
 
     - name: Setup Python 3.10
       uses: actions/setup-python@v5

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -21,6 +21,7 @@ runs:
         id -u
         id -g
         df -h
+        ls -l /__w/pytorch2.0_ttnn/pytorch2.0_ttnn/.pip_cache
         python3 -m pip install --upgrade pip                    
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt

--- a/.github/actions/common_repo_setup/action.yaml
+++ b/.github/actions/common_repo_setup/action.yaml
@@ -24,6 +24,7 @@ runs:
         python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
         python3 -m pip install -r requirements-dev.txt
         python3 -m pip install pytest-github-report
+        pip cache dir
         df -h
 
     - uses: ./.github/actions/common_cleanup

--- a/.github/workflows/run-accuracy-tests.yaml
+++ b/.github/workflows/run-accuracy-tests.yaml
@@ -55,6 +55,7 @@ jobs:
       pytest_verbosity: 0
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +95,7 @@ jobs:
       groups: ${{ steps.calculate-groups.outputs.groups }}
     env:
       PYTHONPATH: ${{ github.workspace }}
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/common_repo_setup        
@@ -133,6 +135,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -187,6 +187,7 @@ jobs:
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
       PIP_CACHE_DIR: ${{ github.workspace }}/.pip_cache
+      AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/tools
     # defaults:
     #   run:
     #     shell: bash

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -156,44 +156,29 @@ jobs:
         run: |
           echo "branch-name=update-docs-$(date +%s)" >> $GITHUB_OUTPUT
 
-  set:
-    runs-on: ubuntu-latest
-    outputs:
-      runner-uid: ${{ steps.run.outputs.runner-uid }}
-      runner-gid: ${{ steps.run.outputs.runner-gid }}
-    steps:
-      - name: run
-        id: run
-        shell: bash
-        run: |
-          echo "runner-uid=$(id -u)" >> $GITHUB_OUTPUT
-          echo "runner-gid=$(id -g)" >> $GITHUB_OUTPUT
-
-
   multi-device-tests:
     # needs: lowering-tests
-    needs: set
     runs-on: >-
       ${{
         ('tt-beta-ubuntu-2204-n300-large-stable')
         || fromJSON('["n300", "in-service", "nfs"]')
       }}
-    container: 
-      image: ${{ inputs.docker_tag }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GH_TOKEN }}
-      options: >-
-        --rm 
-        -u ${{ needs.set.outputs.runner-uid }}:${{ needs.set.outputs.runner-gid }}
-        -v /etc/passwd:/etc/passwd:ro
-        -v /etc/shadow:/etc/shadow:ro
-        -v /etc/bashrc:/etc/bashrc:ro
-        -v /dev/hugepages-1G:/dev/hugepages-1G 
-        -v ${{ github.workspace }}:${{ github.workspace }}
-        --device /dev/tenstorrent
-        -w ${{ github.workspace }}
-        -e HOME=${{ github.workspace }}
+    # container: 
+    #   image: ${{ inputs.docker_tag }}
+    #   credentials:
+    #     username: ${{ github.actor }}
+    #     password: ${{ secrets.GH_TOKEN }}
+    #   options: >-
+    #     --rm 
+    #     -u ${{ needs.set.outputs.runner-uid }}:${{ needs.set.outputs.runner-gid }}
+    #     -v /etc/passwd:/etc/passwd:ro
+    #     -v /etc/shadow:/etc/shadow:ro
+    #     -v /etc/bashrc:/etc/bashrc:ro
+    #     -v /dev/hugepages-1G:/dev/hugepages-1G 
+    #     -v ${{ github.workspace }}:${{ github.workspace }}
+    #     --device /dev/tenstorrent
+    #     -w ${{ github.workspace }}
+    #     -e HOME=${{ github.workspace }}
     env:
       pytest_verbosity: 0
       pytest_report_title: "⭐️ Multi-Device Tests"
@@ -204,10 +189,99 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - uses: ./.github/actions/common_repo_setup
-      - uses: ./.github/actions/common_multi_device_tests
+      # copied from common_repo_setup
+      - name: Setup Python 3.10
+        uses: actions/setup-python@v5
         with:
-          commit_report: ${{ inputs.commit_report }}
+          python-version: '3.10'
+      - name: Set
+        shell: bash
+        run: |
+          echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
+          echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
+      # - name: Docker login
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: https://ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GH_TOKEN }}
+      - uses: tenstorrent/docker-run-action@v5
+        with:
+          shell: bash
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+          registry: ghcr.io
+          image: ${{ inputs.docker_tag }}
+          # The most important option below is `--rm`. Otherwise, the machines will fill up with undeleted containers.
+          # The mounting of /etc/passwd, /etc/shadow, and /etc/bashrc is required in order for the correct file permissions
+          # for newly created files.
+          # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which
+          # may not be writable by the RUNNER_UID user.
+          # --log-driver none: Do not save logs to disk by default as we're printing them to GitHub Actions UI already
+          # and it takes up space on the runner. What can happen is that we can eat up all the space of a runner while it's
+          # spitting our endless logs, causing the runner being unable to call home, resulting in job failures / runner
+          # offline status on GitHub. Issue tt-metal/#12626
+          options: |
+            -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
+            --rm
+            -v /etc/passwd:/etc/passwd:ro
+            -v /etc/shadow:/etc/shadow:ro
+            -v /etc/bashrc:/etc/bashrc:ro
+            -v ${{ github.workspace }}:${{ github.workspace }}
+            --net=host
+            --log-driver local
+            --log-opt max-size=50m
+            ${{ inputs.docker_opts }}
+            -e PYTHONPATH=${{ github.workspace }}
+            -e HOME=${{ github.workspace }}
+            -e GITHUB_ACTIONS=true
+            -e CI=true
+            -e GITHUB_REPOSITORY=${{ github.repository }}
+            -e GITHUB_SHA=${{ github.sha }}
+            -e GITHUB_REF_NAME=${{ github.ref_name }}
+            -e GITHUB_RUN_ID=${{ github.run_id }}
+            -e GITHUB_TRIGGERING_ACTOR=${{ github.github_triggering_actor }}
+            -e RUNNER_NAME=${{ runner.name }}
+            --device /dev/tenstorrent
+            -w ${{ github.workspace }}
+          run: |
+            set -eu
+
+            # from common repo setup
+            df -h
+            python3 -m pip install --upgrade pip                    
+            python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
+            python3 -m pip install -r requirements-dev.txt
+            python3 -m pip install pytest-github-report
+            df -h
+
+            # from common multi device tests
+            if [ "${{ inputs.commit_report }}" == "None" ]; then
+              num_iterations=1
+            else
+              num_iterations=5
+            fi
+            python3 -m pytest --github-report tests/multi_device/ --data_parallel --report_nth_iteration=$num_iterations --export_code=accuracy -s
+            exit_code=$?  # Capture the exit code
+            if [ $exit_code -eq 5 ]; then
+              echo "Error: pytest returned exit code 5 (No tests to run) in the first test group.";
+              exit 1;  # Fail the workflow
+            elif [ $exit_code -ne 0 ]; then
+              echo "Failure: Tests failed with exit code $exit_code.";
+              exit 1;  # Fail the workflow for other errors
+            fi
+            echo "Success: Tests passed!";
+            ls -l
+            cd metrics
+            ls -l
+            cd ..
+            exit 0;
+
+      # - uses: ./.github/actions/common_repo_setup
+      - uses: ./.github/actions/common_cleanup
+      # - uses: ./.github/actions/common_multi_device_tests
+      #   with:
+      #     commit_report: ${{ inputs.commit_report }}
       - name: Upload Metrics Artifact
         if: success()  # Only run if tests passed
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -186,7 +186,7 @@ jobs:
       pytest_report_title: "⭐️ Multi-Device Tests"
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
-      PIP_CACHE_DIR: ${{ github.workspace }}/.pip_cache
+      PIP_CACHE_DIR: ${{ github.workspace }}/pip_cache/.pip_cache
       AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/tools
     # defaults:
     #   run:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -186,11 +186,15 @@ jobs:
       pytest_report_title: "⭐️ Multi-Device Tests"
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
+      PIP_CACHE_DIR: /work/.pip_cache
     # defaults:
     #   run:
     #     shell: bash
     #     working-directory: /work
     steps:
+      - name: Create pip cache
+        shell: bash
+        run: mkdir -p ${{ env.PIP_CACHE_DIR }}
       - uses: actions/checkout@v4
       # copied from common_repo_setup
       # - name: Setup Python 3.10

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -161,7 +161,7 @@ jobs:
     runs-on: >-
       ${{
         ('tt-beta-ubuntu-2204-n300-large-stable')
-        || fromJSON('["n300", "in-service", "cloud-virtual-machine"]')
+        || ["in-service", "nfs", "n300"]
       }}
     container: 
       image: ${{ inputs.docker_tag }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -191,9 +191,6 @@ jobs:
         working-directory: /work
     steps:
       - uses: actions/checkout@v4
-        with:
-          lfs: true
-          fetch-depth: 0
       # copied from common_repo_setup
       - name: Setup Python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -163,22 +163,21 @@ jobs:
         ('tt-beta-ubuntu-2204-n300-large-stable')
         || fromJSON('["n300", "in-service", "nfs"]')
       }}
-    # container: 
-    #   image: ${{ inputs.docker_tag }}
-    #   credentials:
-    #     username: ${{ github.actor }}
-    #     password: ${{ secrets.GH_TOKEN }}
-    #   options: >-
-    #     --rm 
-    #     -u ${{ needs.set.outputs.runner-uid }}:${{ needs.set.outputs.runner-gid }}
-    #     -v /etc/passwd:/etc/passwd:ro
-    #     -v /etc/shadow:/etc/shadow:ro
-    #     -v /etc/bashrc:/etc/bashrc:ro
-    #     -v /dev/hugepages-1G:/dev/hugepages-1G 
-    #     -v ${{ github.workspace }}:${{ github.workspace }}
-    #     --device /dev/tenstorrent
-    #     -w ${{ github.workspace }}
-    #     -e HOME=${{ github.workspace }}
+    container: 
+      image: ${{ inputs.docker_tag }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GH_TOKEN }}
+      options: >-
+        --rm 
+        -v /etc/passwd:/etc/passwd:ro
+        -v /etc/shadow:/etc/shadow:ro
+        -v /etc/bashrc:/etc/bashrc:ro
+        -v /dev/hugepages-1G:/dev/hugepages-1G 
+        -v ${{ github.workspace }}:${{ github.workspace }}
+        --device /dev/tenstorrent
+        -w ${{ github.workspace }}
+        -e HOME=${{ github.workspace }}
     env:
       pytest_verbosity: 0
       pytest_report_title: "⭐️ Multi-Device Tests"
@@ -194,104 +193,103 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - name: Set
-        shell: bash
-        run: |
-          echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
-          echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
+      # - name: Set
+      #   shell: bash
+      #   run: |
+      #     echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
+      #     echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
+      # # - name: Docker login
+      # #   uses: docker/login-action@v3
+      # #   with:
+      # #     registry: https://ghcr.io
+      # #     username: ${{ github.actor }}
+      # #     password: ${{ secrets.GH_TOKEN }}
       # - name: Docker login
       #   uses: docker/login-action@v3
       #   with:
       #     registry: https://ghcr.io
       #     username: ${{ github.actor }}
       #     password: ${{ secrets.GH_TOKEN }}
-      - name: Docker login
-        uses: docker/login-action@v3
-        with:
-          registry: https://ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
-      - name: Pull docker image
-        shell: bash
-        run: |
-          docker pull ${{ inputs.docker_tag }}
-      - uses: tenstorrent/docker-run-action@v5
-        with:
-          shell: bash
-          username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
-          registry: ghcr.io
-          image: ${{ inputs.docker_tag }}
-          # The most important option below is `--rm`. Otherwise, the machines will fill up with undeleted containers.
-          # The mounting of /etc/passwd, /etc/shadow, and /etc/bashrc is required in order for the correct file permissions
-          # for newly created files.
-          # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which
-          # may not be writable by the RUNNER_UID user.
-          # --log-driver none: Do not save logs to disk by default as we're printing them to GitHub Actions UI already
-          # and it takes up space on the runner. What can happen is that we can eat up all the space of a runner while it's
-          # spitting our endless logs, causing the runner being unable to call home, resulting in job failures / runner
-          # offline status on GitHub. Issue tt-metal/#12626
-          options: |
-            -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
-            --rm
-            -v /etc/passwd:/etc/passwd:ro
-            -v /etc/shadow:/etc/shadow:ro
-            -v /etc/bashrc:/etc/bashrc:ro
-            -v ${{ github.workspace }}:${{ github.workspace }}
-            --net=host
-            --log-driver local
-            --log-opt max-size=50m
-            ${{ inputs.docker_opts }}
-            -e PYTHONPATH=${{ github.workspace }}
-            -e HOME=${{ github.workspace }}
-            -e GITHUB_ACTIONS=true
-            -e CI=true
-            -e GITHUB_REPOSITORY=${{ github.repository }}
-            -e GITHUB_SHA=${{ github.sha }}
-            -e GITHUB_REF_NAME=${{ github.ref_name }}
-            -e GITHUB_RUN_ID=${{ github.run_id }}
-            -e GITHUB_TRIGGERING_ACTOR=${{ github.github_triggering_actor }}
-            -e RUNNER_NAME=${{ runner.name }}
-            --device /dev/tenstorrent
-            -w ${{ github.workspace }}
-          run: |
-            set -eu
-
-            # from common repo setup
-            df -h
-            python3 -m pip install --upgrade pip                    
-            python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
-            python3 -m pip install -r requirements-dev.txt
-            python3 -m pip install pytest-github-report
-            df -h
-
-            # from common multi device tests
-            if [ "${{ inputs.commit_report }}" == "None" ]; then
-              num_iterations=1
-            else
-              num_iterations=5
-            fi
-            python3 -m pytest --github-report tests/multi_device/ --data_parallel --report_nth_iteration=$num_iterations --export_code=accuracy -s
-            exit_code=$?  # Capture the exit code
-            if [ $exit_code -eq 5 ]; then
-              echo "Error: pytest returned exit code 5 (No tests to run) in the first test group.";
-              exit 1;  # Fail the workflow
-            elif [ $exit_code -ne 0 ]; then
-              echo "Failure: Tests failed with exit code $exit_code.";
-              exit 1;  # Fail the workflow for other errors
-            fi
-            echo "Success: Tests passed!";
-            ls -l
-            cd metrics
-            ls -l
-            cd ..
-            exit 0;
-
-      # - uses: ./.github/actions/common_repo_setup
-      - uses: ./.github/actions/common_cleanup
-      # - uses: ./.github/actions/common_multi_device_tests
+      # - name: Pull docker image
+      #   shell: bash
+      #   run: |
+      #     docker pull ${{ inputs.docker_tag }}
+      # - uses: tenstorrent/docker-run-action@v5
       #   with:
-      #     commit_report: ${{ inputs.commit_report }}
+      #     shell: bash
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GH_TOKEN }}
+      #     registry: ghcr.io
+      #     image: ${{ inputs.docker_tag }}
+      #     # The most important option below is `--rm`. Otherwise, the machines will fill up with undeleted containers.
+      #     # The mounting of /etc/passwd, /etc/shadow, and /etc/bashrc is required in order for the correct file permissions
+      #     # for newly created files.
+      #     # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which
+      #     # may not be writable by the RUNNER_UID user.
+      #     # --log-driver none: Do not save logs to disk by default as we're printing them to GitHub Actions UI already
+      #     # and it takes up space on the runner. What can happen is that we can eat up all the space of a runner while it's
+      #     # spitting our endless logs, causing the runner being unable to call home, resulting in job failures / runner
+      #     # offline status on GitHub. Issue tt-metal/#12626
+      #     options: |
+      #       -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
+      #       --rm
+      #       -v /etc/passwd:/etc/passwd:ro
+      #       -v /etc/shadow:/etc/shadow:ro
+      #       -v /etc/bashrc:/etc/bashrc:ro
+      #       -v ${{ github.workspace }}:${{ github.workspace }}
+      #       --net=host
+      #       --log-driver local
+      #       --log-opt max-size=50m
+      #       ${{ inputs.docker_opts }}
+      #       -e PYTHONPATH=${{ github.workspace }}
+      #       -e HOME=${{ github.workspace }}
+      #       -e GITHUB_ACTIONS=true
+      #       -e CI=true
+      #       -e GITHUB_REPOSITORY=${{ github.repository }}
+      #       -e GITHUB_SHA=${{ github.sha }}
+      #       -e GITHUB_REF_NAME=${{ github.ref_name }}
+      #       -e GITHUB_RUN_ID=${{ github.run_id }}
+      #       -e GITHUB_TRIGGERING_ACTOR=${{ github.github_triggering_actor }}
+      #       -e RUNNER_NAME=${{ runner.name }}
+      #       --device /dev/tenstorrent
+      #       -w ${{ github.workspace }}
+      #     run: |
+      #       set -eu
+      #
+      #       # from common repo setup
+      #       df -h
+      #       python3 -m pip install --upgrade pip                    
+      #       python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
+      #       python3 -m pip install -r requirements-dev.txt
+      #       python3 -m pip install pytest-github-report
+      #       df -h
+      #
+      #       # from common multi device tests
+      #       if [ "${{ inputs.commit_report }}" == "None" ]; then
+      #         num_iterations=1
+      #       else
+      #         num_iterations=5
+      #       fi
+      #       python3 -m pytest --github-report tests/multi_device/ --data_parallel --report_nth_iteration=$num_iterations --export_code=accuracy -s
+      #       exit_code=$?  # Capture the exit code
+      #       if [ $exit_code -eq 5 ]; then
+      #         echo "Error: pytest returned exit code 5 (No tests to run) in the first test group.";
+      #         exit 1;  # Fail the workflow
+      #       elif [ $exit_code -ne 0 ]; then
+      #         echo "Failure: Tests failed with exit code $exit_code.";
+      #         exit 1;  # Fail the workflow for other errors
+      #       fi
+      #       echo "Success: Tests passed!";
+      #       ls -l
+      #       cd metrics
+      #       ls -l
+      #       cd ..
+      #       exit 0;
+
+      - uses: ./.github/actions/common_repo_setup
+      - uses: ./.github/actions/common_multi_device_tests
+        with:
+          commit_report: ${{ inputs.commit_report }}
       - name: Upload Metrics Artifact
         if: success()  # Only run if tests passed
         uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -106,7 +106,6 @@ jobs:
   model-tests:
     needs: [count-test-files, lowering-tests]
     runs-on: ["in-service", "nfs"]
-    continue-on-error: true
     container: 
       image: ${{ inputs.docker_tag }}
       credentials:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -170,18 +170,18 @@ jobs:
         password: ${{ secrets.GH_TOKEN }}
       options: >-
         --rm 
-        -v /etc/passwd:/etc/passwd:ro
-        -v /etc/shadow:/etc/shadow:ro
-        -v /etc/bashrc:/etc/bashrc:ro
         -v /dev/hugepages-1G:/dev/hugepages-1G 
+        -v ${{ github.workspace }}/docker-job:/work
         --device /dev/tenstorrent
-        -w ${{ github.workspace }}
-        -e HOME=${{ github.workspace }}
     env:
       pytest_verbosity: 0
       pytest_report_title: "⭐️ Multi-Device Tests"
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -186,7 +186,7 @@ jobs:
       pytest_report_title: "⭐️ Multi-Device Tests"
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
-      PIP_CACHE_DIR: /work/.pip_cache
+      PIP_CACHE_DIR: ${{ github.workspace }}/.pip_cache
     # defaults:
     #   run:
     #     shell: bash

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -161,7 +161,7 @@ jobs:
     runs-on: >-
       ${{
         ('tt-beta-ubuntu-2204-n300-large-stable')
-        || ["in-service", "nfs", "n300"]
+        || fromJSON('["n300", "in-service", "nfs"]')
       }}
     container: 
       image: ${{ inputs.docker_tag }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -185,7 +185,7 @@ jobs:
         password: ${{ secrets.GH_TOKEN }}
       options: >-
         --rm 
-      -u ${{ needs.set.outputs.runner-uid }}:${{ needs.set.outputs.runner-gid }}
+        -u ${{ needs.set.outputs.runner-uid }}:${{ needs.set.outputs.runner-gid }}
         -v /etc/passwd:/etc/passwd:ro
         -v /etc/shadow:/etc/shadow:ro
         -v /etc/bashrc:/etc/bashrc:ro

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -156,8 +156,23 @@ jobs:
         run: |
           echo "branch-name=update-docs-$(date +%s)" >> $GITHUB_OUTPUT
 
+  set:
+    runs-on: ubuntu-latest
+    outputs:
+      runner-uid: ${{ steps.run.outputs.runner-uid }}
+      runner-gid: ${{ steps.run.outputs.runner-gid }}
+    steps:
+      -name: run
+      id: run
+      shell: bash
+      run: |
+        echo "runner-uid=$(id -u)" >> $GITHUB_ENV
+        echo "runner-gid=$(id -g)" >> $GITHUB_ENV
+
+
   multi-device-tests:
     # needs: lowering-tests
+    needs: set
     runs-on: >-
       ${{
         ('tt-beta-ubuntu-2204-n300-large-stable')
@@ -170,6 +185,7 @@ jobs:
         password: ${{ secrets.GH_TOKEN }}
       options: >-
         --rm 
+      -u ${{ needs.set.outputs.runner-uid }}:${{ needs.set.outputs.runner-gid }}
         -v /etc/passwd:/etc/passwd:ro
         -v /etc/shadow:/etc/shadow:ro
         -v /etc/bashrc:/etc/bashrc:ro

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -171,7 +171,7 @@ jobs:
       options: >-
         --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent
         -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }}
-        -v /mnt/tt-metal-pytorch-cache/.cache:/root/.cache
+        -v /mnt/tt-metal-pytorch-cache/.cache:/root/.cache -e HOME {{ github.workspace }}
     env:
       pytest_verbosity: 0
       pytest_report_title: "⭐️ Multi-Device Tests"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -171,7 +171,7 @@ jobs:
       options: >-
         --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent
         -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }}
-        -v /mnt/tt-metal-pytorch-cache/.cache:/root/.cache -e HOME {{ github.workspace }}
+        -e HOME ${{ github.workspace }}
     env:
       pytest_verbosity: 0
       pytest_report_title: "⭐️ Multi-Device Tests"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -290,6 +290,14 @@ jobs:
       #       cd ..
       #       exit 0;
 
+      - name: Print info
+        shell: bash
+        run: |
+          ls -la /github/home
+          ls -l /github/home/.cache
+          id -u
+          id -g
+
       - uses: ./.github/actions/common_repo_setup
       - uses: ./.github/actions/common_multi_device_tests
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -128,22 +128,22 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0    
-      - uses: ./.github/actions/common_repo_setup
-      - name: docker-cleanup
-        run: |
-          docker system prune -a -f
-          df -h  # Debug space
-      - uses: ./.github/actions/common_model_tests
-        with:
-          splits: ${{ needs.count-test-files.outputs.num_files }}
-          matrix_group: ${{ matrix.group }}
-          commit_report: ${{ inputs.commit_report }}
-      - name: Upload Metrics Artifact
-        if: success()  # Only run if tests passed
-        uses: actions/upload-artifact@v4
-        with:
-          name: model-tests-metrics-group-${{ matrix.group }}
-          path: metrics/
+      # - uses: ./.github/actions/common_repo_setup
+      # - name: docker-cleanup
+      #   run: |
+      #     docker system prune -a -f
+      #     df -h  # Debug space
+      # - uses: ./.github/actions/common_model_tests
+      #   with:
+      #     splits: ${{ needs.count-test-files.outputs.num_files }}
+      #     matrix_group: ${{ matrix.group }}
+      #     commit_report: ${{ inputs.commit_report }}
+      # - name: Upload Metrics Artifact
+      #   if: success()  # Only run if tests passed
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: model-tests-metrics-group-${{ matrix.group }}
+      #     path: metrics/
 
   get-pr-branch:
     if: ${{ inputs.commit_report != 'None' }}
@@ -168,16 +168,23 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GH_TOKEN }}
+      env:
+        PYTHONPATH: /work
+        GITHUB_ACTIONS: true
+        TORCH_HOME: /work/.cache/torch
+        HF_HOME: /work/.cache/huggingface
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /mnt/tt-metal-pytorch-cache/.cache:/work/.cache
       options: >-
         --rm 
-        -v /dev/hugepages-1G:/dev/hugepages-1G 
-        -v ${{ github.workspace }}/docker-job:/work
         --device /dev/tenstorrent
-    env:
-      pytest_verbosity: 0
-      pytest_report_title: "⭐️ Multi-Device Tests"
-      TORCH_HOME: /root/.cache/torch
-      HF_HOME: /root/.cache/huggingface
+    # env:
+    #   pytest_verbosity: 0
+    #   pytest_report_title: "⭐️ Multi-Device Tests"
+    #   TORCH_HOME: /root/.cache/torch
+    #   HF_HOME: /root/.cache/huggingface
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -157,7 +157,7 @@ jobs:
           echo "branch-name=update-docs-$(date +%s)" >> $GITHUB_OUTPUT
 
   multi-device-tests:
-    needs: lowering-tests
+    # needs: lowering-tests
     runs-on: >-
       ${{
         ('tt-beta-ubuntu-2204-n300-large-stable')

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -161,8 +161,8 @@ jobs:
     needs: lowering-tests
     runs-on: >-
       ${{
-        ((inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
-        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+        ('tt-beta-ubuntu-2204-n300-large-stable')
+        || fromJSON('["n300", "in-service", "cloud-virtual-machine"]')
       }}
     container: 
       image: ${{ inputs.docker_tag }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -159,7 +159,11 @@ jobs:
 
   multi-device-tests:
     needs: lowering-tests
-    runs-on: ["in-service", "nfs", "n300"]
+    runs-on: >-
+      ${{
+        ((inputs.runner-label == 'N300') && format('tt-beta-ubuntu-2204-{0}-large-stable', inputs.runner-label))
+        || fromJSON(format('["{0}", "in-service", "cloud-virtual-machine"]', inputs.runner-label))
+      }}
     container: 
       image: ${{ inputs.docker_tag }}
       credentials:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -302,6 +302,7 @@ jobs:
           whoami
           id -u
           id -g
+          ls -la ${{ env.PIP_CACHE_DIR }}/..
 
       - uses: ./.github/actions/common_repo_setup
       - uses: ./.github/actions/common_multi_device_tests

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -49,6 +49,7 @@ jobs:
     env:
       pytest_verbosity: 2    
       pytest_report_title: "⭐️ Tools Tests"
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     runs-on: ["in-service"]
     container: 
       image: ${{ inputs.docker_tag }}
@@ -78,6 +79,7 @@ jobs:
     env:
       pytest_verbosity: 2    
       pytest_report_title: "⭐️ Aten → TTNN Lowering Tests"
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     strategy:
       matrix: # Need to find a way to replace this with a generator
         group: [1, 2]
@@ -120,6 +122,7 @@ jobs:
       pytest_report_title: "⭐️ Model Tests - Group ${{ matrix.group }}"    
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     strategy:
       matrix: 
         group: ${{ fromJson(needs.count-test-files.outputs.matrix) }}
@@ -185,9 +188,6 @@ jobs:
       HF_HOME: /root/.cache/huggingface
       PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     steps:
-      - name: Create pip cache
-        shell: bash
-        run: mkdir -p ${{ env.PIP_CACHE_DIR }}
       - uses: actions/checkout@v4
       - uses: ./.github/actions/common_repo_setup
       - uses: ./.github/actions/common_multi_device_tests
@@ -217,6 +217,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       PYTHONPATH: ${{ github.workspace }}
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/common_repo_setup
@@ -277,6 +278,7 @@ jobs:
     env:
       pytest_verbosity: 0
       pytest_report_title: "⭐️ Model Input Variations Tests - Group ${{ matrix.group }}"
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/common_repo_setup
@@ -360,6 +362,7 @@ jobs:
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       PYTHONPATH: ${{ github.workspace }}
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/common_repo_setup

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -169,9 +169,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GH_TOKEN }}
       options: >-
-        --rm -v /dev/hugepages-1G:/dev/hugepages-1G --device /dev/tenstorrent
-        -v ${{ github.workspace }}:${{ github.workspace }} -w ${{ github.workspace }}
-        -e HOME ${{ github.workspace }}
+        --rm 
+        -v /dev/hugepages-1G:/dev/hugepages-1G 
+        -v ${{ github.workspace }}:${{ github.workspace }}
+        --device /dev/tenstorrent
+        -w ${{ github.workspace }}
+        -e HOME=${{ github.workspace }}
     env:
       pytest_verbosity: 0
       pytest_report_title: "⭐️ Multi-Device Tests"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -294,7 +294,7 @@ jobs:
         shell: bash
         run: |
           ls -la /github/home
-          ls -l /github/home/.cache
+          whoami
           id -u
           id -g
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -170,6 +170,9 @@ jobs:
         password: ${{ secrets.GH_TOKEN }}
       options: >-
         --rm 
+        -v /etc/passwd:/etc/passwd:ro
+        -v /etc/shadow:/etc/shadow:ro
+        -v /etc/bashrc:/etc/bashrc:ro
         -v /dev/hugepages-1G:/dev/hugepages-1G 
         -v ${{ github.workspace }}:${{ github.workspace }}
         --device /dev/tenstorrent

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -128,22 +128,22 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0    
-      # - uses: ./.github/actions/common_repo_setup
-      # - name: docker-cleanup
-      #   run: |
-      #     docker system prune -a -f
-      #     df -h  # Debug space
-      # - uses: ./.github/actions/common_model_tests
-      #   with:
-      #     splits: ${{ needs.count-test-files.outputs.num_files }}
-      #     matrix_group: ${{ matrix.group }}
-      #     commit_report: ${{ inputs.commit_report }}
-      # - name: Upload Metrics Artifact
-      #   if: success()  # Only run if tests passed
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: model-tests-metrics-group-${{ matrix.group }}
-      #     path: metrics/
+      - uses: ./.github/actions/common_repo_setup
+      - name: docker-cleanup
+        run: |
+          docker system prune -a -f
+          df -h  # Debug space
+      - uses: ./.github/actions/common_model_tests
+        with:
+          splits: ${{ needs.count-test-files.outputs.num_files }}
+          matrix_group: ${{ matrix.group }}
+          commit_report: ${{ inputs.commit_report }}
+      - name: Upload Metrics Artifact
+        if: success()  # Only run if tests passed
+        uses: actions/upload-artifact@v4
+        with:
+          name: model-tests-metrics-group-${{ matrix.group }}
+          path: metrics/
 
   get-pr-branch:
     if: ${{ inputs.commit_report != 'None' }}
@@ -157,7 +157,7 @@ jobs:
           echo "branch-name=update-docs-$(date +%s)" >> $GITHUB_OUTPUT
 
   multi-device-tests:
-    # needs: lowering-tests
+    needs: lowering-tests
     runs-on: >-
       ${{
         ('tt-beta-ubuntu-2204-n300-large-stable')
@@ -171,10 +171,7 @@ jobs:
       env:
         PYTHONPATH: /work
         GITHUB_ACTIONS: true
-        # TORCH_HOME: /work/.cache/torch
-        # HF_HOME: /work/.cache/huggingface
       volumes:
-        # - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - ${{ github.workspace }}:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
         - /mnt/tt-metal-pytorch-cache/.cache:/root/.cache
@@ -187,123 +184,11 @@ jobs:
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
       PIP_CACHE_DIR: /root/pip_cache/.pip_cache
-      AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/tools
-    # defaults:
-    #   run:
-    #     shell: bash
-    #     working-directory: /work
     steps:
       - name: Create pip cache
         shell: bash
         run: mkdir -p ${{ env.PIP_CACHE_DIR }}
       - uses: actions/checkout@v4
-      # copied from common_repo_setup
-      # - name: Setup Python 3.10
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: '3.10'
-      # - name: Set
-      #   shell: bash
-      #   run: |
-      #     echo "RUNNER_UID=$(id -u)" >> $GITHUB_ENV
-      #     echo "RUNNER_GID=$(id -g)" >> $GITHUB_ENV
-      # # - name: Docker login
-      # #   uses: docker/login-action@v3
-      # #   with:
-      # #     registry: https://ghcr.io
-      # #     username: ${{ github.actor }}
-      # #     password: ${{ secrets.GH_TOKEN }}
-      # - name: Docker login
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: https://ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GH_TOKEN }}
-      # - name: Pull docker image
-      #   shell: bash
-      #   run: |
-      #     docker pull ${{ inputs.docker_tag }}
-      # - uses: tenstorrent/docker-run-action@v5
-      #   with:
-      #     shell: bash
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GH_TOKEN }}
-      #     registry: ghcr.io
-      #     image: ${{ inputs.docker_tag }}
-      #     # The most important option below is `--rm`. Otherwise, the machines will fill up with undeleted containers.
-      #     # The mounting of /etc/passwd, /etc/shadow, and /etc/bashrc is required in order for the correct file permissions
-      #     # for newly created files.
-      #     # Passing HOME variable is necessary to avoid Python lib installation into /home/ubuntu/.local folder which
-      #     # may not be writable by the RUNNER_UID user.
-      #     # --log-driver none: Do not save logs to disk by default as we're printing them to GitHub Actions UI already
-      #     # and it takes up space on the runner. What can happen is that we can eat up all the space of a runner while it's
-      #     # spitting our endless logs, causing the runner being unable to call home, resulting in job failures / runner
-      #     # offline status on GitHub. Issue tt-metal/#12626
-      #     options: |
-      #       -u ${{ env.RUNNER_UID }}:${{ env.RUNNER_GID }}
-      #       --rm
-      #       -v /etc/passwd:/etc/passwd:ro
-      #       -v /etc/shadow:/etc/shadow:ro
-      #       -v /etc/bashrc:/etc/bashrc:ro
-      #       -v ${{ github.workspace }}:${{ github.workspace }}
-      #       --net=host
-      #       --log-driver local
-      #       --log-opt max-size=50m
-      #       ${{ inputs.docker_opts }}
-      #       -e PYTHONPATH=${{ github.workspace }}
-      #       -e HOME=${{ github.workspace }}
-      #       -e GITHUB_ACTIONS=true
-      #       -e CI=true
-      #       -e GITHUB_REPOSITORY=${{ github.repository }}
-      #       -e GITHUB_SHA=${{ github.sha }}
-      #       -e GITHUB_REF_NAME=${{ github.ref_name }}
-      #       -e GITHUB_RUN_ID=${{ github.run_id }}
-      #       -e GITHUB_TRIGGERING_ACTOR=${{ github.github_triggering_actor }}
-      #       -e RUNNER_NAME=${{ runner.name }}
-      #       --device /dev/tenstorrent
-      #       -w ${{ github.workspace }}
-      #     run: |
-      #       set -eu
-      #
-      #       # from common repo setup
-      #       df -h
-      #       python3 -m pip install --upgrade pip                    
-      #       python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
-      #       python3 -m pip install -r requirements-dev.txt
-      #       python3 -m pip install pytest-github-report
-      #       df -h
-      #
-      #       # from common multi device tests
-      #       if [ "${{ inputs.commit_report }}" == "None" ]; then
-      #         num_iterations=1
-      #       else
-      #         num_iterations=5
-      #       fi
-      #       python3 -m pytest --github-report tests/multi_device/ --data_parallel --report_nth_iteration=$num_iterations --export_code=accuracy -s
-      #       exit_code=$?  # Capture the exit code
-      #       if [ $exit_code -eq 5 ]; then
-      #         echo "Error: pytest returned exit code 5 (No tests to run) in the first test group.";
-      #         exit 1;  # Fail the workflow
-      #       elif [ $exit_code -ne 0 ]; then
-      #         echo "Failure: Tests failed with exit code $exit_code.";
-      #         exit 1;  # Fail the workflow for other errors
-      #       fi
-      #       echo "Success: Tests passed!";
-      #       ls -l
-      #       cd metrics
-      #       ls -l
-      #       cd ..
-      #       exit 0;
-
-      - name: Print info
-        shell: bash
-        run: |
-          ls -la /github/home
-          whoami
-          id -u
-          id -g
-          ls -la ${{ env.PIP_CACHE_DIR }}/..
-
       - uses: ./.github/actions/common_repo_setup
       - uses: ./.github/actions/common_multi_device_tests
         with:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -162,12 +162,12 @@ jobs:
       runner-uid: ${{ steps.run.outputs.runner-uid }}
       runner-gid: ${{ steps.run.outputs.runner-gid }}
     steps:
-      -name: run
-      id: run
-      shell: bash
-      run: |
-        echo "runner-uid=$(id -u)" >> $GITHUB_ENV
-        echo "runner-gid=$(id -g)" >> $GITHUB_ENV
+      - name: run
+        id: run
+        shell: bash
+        run: |
+          echo "runner-uid=$(id -u)" >> $GITHUB_ENV
+          echo "runner-gid=$(id -g)" >> $GITHUB_ENV
 
 
   multi-device-tests:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -205,6 +205,16 @@ jobs:
       #     registry: https://ghcr.io
       #     username: ${{ github.actor }}
       #     password: ${{ secrets.GH_TOKEN }}
+      - name: Docker login
+        uses: docker/login-action@v3
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+      - name: Pull docker image
+        shell: bash
+        run: |
+          docker pull ${{ inputs.docker_tag }}
       - uses: tenstorrent/docker-run-action@v5
         with:
           shell: bash

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -166,8 +166,8 @@ jobs:
         id: run
         shell: bash
         run: |
-          echo "runner-uid=$(id -u)" >> $GITHUB_ENV
-          echo "runner-gid=$(id -g)" >> $GITHUB_ENV
+          echo "runner-uid=$(id -u)" >> $GITHUB_OUTPUT
+          echo "runner-gid=$(id -g)" >> $GITHUB_OUTPUT
 
 
   multi-device-tests:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -174,7 +174,6 @@ jobs:
         -v /etc/shadow:/etc/shadow:ro
         -v /etc/bashrc:/etc/bashrc:ro
         -v /dev/hugepages-1G:/dev/hugepages-1G 
-        -v ${{ github.workspace }}:${{ github.workspace }}
         --device /dev/tenstorrent
         -w ${{ github.workspace }}
         -e HOME=${{ github.workspace }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -186,7 +186,7 @@ jobs:
       pytest_report_title: "⭐️ Multi-Device Tests"
       TORCH_HOME: /root/.cache/torch
       HF_HOME: /root/.cache/huggingface
-      PIP_CACHE_DIR: ${{ github.workspace }}/pip_cache/.pip_cache
+      PIP_CACHE_DIR: /root/pip_cache/.pip_cache
       AGENT_TOOLSDIRECTORY: ${{ github.workspace }}/tools
     # defaults:
     #   run:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -191,6 +191,8 @@ jobs:
         working-directory: /work
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: docker-job
       # copied from common_repo_setup
       - name: Setup Python 3.10
         uses: actions/setup-python@v5

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -171,33 +171,32 @@ jobs:
       env:
         PYTHONPATH: /work
         GITHUB_ACTIONS: true
-        TORCH_HOME: /work/.cache/torch
-        HF_HOME: /work/.cache/huggingface
+        # TORCH_HOME: /work/.cache/torch
+        # HF_HOME: /work/.cache/huggingface
       volumes:
-        - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        # - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
+        - ${{ github.workspace }}:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
-        - /mnt/tt-metal-pytorch-cache/.cache:/work/.cache
+        - /mnt/tt-metal-pytorch-cache/.cache:/root/.cache
       options: >-
         --rm 
         --device /dev/tenstorrent
-    # env:
-    #   pytest_verbosity: 0
-    #   pytest_report_title: "⭐️ Multi-Device Tests"
-    #   TORCH_HOME: /root/.cache/torch
-    #   HF_HOME: /root/.cache/huggingface
-    defaults:
-      run:
-        shell: bash
-        working-directory: /work
+    env:
+      pytest_verbosity: 0
+      pytest_report_title: "⭐️ Multi-Device Tests"
+      TORCH_HOME: /root/.cache/torch
+      HF_HOME: /root/.cache/huggingface
+    # defaults:
+    #   run:
+    #     shell: bash
+    #     working-directory: /work
     steps:
       - uses: actions/checkout@v4
-        with:
-          path: docker-job
       # copied from common_repo_setup
-      - name: Setup Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+      # - name: Setup Python 3.10
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.10'
       # - name: Set
       #   shell: bash
       #   run: |

--- a/.github/workflows/update-docker-container.yaml
+++ b/.github/workflows/update-docker-container.yaml
@@ -58,8 +58,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      # - name: Set up Docker Buildx
-      #   uses: docker/setup-buildx-action@v3
       # Do not set up docker buildx because of https://github.com/docker/setup-buildx-action/issues/57
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -76,21 +74,8 @@ jobs:
           push: true
           tags: ${{ needs.check-docker-images.outputs.dev-tag}}
           context: .
+          target: release
 
-      # - name: Login to GitHub Container Registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: https://ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GH_TOKEN }}
-      # - name: Build and push
-      #   uses: docker/build-push-action@v6
-      #   with:
-      #     push: true
-      #     context: .
-      #     file: dockerfile/Dockerfile
-      #     target: release
-      #     tags: ${{ needs.check-docker-images.outputs.dev-tag }}
       - name: show output
         run: |
           echo ${{ needs.check-docker-images.outputs.dev-tag }}

--- a/.github/workflows/update-docker-container.yaml
+++ b/.github/workflows/update-docker-container.yaml
@@ -58,22 +58,39 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      # - name: Set up Docker Buildx
+      #   uses: docker/setup-buildx-action@v3
+      # Do not set up docker buildx because of https://github.com/docker/setup-buildx-action/issues/57
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: https://ghcr.io
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GH_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          push: true
-          context: .
           file: dockerfile/Dockerfile
-          target: release
-          tags: ${{ needs.check-docker-images.outputs.dev-tag }}
+          platforms: linux/amd64
+          pull: true
+          push: true
+          tags: ${{ needs.check-docker-images.outputs.dev-tag}}
+          context: .
+
+      # - name: Login to GitHub Container Registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: https://ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GH_TOKEN }}
+      # - name: Build and push
+      #   uses: docker/build-push-action@v6
+      #   with:
+      #     push: true
+      #     context: .
+      #     file: dockerfile/Dockerfile
+      #     target: release
+      #     tags: ${{ needs.check-docker-images.outputs.dev-tag }}
       - name: show output
         run: |
           echo ${{ needs.check-docker-images.outputs.dev-tag }}

--- a/.github/workflows/update-docker-container.yaml
+++ b/.github/workflows/update-docker-container.yaml
@@ -53,7 +53,8 @@ jobs:
 
   create-new-container-and-upload:
     needs: check-docker-images
-    if: needs.check-docker-images.outputs.dev-exists != 'true'
+    # if: needs.check-docker-images.outputs.dev-exists != 'true'
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/.github/workflows/update-docker-container.yaml
+++ b/.github/workflows/update-docker-container.yaml
@@ -53,8 +53,7 @@ jobs:
 
   create-new-container-and-upload:
     needs: check-docker-images
-    # if: needs.check-docker-images.outputs.dev-exists != 'true'
-    if: ${{ always() }}
+    if: needs.check-docker-images.outputs.dev-exists != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -12,19 +12,3 @@ RUN apt-get update && \
 
 # Initialize git lfs (must be done before any git operations)
 RUN git lfs install
-
-# Upgrade pip (best practice before installing Python packages)
-RUN python3 -m pip install --upgrade pip
-
-# Set the extra index URL for pip (for PyTorch)
-RUN python3 -m pip config set global.extra-index-url https://download.pytorch.org/whl/cpu
-
-# Install Python dependencies from requirements-dev.txt and pytest-github-report
-COPY requirements-dev.txt /tmp/requirements-dev.txt
-COPY requirements.txt /tmp/requirements.txt
-
-RUN python3 -m pip install --no-cache-dir -r /tmp/requirements-dev.txt && \
-    python3 -m pip install --no-cache-dir pytest-github-report
-
-# Clean up the temporary requirements files
-RUN rm /tmp/requirements-dev.txt /tmp/requirements.txt


### PR DESCRIPTION
Recently, we have had issues with several GHA runners being flaky. In particular, the N300 runners have been down, which has blocked merges.

This PR adds support for running the multi-device tests in CIv2 infrastructure. It is also the first step to adding CIv2 support to all of our actions.

The main changes include modifying how the multi-device tests use pip and fixing a recursion bug in today's implementation of the multi-device shard analysis pass.