### PR TITLE
Use new nightly TT-NN wheels in dev dependencies

### DIFF
--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -99,7 +99,7 @@ jobs:
           latest_release_name_short=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | tail -n 1)
 
           # prepend v, change dev to -, and change +g to -g
-          latest_version = echo $latest_release_name_short | sed -e 's/.dev/-/' -e 's/+g/-g/' -e 's/^/v/'
+          latest_version=$(echo $latest_release_name_short | sed -e 's/.dev/-/' -e 's/+g/-g/' -e 's/^/v/')
 
           sed -i "/\[submodule \"torch_ttnn\/cpp_extension\/third-party\/tt-metal\"\]/,/^\[/{s/^\s*branch\s*=.*/\tbranch = $latest_version/}" .gitmodules
           echo "Updated .gitmodules with the latest version: $latest_version"

--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -25,16 +25,13 @@ jobs:
           latest_pre_release=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href="\([^"]*\).*/\1/p' | tail -n 1)
           echo "release=$latest_pre_release" >> $GITHUB_OUTPUT
 
-          latest_release_name_short=$(curl -s https://pypi.eng.aws.tenstorrent.com/ttnn/ | sed -n 's/.*href=".*>\(.*\)-cp310-c.*/\1/p' | tail -n 1)
-          echo "release_name_short=$latest_release_name_short" >> $GITHUB_OUTPUT
-
       - name: Update requirements.txt
         id: update-requirements
         run: |
           # Remove any existing ttnn lines (adjust the regex if needed)
           sed -i '/^ttnn @ /d' requirements.txt
           # Append the line for the newest version
-          echo "ttnn @ ${{ repo_url }}${{steps.fetch_release.outputs.release}} ; python_version==\"3.10\"" >> requirements.txt
+          echo "ttnn @ ${{ env.repo_url }}${{steps.fetch_release.outputs.release}} ; python_version==\"3.10\"" >> requirements.txt
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
@@ -79,6 +76,7 @@ jobs:
         -v /mnt/tt-metal-pytorch-cache/.cache:/root/.cache
     env:
       CACHE_DIR: /root/.cache/cpp-extension-cache
+      repo_url: "https://pypi.eng.aws.tenstorrent.com/ttnn/"
     steps:
       # TODO: checkout must be changed to main once branch is merged
       - name: Checkout Repository
@@ -95,7 +93,7 @@ jobs:
       - name: Update .gitsubmodules
         run: |
           # The name of the link nearly matches the spec from git describe. Modify and use that
-          latest_release_name_short=$(curl -s https://pypi.eng.aws.tenstorrent.com/ttnn/ | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | tail -n 1)
+          latest_release_name_short=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | tail -n 1)
 
           # prepend v, change dev to -, and change +g to -g
           latest_version = echo $latest_release_name_short | sed -e 's/.dev/-/' -e 's/+g/-g/' -e 's/^/v/'

--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -22,10 +22,11 @@ jobs:
       - name: Fetch Latest Pre-release from Another Repo
         id: fetch_release
         run: |
-          latest_pre_release=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href="\([^"]*\).*/\1/p' | tail -n 1)
+          # Pull links from internal pypi, sort by version, take the last one (newest)
+          latest_pre_release=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href="\([^"]*\).*/\1/p' | sort -V | tail -n 1)
           echo "release=$latest_pre_release" >> $GITHUB_OUTPUT
 
-          latest_release_name_short=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | tail -n 1)
+          latest_release_name_short=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | sort -V | tail -n 1)
           echo "release_short=$latest_release_name_short" >> $GITHUB_OUTPUT
 
       - name: Update requirements.txt
@@ -96,7 +97,7 @@ jobs:
       - name: Update .gitsubmodules
         run: |
           # The name of the link nearly matches the spec from git describe. Modify and use that
-          latest_release_name_short=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | tail -n 1)
+          latest_release_name_short=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | sort -V | tail -n 1)
 
           # prepend v, change dev to -, and change +g to -g
           latest_version=$(echo $latest_release_name_short | sed -e 's/.dev/-/' -e 's/+g/-g/' -e 's/^/v/')

--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -25,6 +25,9 @@ jobs:
           latest_pre_release=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href="\([^"]*\).*/\1/p' | tail -n 1)
           echo "release=$latest_pre_release" >> $GITHUB_OUTPUT
 
+          latest_release_name_short=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | tail -n 1)
+          echo "release_short=$latest_release_name_short" >> $GITHUB_OUTPUT
+
       - name: Update requirements.txt
         id: update-requirements
         run: |
@@ -43,7 +46,7 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           base: main
           commit-message: "Update dependencies to ${{ steps.fetch_release.outputs.release }}"
