### PR TITLE
Cache eager model test results

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,7 @@ def reset_program_cache(device):
     device.enable_program_cache()
 
 def get_cache_for_model_test(request):
-    cache_path = get_absolute_cache_path("pytorch_eager_results/" + request.node.name)
+    cache_path = get_absolute_cache_path(f"pytorch_eager_results/{request.node.name}.pkl")
 
     if not os.path.exists(cache_path):
         return None

--- a/tests/models/MobileNetV2/test_MobileNetV2.py
+++ b/tests/models/MobileNetV2/test_MobileNetV2.py
@@ -39,12 +39,14 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_MobileNetV2(record_property, mode):
+def test_MobileNetV2(record_property, mode, cached_results):
     model_name = "MobileNetV2"
     record_property("model_name", model_name)
     record_property("mode", mode)
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         # Print the top 5 predictions
         _, indices = torch.topk(results, 5)

--- a/tests/models/albert/test_albert_masked_lm.py
+++ b/tests/models/albert/test_albert_masked_lm.py
@@ -44,12 +44,14 @@ class ThisTester(ModelTester):
         "albert/albert-xxlarge-v2",
     ],
 )
-def test_albert_masked_lm(record_property, model_name, mode):
+def test_albert_masked_lm(record_property, model_name, mode, cached_results):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         # retrieve index of [MASK]

--- a/tests/models/albert/test_albert_question_answering.py
+++ b/tests/models/albert/test_albert_question_answering.py
@@ -28,12 +28,14 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.parametrize("model_name", ["twmkn9/albert-base-v2-squad2"])
-def test_albert_question_answering(record_property, model_name, mode):
+def test_albert_question_answering(record_property, model_name, mode, cached_results):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         answer_start_index = results.start_logits.argmax()

--- a/tests/models/albert/test_albert_sequence_classification.py
+++ b/tests/models/albert/test_albert_sequence_classification.py
@@ -27,12 +27,14 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.parametrize("model_name", ["textattack/albert-base-v2-imdb"])
-def test_albert_sequence_classification(record_property, model_name, mode):
+def test_albert_sequence_classification(record_property, model_name, mode, cached_results):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         logits = results.logits

--- a/tests/models/albert/test_albert_token_classification.py
+++ b/tests/models/albert/test_albert_token_classification.py
@@ -31,12 +31,14 @@ class ThisTester(ModelTester):
         pytest.param("albert/albert-base-v2", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_albert_token_classification(record_property, model_name, mode):
+def test_albert_token_classification(record_property, model_name, mode, cached_results):
     record_property("model_name", f"{model_name}-classification")
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         logits = results.logits

--- a/tests/models/autoencoder_conv/test_autoencoder_conv.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv.py
@@ -48,13 +48,15 @@ AutoencoderTiny(
     ["train", "eval"],
 )
 @pytest.mark.skip(reason="PyTorch compilation flow cannot accept pipeline.")
-def test_autoencoder_conv(record_property, mode):
+def test_autoencoder_conv(record_property, mode, cached_results):
     model_name = "Autoencoder (convolutional)"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         image = results.images[0]

--- a/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
+++ b/tests/models/autoencoder_conv/test_autoencoder_conv_v2.py
@@ -75,13 +75,15 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-def test_autoencoder_conv_v2(record_property, mode):
+def test_autoencoder_conv_v2(record_property, mode, cached_results):
     model_name = f"Autoencoder (conv)"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         print("Output: ", results)

--- a/tests/models/autoencoder_linear/test_autoencoder_linear.py
+++ b/tests/models/autoencoder_linear/test_autoencoder_linear.py
@@ -84,13 +84,15 @@ class ThisTester(ModelTester):
     "mode",
     ["train", pytest.param("eval", marks=pytest.mark.converted_end_to_end)],
 )
-def test_autoencoder_linear(record_property, mode):
+def test_autoencoder_linear(record_property, mode, cached_results):
     model_name = "Autoencoder (linear)"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         print("Output: ", results)

