### PR TITLE
Rename runner for multi device testing

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -163,7 +163,7 @@ jobs:
     needs: lowering-tests
     runs-on: >-
       ${{
-        ('tt-beta-ubuntu-2204-n300-large-stable')
+        ('tt-ubuntu-2204-n300-stable')
         || fromJSON('["n300", "in-service", "nfs"]')
       }}
     container: 


### PR DESCRIPTION
### Problem description
The multi-device-tests action is hanging because it's waiting for an available runner.

### What's changed
`tt-beta-ubuntu-2204-n300-large-stable` has been renamed to `tt-ubuntu-2204-n300-stable` as per internal docs.