-          title: "Update TT-NN to ${{ steps.fetch_release.outputs.release }}"
+          title: "Update TT-NN to ${{ steps.fetch_release.outputs.release_short }}"
           body: "This PR updates TT-NN wheel to the latest pre-release version."          
           labels: ttnn-wheel-update
           delete-branch: true

--- a/.github/workflows/update-ttnn-wheel.yaml
+++ b/.github/workflows/update-ttnn-wheel.yaml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+    env:
+      repo_url: "https://pypi.eng.aws.tenstorrent.com/ttnn/"
       
     steps:
       - name: Checkout Repository
@@ -20,22 +22,19 @@ jobs:
       - name: Fetch Latest Pre-release from Another Repo
         id: fetch_release
         run: |
-          # Fetch the latest pre-release tag from the target repository
-          latest_pre_release=$(curl -s https://api.github.com/repos/tenstorrent/tt-metal/releases | jq -r '[.[] | select(.prerelease == true)][0].tag_name')
-          # Strip leading 'v' from the tag (e.g., v0.51.0 -> 0.51.0)
-          latest_version="${latest_pre_release#v}"
-          # Set the output using the new environment file
-          echo "release=$latest_version" >> $GITHUB_OUTPUT
+          latest_pre_release=$(curl -s ${{ env.repo_url }} | sed -n 's/.*href="\([^"]*\).*/\1/p' | tail -n 1)
+          echo "release=$latest_pre_release" >> $GITHUB_OUTPUT
+
+          latest_release_name_short=$(curl -s https://pypi.eng.aws.tenstorrent.com/ttnn/ | sed -n 's/.*href=".*>\(.*\)-cp310-c.*/\1/p' | tail -n 1)
+          echo "release_name_short=$latest_release_name_short" >> $GITHUB_OUTPUT
 
       - name: Update requirements.txt
         id: update-requirements
         run: |
-          latest_version=${{ steps.fetch_release.outputs.release }}
-          latest_version_short=$(echo $latest_version | sed 's/-rc/rc/')
           # Remove any existing ttnn lines (adjust the regex if needed)
-          sed -i '/^ttnn @ https:\/\/github\.com\/tenstorrent\/tt-metal\/releases\//d' requirements.txt
+          sed -i '/^ttnn @ /d' requirements.txt
           # Append the line for the newest version
-          echo "ttnn @ https://github.com/tenstorrent/tt-metal/releases/download/v${latest_version}/ttnn-$latest_version_short-cp310-cp310-linux_x86_64.whl ; python_version==\"3.10\"" >> requirements.txt
+          echo "ttnn @ ${{ repo_url }}${{steps.fetch_release.outputs.release}} ; python_version==\"3.10\"" >> requirements.txt
           
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
@@ -95,10 +94,12 @@ jobs:
           apt install -y curl jq
       - name: Update .gitsubmodules
         run: |
-          # Fetch the latest pre-release tag from the target repository
-          latest_pre_release=$(curl -s https://api.github.com/repos/tenstorrent/tt-metal/releases | jq -r '[.[] | select(.prerelease == true)][0].tag_name')
-          # Strip leading 'v' from the tag (e.g., v0.51.0 -> 0.51.0)
-          latest_version="${latest_pre_release#v}"
+          # The name of the link nearly matches the spec from git describe. Modify and use that
+          latest_release_name_short=$(curl -s https://pypi.eng.aws.tenstorrent.com/ttnn/ | sed -n 's/.*href=".*>ttnn-\(.*\)-cp310-c.*/\1/p' | tail -n 1)
+
+          # prepend v, change dev to -, and change +g to -g
+          latest_version = echo $latest_release_name_short | sed -e 's/.dev/-/' -e 's/+g/-g/' -e 's/^/v/'
+
           sed -i "/\[submodule \"torch_ttnn\/cpp_extension\/third-party\/tt-metal\"\]/,/^\[/{s/^\s*branch\s*=.*/\tbranch = $latest_version/}" .gitmodules
           echo "Updated .gitmodules with the latest version: $latest_version"
 


### PR DESCRIPTION
It was recently requested that we start using a different PyPI registry for our dev dependencies. This will allow the tt-metal team to no longer publish RC's on their releases page, which will aid DevEx.

This PR accomplishes this ask. Namely it:

- Fetches the latest nightly release from the new URL
- Updates requirements.txt with the new URL
- Updates submodules to the corresponding git hash for the cpp extension

This PR does not address the additional requirements to clean up our release flow (publishing releases to PyPI that align with the tt-metal releases, using pyproject.toml instead for dependencies)

closes #1119 