--- a/tests/models/beit/test_beit_image_classification.py
+++ b/tests/models/beit/test_beit_image_classification.py
@@ -38,12 +38,14 @@ class ThisTester(ModelTester):
 @pytest.mark.skip(reason="https://github.com/tenstorrent/pytorch2.0_ttnn/issues/865")
 @pytest.mark.parametrize("mode", ["train", "eval"])
 @pytest.mark.parametrize("model_name", ["microsoft/beit-base-patch16-224", "microsoft/beit-large-patch16-224"])
-def test_beit_image_classification(record_property, model_name, mode):
+def test_beit_image_classification(record_property, model_name, mode, cached_results):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         logits = results.logits

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -59,13 +59,15 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.e2e_with_native_integration
-def test_bert(record_property, mode, batch_size):
+def test_bert(record_property, mode, batch_size, cached_results):
     model_name = "BERT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode, batch_size)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         # Helper function to decode output to human-readable text

--- a/tests/models/bloom/test_bloom.py
+++ b/tests/models/bloom/test_bloom.py
@@ -36,13 +36,15 @@ class ThisTester(ModelTester):
     "mode",
     [pytest.param("eval", marks=pytest.mark.compilation_xfail)],
 )
-def test_bloom(record_property, mode):
+def test_bloom(record_property, mode, cached_results):
     model_name = "Bloom"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         # Helper function to decode output to human-readable text

--- a/tests/models/clip/test_clip.py
+++ b/tests/models/clip/test_clip.py
@@ -52,13 +52,15 @@ class ThisTester(ModelTester):
         "eval",
     ],
 )
-def test_clip(record_property, mode):
+def test_clip(record_property, mode, cached_results):
     model_name = "CLIP"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         logits_per_image = results.logits_per_image  # this is the image-text similarity score

--- a/tests/models/codegen/test_codegen.py
+++ b/tests/models/codegen/test_codegen.py
@@ -31,13 +31,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail
-def test_codegen(record_property, mode):
+def test_codegen(record_property, mode, cached_results):
     model_name = "codegen"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         print(tester.tokenizer.decode(results[0]))

--- a/tests/models/deit/test_deit.py
+++ b/tests/models/deit/test_deit.py
@@ -39,12 +39,14 @@ class ThisTester(ModelTester):
 
 @pytest.mark.parametrize("mode", ["train", "eval"])
 @pytest.mark.parametrize("model_name", ["facebook/deit-base-patch16-224"])
-def test_deit(record_property, model_name, mode):
+def test_deit(record_property, model_name, mode, cached_results):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         logits = results.logits

--- a/tests/models/detr/test_detr.py
+++ b/tests/models/detr/test_detr.py
@@ -42,13 +42,15 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_detr(record_property, mode):
+def test_detr(record_property, mode, cached_results):
     model_name = "DETR"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         # Results

--- a/tests/models/dino/test_dino.py
+++ b/tests/models/dino/test_dino.py
@@ -34,12 +34,14 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_dino(record_property, mode):
+def test_dino(record_property, mode, cached_results):
     model_name = "DINOv2"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/distilbert/test_distilbert.py
+++ b/tests/models/distilbert/test_distilbert.py
@@ -26,12 +26,14 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.converted_end_to_end
 @pytest.mark.parametrize("model_name", ["distilbert-base-uncased"])
-def test_distilbert(record_property, model_name, mode):
+def test_distilbert(record_property, model_name, mode, cached_results):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         print(f"Model: {model_name} | Input: {tester.text} | Output: {results}")

--- a/tests/models/dpr/test_dpr.py
+++ b/tests/models/dpr/test_dpr.py
@@ -31,13 +31,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_dpr(record_property, mode):
+def test_dpr(record_property, mode, cached_results):
     model_name = "DPR"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         start_logits = results.start_logits

--- a/tests/models/falcon/test_falcon.py
+++ b/tests/models/falcon/test_falcon.py
@@ -35,13 +35,15 @@ class ThisTester(ModelTester):
     [1],
 )
 @pytest.mark.compilation_xfail(reason="OOM for DRAM")
