### PR TITLE
Align pip package with recent tt-metal release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 keywords = ["pytorch", "ttnn", "tenstorrent", "compiler", "machine-learning", "deep-learning"]
 
 [project.optional-dependencies]
-ttnn = ["ttnn==0.59.0"]
 dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,9 @@ setup(
         "graphviz",
         "matplotlib==3.7.1",
         "paramiko==3.5.1",
+        "ttnn==0.60.1",
     ],
     extras_require={
-        "ttnn": ["ttnn==0.59.0"],
         "dev": [
             "pytest>=7.4.0",
             "pytest-cov>=4.1.0",


### PR DESCRIPTION
Removes [ttnn] optional install, now installs ttnn by default
Updates ttnn version to match what is latest on PyPI

In the future, we should automatically check for releases and update to the latest one. I was playing around with this today, but it gets a bit annoying if we want [dev] to point to the latest nightly