-def test_falcon(record_property, mode, batch_size):
+def test_falcon(record_property, mode, batch_size, cached_results):
     model_name = "Falcon-7B"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode, batch_size)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     if mode == "eval":
         # Helper function to decode output to human-readable text

--- a/tests/models/flan_t5/test_flan_t5.py
+++ b/tests/models/flan_t5/test_flan_t5.py
@@ -29,13 +29,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail
-def test_flan_t5(record_property, mode):
+def test_flan_t5(record_property, mode, cached_results):
     model_name = "FLAN-T5"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         results = tester.tokenizer.batch_decode(results, skip_special_tokens=True)
 

--- a/tests/models/glpn_kitti/test_glpn_kitti.py
+++ b/tests/models/glpn_kitti/test_glpn_kitti.py
@@ -30,13 +30,15 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_glpn_kitti(record_property, mode):
+def test_glpn_kitti(record_property, mode, cached_results):
     model_name = "GLPN-KITTI"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         predicted_depth = results.predicted_depth
 

--- a/tests/models/gpt2/test_gpt2.py
+++ b/tests/models/gpt2/test_gpt2.py
@@ -29,13 +29,15 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_gpt2(record_property, mode):
+def test_gpt2(record_property, mode, cached_results):
     model_name = "GPT-2"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         # Helper function to decode output to human-readable text
         def decode_output(outputs):

--- a/tests/models/gpt_neo/test_gpt_neo.py
+++ b/tests/models/gpt_neo/test_gpt_neo.py
@@ -36,13 +36,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail
-def test_gpt_neo(record_property, mode):
+def test_gpt_neo(record_property, mode, cached_results):
     model_name = "GPTNeo"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         gen_text = tester.tokenizer.batch_decode(results)[0]
 

--- a/tests/models/hand_landmark/test_hand_landmark.py
+++ b/tests/models/hand_landmark/test_hand_landmark.py
@@ -45,7 +45,7 @@ class ThisTester(ModelTester):
 @pytest.mark.usefixtures("manage_dependencies")
 @pytest.mark.converted_end_to_end
 @pytest.mark.skip(reason="Issues with calling git lfs pull on CI")
-def test_hand_landmark(record_property, mode):
+def test_hand_landmark(record_property, mode, cached_results):
     model_name = "Hand Landmark"
     record_property("model_name", model_name)
     record_property("mode", mode)
@@ -87,6 +87,8 @@ def test_hand_landmark(record_property, mode):
     )
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/hardnet/test_hardnet.py
+++ b/tests/models/hardnet/test_hardnet.py
@@ -45,13 +45,15 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_hardnet(record_property, mode):
+def test_hardnet(record_property, mode, cached_results):
     model_name = "HardNet"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         # Tensor of shape 1000, with confidence scores over ImageNet's 1000 classes
         print(results[0])

--- a/tests/models/llama/test_llama.py
+++ b/tests/models/llama/test_llama.py
@@ -41,13 +41,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail(reason="OOM for DRAM")
-def test_llama(record_property, mode):
+def test_llama(record_property, mode, cached_results):
     model_name = "Llama"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         # Helper function to decode output to human-readable text
         def decode_output(outputs):

--- a/tests/models/mlpmixer/test_mlpmixer.py
+++ b/tests/models/mlpmixer/test_mlpmixer.py
@@ -26,11 +26,13 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-def test_mlpmixer(record_property, mode):
+def test_mlpmixer(record_property, mode, cached_results):
     model_name = "MLPMixer"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/mnist/test_mnist.py
+++ b/tests/models/mnist/test_mnist.py
@@ -57,12 +57,15 @@ class ThisTester(ModelTester):
     "mode",
     ["train", pytest.param("eval", marks=[pytest.mark.converted_end_to_end, pytest.mark.e2e_with_native_integration])],
 )
-def test_mnist_train(record_property, mode):
+def test_mnist_train(record_property, mode, cached_results):
     model_name = "Mnist"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
+++ b/tests/models/mobilenet_ssd/test_mobilenet_ssd.py
@@ -36,12 +36,14 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_mobilenet_ssd(record_property, mode):
+def test_mobilenet_ssd(record_property, mode, cached_results):
     model_name = "MobileNetSSD"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/musicgen_small/test_musicgen_small.py
+++ b/tests/models/musicgen_small/test_musicgen_small.py
@@ -34,12 +34,14 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.skip("torch run with bypass compilation is stalling")
-def test_musicgen_small(record_property, mode):
+def test_musicgen_small(record_property, mode, cached_results):
     model_name = "musicgen_small"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/openpose/test_openpose.py
+++ b/tests/models/openpose/test_openpose.py
@@ -33,12 +33,14 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.usefixtures("manage_dependencies")
 @pytest.mark.skip(reason="failing during torch run with bypass compilation")
-def test_openpose(record_property, mode):
+def test_openpose(record_property, mode, cached_results):
     model_name = "OpenPose"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/openpose/test_openpose_v2.py
+++ b/tests/models/openpose/test_openpose_v2.py
@@ -51,13 +51,15 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_openpose_v2(record_property, mode):
+def test_openpose_v2(record_property, mode, cached_results):
     model_name = "OpenPose V2"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         print(f"Output: {results}")
 

--- a/tests/models/opt/test_opt.py
+++ b/tests/models/opt/test_opt.py
@@ -38,13 +38,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail
-def test_opt(record_property, mode):
+def test_opt(record_property, mode, cached_results):
     model_name = "OPT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         tester.tokenizer.batch_decode(results)[0]
 

--- a/tests/models/perceiver_io/test_perceiver_io.py
+++ b/tests/models/perceiver_io/test_perceiver_io.py
@@ -33,13 +33,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_perceiver_io(record_property, mode):
+def test_perceiver_io(record_property, mode, cached_results):
     model_name = "Perceiver IO"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         logits = results.logits
         masked_tokens_predictions = logits[0, 51:61].argmax(dim=-1)

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -26,13 +26,15 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_resnet(record_property, mode):
+def test_resnet(record_property, mode, cached_results):
     model_name = "ResNet18"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     # Check inference result
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/resnet50/test_resnet50.py
+++ b/tests/models/resnet50/test_resnet50.py
@@ -41,13 +41,15 @@ class ThisTester(ModelTester):
         pytest.param("eval", 4, marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_resnet(record_property, mode, batch_size):
+def test_resnet(record_property, mode, batch_size, cached_results):
     model_name = "ResNet50"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode, batch_size)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         # Print the top 5 predictions
         _, indices = torch.topk(results, 5)

--- a/tests/models/roberta/test_roberta.py
+++ b/tests/models/roberta/test_roberta.py
@@ -26,13 +26,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_roberta(record_property, mode):
+def test_roberta(record_property, mode, cached_results):
     model_name = "RoBERTa"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         logits = results.logits
         # retrieve index of <mask>

--- a/tests/models/segformer/test_segformer.py
+++ b/tests/models/segformer/test_segformer.py
@@ -41,13 +41,15 @@ class ThisTester(ModelTester):
     "mode",
     ["train", "eval"],
 )
-def test_segformer(record_property, mode):
+def test_segformer(record_property, mode, cached_results):
     model_name = "SegFormer"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         logits = results.logits  # shape (batch_size, num_labels, height/4, width/4)
 

--- a/tests/models/segment_anything/test_segment_anything.py
+++ b/tests/models/segment_anything/test_segment_anything.py
@@ -38,12 +38,14 @@ class ThisTester(ModelTester):
 @pytest.mark.skip(
     reason="Failed to install sam2. sam2 requires Python >=3.10.0 but the default version on Ubuntu 20.04 is 3.8. We found no other pytorch implementation of segment-anything."
 )
-def test_segment_anything(record_property, mode):
+def test_segment_anything(record_property, mode, cached_results):
     model_name = "segment-anything"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/speecht5_tts/test_speecht5_tts.py
+++ b/tests/models/speecht5_tts/test_speecht5_tts.py
@@ -38,13 +38,15 @@ class ThisTester(ModelTester):
     "mode",
     [pytest.param("eval", marks=pytest.mark.compilation_xfail(reason="Fail with more run_once"))],
 )
-def test_speecht5_tts(record_property, mode):
+def test_speecht5_tts(record_property, mode, cached_results):
     model_name = "speecht5-tts"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     # if mode == "eval":
     #     # Uncomment below if you really want to hear the result.
     #     # import soundfile as sf

--- a/tests/models/squeeze_bert/test_squeeze_bert.py
+++ b/tests/models/squeeze_bert/test_squeeze_bert.py
@@ -28,13 +28,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.converted_end_to_end
-def test_squeeze_bert(record_property, mode):
+def test_squeeze_bert(record_property, mode, cached_results):
     model_name = "SqueezeBERT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         logits = results.logits
         predicted_class_id = logits.argmax().item()

--- a/tests/models/stable_diffusion/test_stable_diffusion.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion.py
@@ -25,13 +25,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.skip(reason="Dynamo cannot support pipeline.")
-def test_stable_diffusion(record_property, mode):
+def test_stable_diffusion(record_property, mode, cached_results):
     model_name = "Stable Diffusion"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         image = results.images[0]
 

--- a/tests/models/stable_diffusion/test_stable_diffusion_v2.py
+++ b/tests/models/stable_diffusion/test_stable_diffusion_v2.py
@@ -53,13 +53,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail
-def test_stable_diffusion_v2(record_property, mode):
+def test_stable_diffusion_v2(record_property, mode, cached_results):
     model_name = "Stable Diffusion V2"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         noise_pred = results.sample
 

--- a/tests/models/t5/test_t5.py
+++ b/tests/models/t5/test_t5.py
@@ -29,12 +29,14 @@ class ThisTester(ModelTester):
 )
 @pytest.mark.parametrize("model_name", ["t5-small", "t5-base", "t5-large"])
 @pytest.mark.compilation_xfail
-def test_t5(record_property, model_name, mode):
+def test_t5(record_property, model_name, mode, cached_results):
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         output_text = tester.tokenizer.decode(results[0], skip_special_tokens=True)
         print(f"Model: {model_name} | Input: {tester.input_text} | Output: {output_text}")

--- a/tests/models/timm/test_timm_image_classification.py
+++ b/tests/models/timm/test_timm_image_classification.py
@@ -72,14 +72,16 @@ model_and_mode_list = [
 
 @pytest.mark.usefixtures("manage_dependencies")
 @pytest.mark.parametrize("model_and_mode", model_and_mode_list)
-def test_timm_image_classification(record_property, model_and_mode):
+def test_timm_image_classification(record_property, model_and_mode, cached_results):
     model_name = model_and_mode[0]
     mode = model_and_mode[1]
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         top5_probabilities, top5_class_indices = torch.topk(results.softmax(dim=1) * 100, k=5)
 

--- a/tests/models/torchvision/test_torchvision_image_classification.py
+++ b/tests/models/torchvision/test_torchvision_image_classification.py
@@ -104,7 +104,7 @@ model_info_and_mode_list = [
 
 
 @pytest.mark.parametrize("model_info_and_mode", model_info_and_mode_list)
-def test_torchvision_image_classification(record_property, model_info_and_mode):
+def test_torchvision_image_classification(record_property, model_info_and_mode, cached_results, cached_results):
     model_info = model_info_and_mode[0]
     mode = model_info_and_mode[1]
     model_name, _ = model_info
@@ -112,7 +112,11 @@ def test_torchvision_image_classification(record_property, model_info_and_mode):
     record_property("mode", mode)
 
     tester = ThisTester(model_info, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         # Print the top 5 predictions
         _, indices = torch.topk(results, 5)

--- a/tests/models/torchvision/test_torchvision_object_detection.py
+++ b/tests/models/torchvision/test_torchvision_object_detection.py
@@ -57,13 +57,15 @@ class ThisTester(ModelTester):
         ),
     ],
 )
-def test_torchvision_object_detection(record_property, model_info, mode):
+def test_torchvision_object_detection(record_property, model_info, mode, cached_results):
     model_name, _ = model_info
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_info, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         print(f"Model: {model_name} | Output: {results}")
 

--- a/tests/models/unet/test_unet.py
+++ b/tests/models/unet/test_unet.py
@@ -54,13 +54,15 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_unet(record_property, mode):
+def test_unet(record_property, mode, cached_results):
     model_name = "U-Net"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         results = torch.round(results[0])
 

--- a/tests/models/unet_brain/test_unet_brain.py
+++ b/tests/models/unet_brain/test_unet_brain.py
@@ -56,13 +56,15 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_unet_brain(record_property, mode):
+def test_unet_brain(record_property, mode, cached_results):
     model_name = "Unet-brain"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         print(torch.round(results[0]))
 

--- a/tests/models/unet_carvana/test_unet_carvana.py
+++ b/tests/models/unet_carvana/test_unet_carvana.py
@@ -34,12 +34,14 @@ class ThisTester(ModelTester):
         pytest.param("eval", marks=pytest.mark.converted_end_to_end),
     ],
 )
-def test_unet_carvana(record_property, mode):
+def test_unet_carvana(record_property, mode, cached_results):
     model_name = "Unet-carvana"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/vilt/test_vilt.py
+++ b/tests/models/vilt/test_vilt.py
@@ -34,13 +34,15 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail(reason="cannot sample n_sample <= 0")
-def test_vilt(record_property, mode):
+def test_vilt(record_property, mode, cached_results):
     model_name = "ViLT"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         logits = results.logits
         idx = logits.argmax(-1).item()

--- a/tests/models/whisper/test_whisper.py
+++ b/tests/models/whisper/test_whisper.py
@@ -42,12 +42,14 @@ class ThisTester(ModelTester):
     ["eval"],
 )
 @pytest.mark.compilation_xfail
-def test_whisper(record_property, mode):
+def test_whisper(record_property, mode, cached_results):
     model_name = "Whisper"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/xglm/test_xglm.py
+++ b/tests/models/xglm/test_xglm.py
@@ -30,12 +30,14 @@ class ThisTester(ModelTester):
     "mode",
     [pytest.param("eval", marks=pytest.mark.skip(reason="temp fail due to (tt-metal#21494)"))],
 )
-def test_xglm(record_property, mode):
+def test_xglm(record_property, mode, cached_results):
     model_name = "XGLM"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/yolos/test_yolos.py
+++ b/tests/models/yolos/test_yolos.py
@@ -37,13 +37,15 @@ class ThisTester(ModelTester):
 )
 
 # @pytest.mark.xfail
-def test_yolos(record_property, mode):
+def test_yolos(record_property, mode, cached_results):
     model_name = "YOLOS"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
     if mode == "eval":
         # Helper function to decode output to human-readable text
         def decode_output(outputs):

--- a/tests/models/yolov3/test_yolov3.py
+++ b/tests/models/yolov3/test_yolov3.py
@@ -53,12 +53,14 @@ class ThisTester(ModelTester):
     "mode",
     ["eval"],
 )
-def test_yolov3(record_property, mode):
+def test_yolov3(record_property, mode, cached_results):
     model_name = "YOLOv3"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))

--- a/tests/models/yolov5/test_yolov5.py
+++ b/tests/models/yolov5/test_yolov5.py
@@ -105,12 +105,14 @@ def teardown_module(module):
 )
 @pytest.mark.compilation_xfail(reason="non-singleton SymInt in CSEPass")
 @pytest.mark.usefixtures("manage_dependencies")
-def test_yolov5(record_property, mode):
+def test_yolov5(record_property, mode, cached_results):
     model_name = "YOLOv5"
     record_property("model_name", model_name)
     record_property("mode", mode)
 
     tester = ThisTester(model_name, mode)
-    results = tester.test_model()
+    results = cached_results
+    if results is None:
+        results = tester.test_model()
 
     record_property("torch_ttnn", (tester, results))


### PR DESCRIPTION
Today, we rerun the eager mode of each model every time it is run for tests, but we expect these results to not change from run to run.

By caching, we can reduce CI time considerably. This also sets us up to be better citizens for CIv2 usage.

For example, this reduces BERT batch 8 model test from 17:06 -> 00:45 (though I expect most model tests will not see as significant of a speedup)
